### PR TITLE
fix: add bottomSafeAreaPadding() view modifier

### DIFF
--- a/Bitkit/Components/BalanceHeaderView.swift
+++ b/Bitkit/Components/BalanceHeaderView.swift
@@ -12,9 +12,9 @@ struct BalanceHeaderView: View {
                 if currency.primaryDisplay == .bitcoin {
                     HStack {
                         if let sign {
-                            BodySText("<accent>\(sign)</accent>", textColor: .textSecondary, accentColor: .textSecondary)
+                            CaptionBText("<accent>\(sign)</accent>", textColor: .textSecondary, accentColor: .textSecondary)
                         }
-                        BodySText(
+                        CaptionBText(
                             "<accent>\(converted.symbol)</accent> \(converted.formatted)", textColor: .textSecondary, accentColor: .textSecondary
                         )
                         .padding(.bottom, 4)
@@ -46,9 +46,9 @@ struct BalanceHeaderView: View {
                     let btcComponents = converted.bitcoinDisplay(unit: currency.displayUnit)
                     HStack {
                         if let sign {
-                            BodySText("<accent>\(sign)</accent>", textColor: .textSecondary, accentColor: .textSecondary)
+                            CaptionBText("<accent>\(sign)</accent>", textColor: .textSecondary, accentColor: .textSecondary)
                         }
-                        BodySText(
+                        CaptionBText(
                             "<accent>\(btcComponents.symbol)</accent> \(btcComponents.value)", textColor: .textSecondary, accentColor: .textSecondary
                         )
                         .padding(.bottom, 4)

--- a/Bitkit/Components/EmptyStateView.swift
+++ b/Bitkit/Components/EmptyStateView.swift
@@ -49,7 +49,7 @@ struct EmptyStateView: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity)
-            .padding(.bottom, 130)
+            .padding(.bottom, 100)
             .overlay {
                 VStack {
                     Button(action: {
@@ -57,8 +57,9 @@ struct EmptyStateView: View {
                         onClose()
                     }) {
                         Image(systemName: "xmark")
-                            .foregroundColor(.textPrimary.opacity(0.8))
-                            .frame(width: 44, height: 44, alignment: .topTrailing)
+                            .resizable()
+                            .foregroundColor(.white64)
+                            .frame(width: 10, height: 10, alignment: .topTrailing)
                     }
                     .frame(maxWidth: .infinity, alignment: .topTrailing)
                     Spacer()

--- a/Bitkit/Components/TabBar.swift
+++ b/Bitkit/Components/TabBar.swift
@@ -34,7 +34,8 @@ struct TabBar: View {
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
                                     .frame(height: 16)
-                                BodySText("Send")
+                                    .rotationEffect(.degrees(180))
+                                BodySSBText("Send")
                             }
                             .foregroundColor(.white)
                         })
@@ -52,8 +53,7 @@ struct TabBar: View {
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
                                     .frame(height: 16)
-                                    .rotationEffect(.degrees(180))
-                                BodySText("Receive")
+                                BodySSBText("Receive")
                             }
                             .foregroundColor(.white)
                         })
@@ -82,7 +82,6 @@ struct TabBar: View {
                             Image("scan")
                                 .resizable()
                                 .frame(width: 32, height: 32)
-                                .foregroundColor(Color.gray2)
                                 .padding(24)
                                 .frame(width: 80, height: 80)
                                 .background(Circle().fill(Color.gray6))
@@ -95,7 +94,8 @@ struct TabBar: View {
                     )
                     .buttonStyle(NoAnimationButtonStyle())
                 }
-                .padding()
+                .padding(.horizontal)
+                .padding(.bottom, 12)
                 .transition(.move(edge: .bottom))
             }
         }

--- a/Bitkit/Extensions/View+SafeArea.swift
+++ b/Bitkit/Extensions/View+SafeArea.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import UIKit
+
+struct BottomSafeAreaPadding: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding(.bottom, UIDevice.current.hasHomeIndicator ? 0 : 16)
+    }
+}
+
+extension View {
+    func bottomSafeAreaPadding() -> some View {
+        modifier(BottomSafeAreaPadding())
+    }
+}
+
+extension UIDevice {
+    var hasHomeIndicator: Bool {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            let window = windowScene.windows.first
+        else {
+            return false
+        }
+        return window.safeAreaInsets.bottom > 0
+    }
+}

--- a/Bitkit/Styles/Colors.swift
+++ b/Bitkit/Styles/Colors.swift
@@ -14,7 +14,7 @@ extension Color {
     static let customWhite = Color.white
 
     // MARK: - Gray Base
-    static let gray6 = Color(hex: 0x151515)
+    static let gray6 = Color(hex: 0x101010)
     static let gray5 = Color(hex: 0x1C1C1D)
     static let gray3 = Color(hex: 0x48484A)
     static let gray2 = Color(hex: 0x636366)

--- a/Bitkit/Styles/TextStyle.swift
+++ b/Bitkit/Styles/TextStyle.swift
@@ -92,7 +92,10 @@ struct BodyMText: View {
     var accentFont: String? = nil
     var textAlignment: NSTextAlignment = .left
 
-    init(_ text: String, textColor: Color = .textSecondary, accentColor: Color = .white, accentFont: String? = nil, textAlignment: NSTextAlignment = .left) {
+    init(
+        _ text: String, textColor: Color = .textSecondary, accentColor: Color = .white, accentFont: String? = nil,
+        textAlignment: NSTextAlignment = .left
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
@@ -174,12 +177,12 @@ struct BodySText: View {
 
 struct BodySSBText: View {
     let text: String
-    var textColor: Color = .textSecondary
+    var textColor: Color = .textPrimary
     var accentColor: Color? = nil
     var url: URL? = nil
     private let fontSize: CGFloat = 15
 
-    init(_ text: String, textColor: Color = .textSecondary, accentColor: Color? = nil, url: URL? = nil) {
+    init(_ text: String, textColor: Color = .textPrimary, accentColor: Color? = nil, url: URL? = nil) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
@@ -419,7 +422,7 @@ struct CustomTextWrapper: View {
                         accentString.addAttributes(
                             [
                                 .foregroundColor: UIColor(accentColor),
-                                .font: font
+                                .font: font,
                             ], range: NSRange(location: 0, length: processedAccentText.count))
                     }
                     attributedString.append(accentString)
@@ -522,7 +525,7 @@ struct DisplayTextUIView: UIViewRepresentable {
                         accentString.addAttributes(
                             [
                                 .foregroundColor: UIColor(accentColor),
-                                .font: font
+                                .font: font,
                             ], range: NSRange(location: 0, length: processedAccentText.count))
                     }
                     attributedString.append(accentString)

--- a/Bitkit/Views/Onboarding/CreateWalletView.swift
+++ b/Bitkit/Views/Onboarding/CreateWalletView.swift
@@ -47,6 +47,8 @@ struct CreateWalletView: View {
             // TODO: check why secondary button is cut off
             .padding(.bottom, 1)
         }
+        .padding(.horizontal, 32)
+        .bottomSafeAreaPadding()
     }
 }
 

--- a/Bitkit/Views/Onboarding/CreateWalletWithPassphraseView.swift
+++ b/Bitkit/Views/Onboarding/CreateWalletWithPassphraseView.swift
@@ -50,6 +50,7 @@ struct CreateWalletWithPassphraseView: View {
             }
         }
         .padding(.horizontal, 32)
+        .bottomSafeAreaPadding()
         .gesture(
             DragGesture()
                 .onChanged { _ in

--- a/Bitkit/Views/Onboarding/IntroView.swift
+++ b/Bitkit/Views/Onboarding/IntroView.swift
@@ -31,6 +31,7 @@ struct IntroView: View {
             }
         }
         .padding(.horizontal, 32)
+        .bottomSafeAreaPadding()
         .background(
             Image("figures")
                 .resizable()

--- a/Bitkit/Views/Onboarding/MultipleWalletsView.swift
+++ b/Bitkit/Views/Onboarding/MultipleWalletsView.swift
@@ -13,6 +13,7 @@ struct MultipleWalletsView: View {
             CustomButton(title: NSLocalizedString("common__understood", comment: ""), destination: RestoreWalletView())
         }
         .padding(.horizontal, 32)
+        .bottomSafeAreaPadding()
     }
 }
 

--- a/Bitkit/Views/Onboarding/OnboardingTab.swift
+++ b/Bitkit/Views/Onboarding/OnboardingTab.swift
@@ -25,7 +25,7 @@ struct OnboardingTab: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 if let disclaimer = disclaimerText {
-                    CaptionText(disclaimer)
+                    CaptionText(disclaimer, textColor: .white32)
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.top, 4)
@@ -33,6 +33,7 @@ struct OnboardingTab: View {
             }
             .frame(maxWidth: .infinity, minHeight: 255, alignment: .top)
             .padding(.top, 48)
+            .padding(.horizontal, 32)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Bitkit/Views/Onboarding/OnboardingView.swift
+++ b/Bitkit/Views/Onboarding/OnboardingView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct OnboardingToolbar: View {
     let currentTab: Int
     let onSkip: () -> Void
-  
+
     // TODO: use Button .tertiary
 
     var body: some View {
@@ -13,7 +13,7 @@ struct OnboardingToolbar: View {
             }) {
                 HStack {
                     Spacer()
-                    BodyMSBText(NSLocalizedString("onboarding__advanced_setup", comment: ""))
+                    BodyMSBText(NSLocalizedString("onboarding__advanced_setup", comment: ""), textColor: .secondary)
                 }
             }
             .opacity(currentTab == 4 ? 1 : 0)
@@ -23,7 +23,7 @@ struct OnboardingToolbar: View {
             } label: {
                 HStack {
                     Spacer()
-                    BodyMSBText(NSLocalizedString("onboarding__skip", comment: ""))
+                    BodyMSBText(NSLocalizedString("onboarding__skip", comment: ""), textColor: .secondary)
                 }
             }
             .opacity(currentTab == 4 ? 0 : 1)
@@ -46,7 +46,7 @@ struct Dots: View {
                 }
             }
             .animation(.easeInOut(duration: 0.3), value: currentTab)
-            .padding(.bottom)
+            .padding(.bottom, 26)
         }
     }
 }
@@ -65,7 +65,6 @@ struct OnboardingView: View {
                         text: NSLocalizedString("onboarding__slide0_text", comment: ""),
                         accentColor: .blueAccent
                     )
-                    .padding(.horizontal, 32)
                     .tag(0)
 
                     // Slide 1
@@ -76,7 +75,6 @@ struct OnboardingView: View {
                         disclaimerText: NSLocalizedString("onboarding__slide1_note", comment: ""),
                         accentColor: .purpleAccent
                     )
-                    .padding(.horizontal, 32)
                     .tag(1)
 
                     // Slide 2
@@ -86,7 +84,6 @@ struct OnboardingView: View {
                         text: NSLocalizedString("onboarding__slide2_text", comment: ""),
                         accentColor: .yellowAccent
                     )
-                    .padding(.horizontal, 32)
                     .tag(2)
 
                     // Slide 3
@@ -96,12 +93,10 @@ struct OnboardingView: View {
                         text: NSLocalizedString("onboarding__slide3_text", comment: ""),
                         accentColor: .greenAccent
                     )
-                    .padding(.horizontal, 32)
                     .tag(3)
 
                     // Slide 4
                     CreateWalletView()
-                        .padding(.horizontal, 32)
                         .tag(4)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
@@ -113,6 +108,7 @@ struct OnboardingView: View {
         }
         .navigationBarBackButtonHidden(true)
         .navigationBarTitleDisplayMode(.inline)
+        .bottomSafeAreaPadding()
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 OnboardingToolbar(currentTab: currentTab) {

--- a/Bitkit/Views/Onboarding/RestoreWalletView.swift
+++ b/Bitkit/Views/Onboarding/RestoreWalletView.swift
@@ -66,7 +66,7 @@ struct RestoreWalletView: View {
                         VStack(spacing: 4) {
                             ForEach(0 ..< wordsPerColumn) { index in
                                 HStack(spacing: 4) {
-                                    BodyMSBText("\(index + 1).")
+                                    BodyMSBText("\(index + 1).", textColor: .secondary)
                                         .padding(.leading, 16)
 
                                     SeedTextField(
@@ -93,7 +93,7 @@ struct RestoreWalletView: View {
                         VStack(spacing: 4) {
                             ForEach(wordsPerColumn ..< (wordsPerColumn * 2)) { index in
                                 HStack(spacing: 4) {
-                                    BodyMSBText("\(index + 1).")
+                                    BodyMSBText("\(index + 1).", textColor: .secondary)
                                         .padding(.leading, 16)
 
                                     SeedTextField(
@@ -143,6 +143,7 @@ struct RestoreWalletView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .padding(.horizontal, 32)
+        .bottomSafeAreaPadding()
         .alert(NSLocalizedString("onboarding__passphrase", comment: ""), isPresented: $showingPassphraseAlert) {
             TextField(NSLocalizedString("onboarding__restore_passphrase_placeholder", comment: ""), text: $tempPassphrase)
                 .autocapitalization(.none)

--- a/Bitkit/Views/Onboarding/TermsView.swift
+++ b/Bitkit/Views/Onboarding/TermsView.swift
@@ -90,7 +90,7 @@ struct TermsView: View {
             TermsFooter()
         }
         .padding(.horizontal, 32)
-        .navigationBarBackButtonHidden(true)
+        .bottomSafeAreaPadding()
     }
 }
 

--- a/Bitkit/Views/Onboarding/WalletInitResultView.swift
+++ b/Bitkit/Views/Onboarding/WalletInitResultView.swift
@@ -69,6 +69,7 @@ struct WalletInitResultView: View {
             .padding(.bottom, 40)
         }
         .padding(.horizontal)
+        .bottomSafeAreaPadding()
     }
 
     private var titleText1: String {

--- a/Bitkit/Views/Wallets/HomeView.swift
+++ b/Bitkit/Views/Wallets/HomeView.swift
@@ -129,7 +129,7 @@ struct HomeView: View {
         }
         .overlay {
             TabBar()
-                .padding(.bottom, 20)
+                .bottomSafeAreaPadding()
         }
         .sheet(
             isPresented: $app.showSendOptionsSheet,
@@ -138,7 +138,7 @@ struct HomeView: View {
                     SendOptionsView()
                         .presentationDetents([.height(sheetHeight)])
                 } else {
-                    SendOptionsView()  // Will just consume full screen on older iOS versions
+                    SendOptionsView() // Will just consume full screen on older iOS versions
                 }
             }
         )
@@ -149,7 +149,7 @@ struct HomeView: View {
                     ReceiveView()
                         .presentationDetents([.height(sheetHeight)])
                 } else {
-                    ReceiveView()  // Will just consume full screen on older iOS versions
+                    ReceiveView() // Will just consume full screen on older iOS versions
                 }
             }
         )
@@ -161,7 +161,7 @@ struct HomeView: View {
                         SendAmountView()
                             .presentationDetents([.height(sheetHeight)])
                     } else {
-                        SendAmountView()  // Will just consume full screen on older iOS versions
+                        SendAmountView() // Will just consume full screen on older iOS versions
                     }
                 }
             }
@@ -174,7 +174,7 @@ struct HomeView: View {
                         SendConfirmationView()
                             .presentationDetents([.height(sheetHeight)])
                     } else {
-                        SendConfirmationView()  // Will just consume full screen on older iOS versions
+                        SendConfirmationView() // Will just consume full screen on older iOS versions
                     }
                 }
             }
@@ -204,10 +204,10 @@ struct HomeView: View {
         .sheet(isPresented: $showProfile) {
             NavigationView {
                 if #available(iOS 16.0, *) {
-                    Text("Profile View")  // Placeholder for profile view
+                    Text("Profile View") // Placeholder for profile view
                         .presentationDetents([.height(sheetHeight)])
                 } else {
-                    Text("Profile View")  // Placeholder for profile view
+                    Text("Profile View") // Placeholder for profile view
                 }
             }
         }


### PR DESCRIPTION
### Description

- add `bottomSafeAreaPadding()` view modifier, so that iPhone SE has padding bottom 16 and other phones have safe area
- polish `TabBar` and empty wallet view

![image](https://github.com/user-attachments/assets/485d7796-f106-474b-994a-e4fe54adbe5a)
