### PR TITLE
fix(ui): fix text line height

### DIFF
--- a/Bitkit/Components/AmountInput.swift
+++ b/Bitkit/Components/AmountInput.swift
@@ -14,7 +14,7 @@ struct AmountInput: View {
 
     init(
         defaultValue: UInt64 = 0, primaryDisplay: Binding<PrimaryDisplay>, overrideSats: Binding<UInt64?> = .constant(nil),
-        showConversion: Bool = false, 
+        showConversion: Bool = false,
         shouldAutoFocus: Bool = true,
         onSatsChange: @escaping (UInt64) -> Void
     ) {
@@ -30,12 +30,12 @@ struct AmountInput: View {
     private var sats: UInt64 {
         return !satsAmount.isEmpty ? UInt64(satsAmount) ?? 0 : 0
     }
-    
+
     private func triggerOnSatsChange(_ value: UInt64) {
         Haptics.play(.buttonTap)
         onSatsChange(value)
     }
-    
+
     private func focusTextField() {
         if primaryDisplay == .bitcoin {
             isSatsFocused = true
@@ -135,7 +135,7 @@ struct AmountInput: View {
                         focusTextField()
                     }
                 }
-                
+
                 if let converted = currency.convert(sats: sats) {
                     if primaryDisplay == .bitcoin {
                         let btcComponents = converted.bitcoinDisplay(unit: currency.displayUnit)
@@ -190,7 +190,7 @@ struct AmountInput: View {
                     isFiatFocused = true
                 }
             }
-            
+
             // Initialize fiat amount if we have a default sats value
             if sats > 0, let converted = currency.convert(sats: sats) {
                 fiatAmount = converted.formatted
@@ -212,7 +212,7 @@ struct AmountInput: View {
                     vm.displayUnit = .modern
                     return vm
                 }())
-        
+
         AmountInput(primaryDisplay: .constant(.bitcoin), showConversion: true) { _ in }
             .environmentObject(
                 {
@@ -230,7 +230,7 @@ struct AmountInput: View {
                     vm.selectedCurrency = "USD"
                     return vm
                 }())
-        
+
         AmountInput(primaryDisplay: .constant(.fiat), showConversion: true) { _ in }
             .environmentObject(
                 {

--- a/Bitkit/Components/CheckboxRow.swift
+++ b/Bitkit/Components/CheckboxRow.swift
@@ -15,7 +15,9 @@ struct CheckboxRow: View {
                     subtitle,
                     textColor: .textSecondary,
                     accentColor: .brandAccent,
-                    url: subtitleUrl
+                    accentAction: {
+                        UIApplication.shared.open(subtitleUrl!)
+                    }
                 )
             }
             .padding(.vertical, 3)

--- a/Bitkit/Components/EmptyStateView.swift
+++ b/Bitkit/Components/EmptyStateView.swift
@@ -49,7 +49,7 @@ struct EmptyStateView: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity)
-            .padding(.bottom, 100)
+            .padding(.bottom, 115)
             .overlay {
                 if let onClose = onClose {
                     VStack {

--- a/Bitkit/Components/MoneyStack.swift
+++ b/Bitkit/Components/MoneyStack.swift
@@ -15,7 +15,7 @@ struct MoneyStack: View {
     private let springAnimation = Animation.spring(response: 0.3, dampingFraction: 0.8)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 16) {
             if currency.primaryDisplay == .bitcoin {
                 MoneyText(
                     sats: sats,

--- a/Bitkit/Components/OnboardingContent.swift
+++ b/Bitkit/Components/OnboardingContent.swift
@@ -19,8 +19,7 @@ struct OnboardingContent: View {
 
             DisplayText(title, accentColor: accentColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                // TODO: fix line height and spacing
-                .padding(.bottom, 2)
+                .padding(.bottom, 14)
 
             BodyMText(text)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Bitkit/Components/SettingsListLabel.swift
+++ b/Bitkit/Components/SettingsListLabel.swift
@@ -8,31 +8,8 @@
 import SwiftUI
 
 enum SettingsListRightIcon {
-    case rightArrow
+    case chevron
     case checkmark
-}
-
-struct SettingsListIcon: View {
-    let imageName: String
-    let iconColor: Color
-
-    init(_ imageName: String, iconColor: Color = .white) {
-        self.imageName = imageName
-        self.iconColor = iconColor
-    }
-
-    var body: some View {
-        Image(imageName)
-            .resizable()
-            .scaledToFit()
-            .foregroundColor(iconColor)
-            .frame(width: 14, height: 14)
-            .background(
-                Circle()
-                    .fill(Color.white10)
-                    .frame(width: 32, height: 32)
-            )
-    }
 }
 
 struct SettingsListLabel: View {
@@ -48,7 +25,7 @@ struct SettingsListLabel: View {
         iconName: String? = nil,
         iconColor: Color = .white,
         rightText: String? = nil,
-        rightIcon: SettingsListRightIcon? = .rightArrow,
+        rightIcon: SettingsListRightIcon? = .chevron,
         toggle: Binding<Bool>? = nil
     ) {
         self.title = title
@@ -60,14 +37,14 @@ struct SettingsListLabel: View {
     }
 
     var body: some View {
-        VStack {
-            HStack {
+        VStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 0) {
                 if let iconName = iconName {
                     Label {
                         BodyMText(title, textColor: .textPrimary)
                     } icon: {
-                        SettingsListIcon(iconName, iconColor: iconColor)
-                            .padding(.trailing, 12)
+                        CircularIcon(icon: iconName, iconColor: iconColor)
+                            .padding(.trailing, 8)
                     }
                 } else {
                     BodyMText(title, textColor: .textPrimary)
@@ -81,15 +58,17 @@ struct SettingsListLabel: View {
                         .labelsHidden()
                 } else {
                     if let rightText = rightText {
-                        BodyMText(rightText, textColor: .textPrimary, textAlignment: .right)
-                            .padding(.trailing, 8)
+                        BodyMText(rightText, textColor: .textPrimary)
+                            .padding(.trailing, 5)
                     }
 
                     if let rightIcon = rightIcon {
                         switch rightIcon {
-                        case .rightArrow:
+                        case .chevron:
                             Image("chevron")
+                                .resizable()
                                 .foregroundColor(.textSecondary)
+                                .frame(width: 24, height: 24)
                         case .checkmark:
                             Image("checkmark")
                                 .foregroundColor(.brandAccent)
@@ -97,8 +76,12 @@ struct SettingsListLabel: View {
                     }
                 }
             }
-            .padding(.vertical, 8)
-            Divider()
+            .frame(height: 50)
+
+            // Bottom border
+            Rectangle()
+                .fill(Color.white10)
+                .frame(height: 1)
         }
         .padding(.horizontal, 16)
     }

--- a/Bitkit/Components/SheetIntro.swift
+++ b/Bitkit/Components/SheetIntro.swift
@@ -51,6 +51,7 @@ struct SheetIntro: View {
                     .padding(.bottom, 32)
 
                 DisplayText(title, accentColor: accentColor)
+                    .padding(.bottom, 14)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 BodyMText(description)

--- a/Bitkit/Components/WalletBalanceView.swift
+++ b/Bitkit/Components/WalletBalanceView.swift
@@ -34,7 +34,6 @@ struct WalletBalanceView: View {
                 }
             }
         }
-        .padding(.vertical, 4)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Bitkit/Components/Widgets/WeatherWidget.swift
+++ b/Bitkit/Components/Widgets/WeatherWidget.swift
@@ -98,9 +98,10 @@ struct WeatherWidget: View {
                     VStack(spacing: 16) {
                         // Status condition with icon
                         if options.showStatus {
-                            HStack(spacing: 0) {
+                            HStack(spacing: 16) {
                                 WeatherTitleText(data.condition.title)
-                                    .lineLimit(2)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
 
                                 Text(data.condition.icon)
                                     .font(.system(size: 100))
@@ -162,6 +163,22 @@ struct WeatherWidget: View {
             // Start data updates
             viewModel.startUpdates()
         }
+    }
+}
+
+struct WeatherTitleText: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text)
+            .font(Fonts.bold(size: 34))
+            .foregroundColor(.textPrimary)
+            .kerning(0)
+            .environment(\._lineHeightMultiple, 0.85)
     }
 }
 

--- a/Bitkit/Styles/StyleGuideView.swift
+++ b/Bitkit/Styles/StyleGuideView.swift
@@ -42,7 +42,10 @@ struct StyleGuideView: View {
                 BodySText("Body s style with <accent>bold accent</accent> over here")
                 BodySText("Body s style with <accent>colored accent</accent> over here", accentColor: .redAccent)
                 BodySText(
-                    "Click here to visit <accent>Google</accent> website", accentColor: .brandAccent, url: URL(string: "https://www.google.com"))
+                    "Click here to visit <accent>Google</accent> website", accentColor: .brandAccent,
+                    accentAction: {
+                        UIApplication.shared.open(URL(string: "https://www.google.com")!)
+                    })
 
                 Divider()
 

--- a/Bitkit/Styles/TextStyle.swift
+++ b/Bitkit/Styles/TextStyle.swift
@@ -1,31 +1,48 @@
 import SwiftUI
-import UIKit
 
-// Bugger headings need custom kerning and line spacing that isn't supported by SwiftUI perfectly so using a UIKit component for some text styles
+// We have some requirements for text styles:
+// - The custom font (InterTight) has extra bottom space -> negative padding
+// - We need to set a smaller than supported line height (without cutting off glyphs) -> (deprecated) lineHeightMultiple
+// - Customize <accent> text (color, weight, action) -> helper functions
+// - kerning & .lineLimit() -> supported by SwiftUI
+
 struct DisplayText: View {
     let text: String
     var textColor: Color = .textPrimary
     var accentColor: Color = .brandAccent
-    var accentFont: String? = nil
-    var textAlignment: NSTextAlignment = .left
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
+    private let fontSize: CGFloat = 44
 
     init(
-        _ text: String, textColor: Color = .textPrimary, accentColor: Color = .brandAccent, accentFont: String? = nil,
-        textAlignment: NSTextAlignment = .left
+        _ text: String,
+        textColor: Color = .textPrimary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
     ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
         self.accentFont = accentFont
-        self.textAlignment = textAlignment
+        self.accentAction = accentAction
     }
 
-    // TODO: lineHeight should be 44, but glyphs are cut off
-
     var body: some View {
-        CustomTextWrapper(
-            text: text, fontSize: 44, lineHeight: 47, shouldCapitalize: true, font: Fonts.black, textColor: textColor, accentColor: accentColor,
-            accentFont: accentFont, kerning: -1, textAlignment: textAlignment)
+        AccentedText(
+            text,
+            font: Fonts.black(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
+        )
+        .kerning(-1)
+        .environment(\._lineHeightMultiple, 0.83)
+        .textCase(.uppercase)
+        .padding(.bottom, -9)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -33,37 +50,38 @@ struct HeadlineText: View {
     let text: String
     var textColor: Color = .textPrimary
     var accentColor: Color = .brandAccent
-    var textAlignment: NSTextAlignment = .left
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
 
-    init(_ text: String, textColor: Color = .textPrimary, accentColor: Color = .brandAccent, textAlignment: NSTextAlignment = .left) {
+    private let fontSize: CGFloat = 30
+
+    init(
+        _ text: String,
+        textColor: Color = .textPrimary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
-        self.textAlignment = textAlignment
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        CustomTextWrapper(
-            text: text, fontSize: 30, lineHeight: 30, shouldCapitalize: true, font: Fonts.black, textColor: textColor, accentColor: accentColor,
-            kerning: -1, textAlignment: textAlignment)
-    }
-}
-
-struct WeatherTitleText: View {
-    let text: String
-    var textColor: Color = .textPrimary
-    var textAlignment: NSTextAlignment = .left
-
-    init(_ text: String, textColor: Color = .textPrimary, textAlignment: NSTextAlignment = .left) {
-        self.text = text
-        self.textColor = textColor
-        self.textAlignment = textAlignment
-    }
-
-    var body: some View {
-        CustomTextWrapper(
-            text: text, fontSize: 34, lineHeight: 34, shouldCapitalize: false, font: Fonts.bold, textColor: textColor, accentColor: textColor,
-            kerning: 0, textAlignment: textAlignment)
+        AccentedText(
+            text,
+            font: Fonts.black(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
+        )
+        .kerning(-1)
+        .environment(\._lineHeightMultiple, 0.83)
+        .textCase(.uppercase)
+        .padding(.bottom, -6)
     }
 }
 
@@ -71,19 +89,35 @@ struct TitleText: View {
     let text: String
     var textColor: Color = .textPrimary
     var accentColor: Color = .brandAccent
-    var textAlignment: NSTextAlignment = .left
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
 
-    init(_ text: String, textColor: Color = .textPrimary, accentColor: Color = .brandAccent, textAlignment: NSTextAlignment = .left) {
+    private let fontSize: CGFloat = 22
+
+    init(
+        _ text: String,
+        textColor: Color = .textPrimary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
-        self.textAlignment = textAlignment
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        CustomTextWrapper(
-            text: text, fontSize: 22, lineHeight: 26, shouldCapitalize: false, font: Fonts.bold, textColor: textColor, accentColor: accentColor,
-            kerning: 0.4, textAlignment: textAlignment)
+        AccentedText(
+            text,
+            font: Fonts.bold(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
+        )
+        .kerning(0.4)
     }
 }
 
@@ -91,65 +125,106 @@ struct SubtitleText: View {
     let text: String
     var textColor: Color = .textPrimary
     var accentColor: Color = .brandAccent
-    var textAlignment: NSTextAlignment = .left
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
 
-    init(_ text: String, textColor: Color = .textPrimary, accentColor: Color = .brandAccent, textAlignment: NSTextAlignment = .left) {
-        self.text = text
-        self.textColor = textColor
-        self.accentColor = accentColor
-        self.textAlignment = textAlignment
-    }
-
-    var body: some View {
-        CustomTextWrapper(
-            text: text, fontSize: 17, lineHeight: 22, shouldCapitalize: false, font: Fonts.bold, textColor: textColor, accentColor: accentColor,
-            kerning: 0.4, textAlignment: textAlignment)
-    }
-}
-
-struct BodyMText: View {
-    let text: String
-    let font = Fonts.regular
-    var textColor: Color = .textSecondary
-    var accentColor: Color = .white
-    var accentFont: String? = nil
-    var textAlignment: NSTextAlignment = .left
+    private let fontSize: CGFloat = 17
 
     init(
-        _ text: String, textColor: Color = .textSecondary, accentColor: Color = .white, accentFont: String? = nil,
-        textAlignment: NSTextAlignment = .left
+        _ text: String,
+        textColor: Color = .textPrimary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
     ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
         self.accentFont = accentFont
-        self.textAlignment = textAlignment
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        CustomTextWrapper(
-            text: text, fontSize: 17, lineHeight: 22, shouldCapitalize: false, font: font, textColor: textColor,
-            accentColor: accentColor, accentFont: accentFont, kerning: 0.4, textAlignment: textAlignment)
+        AccentedText(
+            text,
+            font: Fonts.bold(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
+        )
+        .kerning(0.4)
+    }
+}
+
+struct BodyMText: View {
+    let text: String
+    var textColor: Color = .textSecondary
+    var accentColor: Color = .white
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
+    private let fontSize: CGFloat = 17
+
+    init(
+        _ text: String,
+        textColor: Color = .textSecondary,
+        accentColor: Color = .white,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
+        self.text = text
+        self.textColor = textColor
+        self.accentColor = accentColor
+        self.accentFont = accentFont
+        self.accentAction = accentAction
+    }
+
+    var body: some View {
+        AccentedText(
+            text,
+            font: Fonts.regular(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
+        )
+        .kerning(0.4)
     }
 }
 
 struct BodyMSBText: View {
     let text: String
     var textColor: Color = .textPrimary
-    var accentColor: Color? = nil
+    var accentColor: Color = .brandAccent
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
     private let fontSize: CGFloat = 17
 
-    init(_ text: String, textColor: Color = .textPrimary, accentColor: Color? = nil) {
+    init(
+        _ text: String,
+        textColor: Color = .textPrimary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        Text(
-            AttributedString(parseAccentTags(text: text, defaultColor: textColor, accentColor: accentColor, fontSize: fontSize, font: Fonts.semiBold))
+        AccentedText(
+            text,
+            font: Fonts.semiBold(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
         )
-        .font(.custom(Fonts.semiBold, size: fontSize))
         .kerning(0.4)
     }
 }
@@ -158,89 +233,142 @@ struct BodyMBoldText: View {
     let text: String
     var textColor: Color = .textSecondary
     var accentColor: Color = .brandAccent
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
     private let fontSize: CGFloat = 17
 
-    init(_ text: String, textColor: Color = .textSecondary, accentColor: Color = .brandAccent) {
+    init(
+        _ text: String,
+        textColor: Color = .textSecondary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        Text(AttributedString(parseAccentTags(text: text, defaultColor: textColor, accentColor: accentColor, fontSize: fontSize, font: Fonts.bold)))
-            .font(.custom(Fonts.bold, size: fontSize))
-            .kerning(0.4)
+        AccentedText(
+            text,
+            font: Fonts.bold(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
+        )
+        .kerning(0.4)
     }
 }
 
 struct BodySText: View {
     let text: String
     var textColor: Color = .textSecondary
-    var accentColor: Color? = nil
-    var url: URL? = nil
+    var accentColor: Color = .brandAccent
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
     private let fontSize: CGFloat = 15
 
-    init(_ text: String, textColor: Color = .textSecondary, accentColor: Color? = nil, url: URL? = nil) {
+    init(
+        _ text: String,
+        textColor: Color = .textSecondary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
-        self.url = url
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        Text(
-            AttributedString(
-                parseAccentTags(text: text, defaultColor: textColor, accentColor: accentColor, url: url, fontSize: fontSize, font: Fonts.regular))
+        AccentedText(
+            text,
+            font: Fonts.regular(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
         )
-        .font(.custom(Fonts.regular, size: fontSize))
         .kerning(0.4)
-        .tint(accentColor ?? .brandAccent)
     }
 }
 
 struct BodySSBText: View {
     let text: String
     var textColor: Color = .textPrimary
-    var accentColor: Color? = nil
-    var url: URL? = nil
+    var accentColor: Color = .brandAccent
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
     private let fontSize: CGFloat = 15
 
-    init(_ text: String, textColor: Color = .textPrimary, accentColor: Color? = nil, url: URL? = nil) {
+    init(
+        _ text: String,
+        textColor: Color = .textPrimary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
-        self.url = url
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        Text(
-            AttributedString(
-                parseAccentTags(text: text, defaultColor: textColor, accentColor: accentColor, url: url, fontSize: fontSize, font: Fonts.semiBold))
+        AccentedText(
+            text,
+            font: Fonts.semiBold(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
         )
-        .font(.custom(Fonts.semiBold, size: fontSize))
         .kerning(0.4)
-        .lineSpacing(1)
-        .tint(accentColor ?? .brandAccent)
+        // .lineSpacing(0)
     }
 }
 
 struct CaptionText: View {
     let text: String
     var textColor: Color = .textSecondary
-    var accentColor: Color? = nil
+    var accentColor: Color = .brandAccent
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
     private let fontSize: CGFloat = 13
 
-    init(_ text: String, textColor: Color = .textSecondary, accentColor: Color? = nil) {
+    init(
+        _ text: String,
+        textColor: Color = .textSecondary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
+        self.accentFont = accentFont
     }
 
     var body: some View {
-        Text(
-            AttributedString(parseAccentTags(text: text, defaultColor: textColor, accentColor: accentColor, fontSize: fontSize, font: Fonts.regular))
+        AccentedText(
+            text,
+            font: Fonts.regular(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
         )
-        .font(.custom(Fonts.regular, size: fontSize))
         .kerning(0.4)
     }
 }
@@ -248,20 +376,35 @@ struct CaptionText: View {
 struct CaptionBText: View {
     let text: String
     var textColor: Color = .textSecondary
-    var accentColor: Color? = nil
+    var accentColor: Color = .brandAccent
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
     private let fontSize: CGFloat = 13
 
-    init(_ text: String, textColor: Color = .textSecondary, accentColor: Color? = nil) {
+    init(
+        _ text: String,
+        textColor: Color = .textSecondary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
         self.text = text
         self.textColor = textColor
         self.accentColor = accentColor
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        Text(
-            AttributedString(parseAccentTags(text: text, defaultColor: textColor, accentColor: accentColor, fontSize: fontSize, font: Fonts.semiBold))
+        AccentedText(
+            text,
+            font: Fonts.semiBold(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
         )
-        .font(.custom(Fonts.semiBold, size: fontSize))
         .kerning(0.4)
     }
 }
@@ -269,332 +412,169 @@ struct CaptionBText: View {
 struct FootnoteText: View {
     let text: String
     var textColor: Color = .textSecondary
-    var accentColor: Color? = nil
+    var accentColor: Color = .brandAccent
+    var accentFont: ((CGFloat) -> Font)? = nil
+    var accentAction: (() -> Void)? = nil
+
     private let fontSize: CGFloat = 12
 
-    init(_ text: String, textColor: Color = .textSecondary, accentColor: Color? = nil) {
-        self.text = text
-        self.textColor = textColor
-        self.accentColor = accentColor
-    }
-
-    var body: some View {
-        Text(AttributedString(parseAccentTags(text: text, defaultColor: textColor, accentColor: accentColor, fontSize: fontSize, font: Fonts.medium)))
-            .font(.custom(Fonts.medium, size: fontSize))
-            .kerning(0.4)
-    }
-}
-
-// Helper function to parse accent tags
-private func parseAccentTags(
-    text: String, defaultColor: Color, accentColor: Color?, url: URL? = nil, fontSize: CGFloat = 15, font: String = Fonts.regular,
-    accentFont: String? = nil
-) -> NSAttributedString {
-    let attributedString = NSMutableAttributedString(string: "")
-    var currentIndex = text.startIndex
-
-    while currentIndex < text.endIndex {
-        if let accentStartRange = text[currentIndex...].range(of: "<accent>") {
-            // Add text before the accent tag
-            let beforeAccent = String(text[currentIndex ..< accentStartRange.lowerBound])
-            if !beforeAccent.isEmpty {
-                let normalString = NSAttributedString(
-                    string: beforeAccent,
-                    attributes: [
-                        .foregroundColor: UIColor(defaultColor),
-                        .font: UIFont(name: font, size: fontSize) ?? .systemFont(ofSize: fontSize),
-                    ])
-                attributedString.append(normalString)
-            }
-
-            // Find the end of accent tag
-            if let accentEndRange = text[accentStartRange.upperBound...].range(of: "</accent>") {
-                // Get the accented text
-                let accentedText = String(text[accentStartRange.upperBound ..< accentEndRange.lowerBound])
-                var attributes: [NSAttributedString.Key: Any] = [:]
-
-                if let accentColor = accentColor {
-                    attributes[.foregroundColor] = UIColor(accentColor)
-                    attributes[.font] = UIFont(name: accentFont ?? font, size: fontSize) ?? .systemFont(ofSize: fontSize)
-                } else {
-                    attributes[.foregroundColor] = UIColor(defaultColor)
-                    attributes[.font] = UIFont(name: Fonts.bold, size: fontSize) ?? .systemFont(ofSize: fontSize, weight: .bold)
-                }
-
-                if let url = url {
-                    attributes[.link] = url
-                }
-
-                let accentString = NSAttributedString(string: accentedText, attributes: attributes)
-                attributedString.append(accentString)
-
-                currentIndex = accentEndRange.upperBound
-            } else {
-                // No closing tag found, treat rest as normal text
-                let remainingText = String(text[accentStartRange.lowerBound...])
-                let normalString = NSAttributedString(
-                    string: remainingText,
-                    attributes: [
-                        .foregroundColor: UIColor(defaultColor),
-                        .font: UIFont(name: font, size: fontSize) ?? .systemFont(ofSize: fontSize),
-                    ])
-                attributedString.append(normalString)
-                break
-            }
-        } else {
-            // No more accent tags, add remaining text
-            let remainingText = String(text[currentIndex...])
-            let normalString = NSAttributedString(
-                string: remainingText,
-                attributes: [
-                    .foregroundColor: UIColor(defaultColor),
-                    .font: UIFont(name: font, size: fontSize) ?? .systemFont(ofSize: fontSize),
-                ])
-            attributedString.append(normalString)
-            break
-        }
-    }
-
-    return attributedString
-}
-
-private struct ViewWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
-struct CustomTextWrapper: View {
-    let text: String
-    let fontSize: CGFloat
-    let lineHeight: CGFloat
-    let shouldCapitalize: Bool
-    let font: String
-    let textColor: Color
-    let accentColor: Color
-    let accentFont: String?
-    let kerning: CGFloat
-    let textAlignment: NSTextAlignment
-    @State private var viewWidth: CGFloat = 0
-
     init(
-        text: String, fontSize: CGFloat, lineHeight: CGFloat, shouldCapitalize: Bool, font: String, textColor: Color, accentColor: Color,
-        accentFont: String? = nil, kerning: CGFloat, textAlignment: NSTextAlignment = .left
+        _ text: String,
+        textColor: Color = .textSecondary,
+        accentColor: Color = .brandAccent,
+        accentFont: ((CGFloat) -> Font)? = nil,
+        accentAction: (() -> Void)? = nil
     ) {
         self.text = text
-        self.fontSize = fontSize
-        self.lineHeight = lineHeight
-        self.shouldCapitalize = shouldCapitalize
-        self.font = font
         self.textColor = textColor
         self.accentColor = accentColor
         self.accentFont = accentFont
-        self.kerning = kerning
-        self.textAlignment = textAlignment
+        self.accentAction = accentAction
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            DisplayTextUIView(
-                text: text, fontSize: fontSize, lineHeight: lineHeight, width: geometry.size.width, shouldCapitalize: shouldCapitalize, font: font,
-                textColor: textColor, accentColor: accentColor, accentFont: accentFont ?? font, kerning: kerning, textAlignment: textAlignment
-            )
-            .preference(key: ViewWidthKey.self, value: geometry.size.width)
-        }
-        // .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: calculateHeight())
-        .onPreferenceChange(ViewWidthKey.self) { width in
-            viewWidth = width
-        }
-    }
-
-    private func calculateHeight() -> CGFloat {
-        let label = UILabel()
-        label.font = UIFont(name: font, size: fontSize)
-        label.numberOfLines = 0
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.minimumLineHeight = lineHeight
-        paragraphStyle.maximumLineHeight = lineHeight
-        paragraphStyle.lineSpacing = 0
-        paragraphStyle.alignment = textAlignment
-
-        // Parse text for accent tags and create attributed string
-        let attributedString = NSMutableAttributedString(string: "")
-
-        var currentIndex = text.startIndex
-        while currentIndex < text.endIndex {
-            if let accentStartRange = text[currentIndex...].range(of: "<accent>") {
-                // Add text before the accent tag
-                let beforeAccent = String(text[currentIndex ..< accentStartRange.lowerBound])
-                let processedText = shouldCapitalize ? beforeAccent.uppercased() : beforeAccent
-                if !beforeAccent.isEmpty {
-                    let normalString = NSMutableAttributedString(string: processedText)
-                    normalString.addAttribute(.foregroundColor, value: UIColor(textColor), range: NSRange(location: 0, length: processedText.count))
-                    attributedString.append(normalString)
-                }
-
-                // Find the end of accent tag
-                if let accentEndRange = text[accentStartRange.upperBound...].range(of: "</accent>") {
-                    // Get the accented text
-                    let accentedText = String(text[accentStartRange.upperBound ..< accentEndRange.lowerBound])
-                    let processedAccentText = shouldCapitalize ? accentedText.uppercased() : accentedText
-                    let accentString = NSMutableAttributedString(string: processedAccentText)
-                    if let font = UIFont(name: accentFont ?? font, size: fontSize) {
-                        accentString.addAttributes(
-                            [
-                                .foregroundColor: UIColor(accentColor),
-                                .font: font,
-                            ], range: NSRange(location: 0, length: processedAccentText.count))
-                    }
-                    attributedString.append(accentString)
-
-                    currentIndex = accentEndRange.upperBound
-                } else {
-                    // No closing tag found, treat rest as normal text
-                    let remainingText = String(text[accentStartRange.lowerBound...])
-                    let processedText = shouldCapitalize ? remainingText.uppercased() : remainingText
-                    let normalString = NSMutableAttributedString(string: processedText)
-                    normalString.addAttribute(.foregroundColor, value: UIColor(textColor), range: NSRange(location: 0, length: processedText.count))
-                    attributedString.append(normalString)
-                    break
-                }
-            } else {
-                // No more accent tags, add remaining text
-                let remainingText = String(text[currentIndex...])
-                let processedText = shouldCapitalize ? remainingText.uppercased() : remainingText
-                let normalString = NSMutableAttributedString(string: processedText)
-                normalString.addAttribute(.foregroundColor, value: UIColor(textColor), range: NSRange(location: 0, length: processedText.count))
-                attributedString.append(normalString)
-                break
-            }
-        }
-
-        // Apply common attributes
-        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
-        attributedString.addAttribute(.baselineOffset, value: 0, range: NSRange(location: 0, length: attributedString.length))
-
-        label.attributedText = attributedString
-
-        label.setContentHuggingPriority(.required, for: .vertical)
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
-
-        let size = label.sizeThatFits(CGSize(width: viewWidth, height: .infinity))
-        return size.height
+        AccentedText(
+            text,
+            font: Fonts.medium(size: fontSize),
+            fontColor: textColor,
+            accentColor: accentColor,
+            accentFont: accentFont?(fontSize),
+            accentAction: accentAction
+        )
+        .kerning(0.4)
     }
 }
 
-struct DisplayTextUIView: UIViewRepresentable {
+struct AccentedText: View {
     let text: String
-    let fontSize: CGFloat
-    let lineHeight: CGFloat
-    let width: CGFloat
-    let shouldCapitalize: Bool
-    let font: String
-    let textColor: Color
+    let font: Font
+    let fontColor: Color
     let accentColor: Color
-    let accentFont: String
-    let kerning: CGFloat
-    let textAlignment: NSTextAlignment
+    let accentFont: Font?
+    let accentAction: (() -> Void)?
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
+    init(
+        _ text: String,
+        font: Font = .system(size: 17),
+        fontColor: Color = .primary,
+        accentColor: Color = .accentColor,
+        accentFont: Font? = nil,
+        accentAction: (() -> Void)? = nil
+    ) {
+        self.text = text
+        self.font = font
+        self.fontColor = fontColor
+        self.accentColor = accentColor
+        self.accentFont = accentFont
+        self.accentAction = accentAction
     }
 
-    class Coordinator: NSObject {
-        var parent: DisplayTextUIView
+    var body: some View {
+        let parts = parseAccentTags(from: text)
 
-        init(_ parent: DisplayTextUIView) {
-            self.parent = parent
+        // If there's no accent action, use the simple concatenated text approach
+        if accentAction == nil {
+            let combinedText = parts.reduce(Text("")) { result, part in
+                let selectedFont = part.isAccented ? (accentFont ?? font) : font
+                let baseText = Text(part.text)
+                    .font(selectedFont)
+                    .foregroundColor(part.isAccented ? accentColor : fontColor)
+
+                return result + baseText
+            }
+            combinedText
+            // .background(Color.gray3)
+        } else {
+            // Use a flexible layout that allows tap gestures
+            FlexibleTextView(
+                parts: parts, font: font, fontColor: fontColor, accentColor: accentColor, accentFont: accentFont, accentAction: accentAction)
         }
     }
 
-    private func updateLabel(_ label: UILabel) {
-        label.font = UIFont(name: font, size: fontSize)
-        label.textColor = UIColor(textColor)
-        label.numberOfLines = 0
-        label.preferredMaxLayoutWidth = width
-        label.textAlignment = textAlignment
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.minimumLineHeight = lineHeight
-        paragraphStyle.maximumLineHeight = lineHeight
-        paragraphStyle.lineSpacing = 0
-        paragraphStyle.alignment = textAlignment
-
-        // Parse text for accent tags and create attributed string
-        let attributedString = NSMutableAttributedString(string: "")
-
+    private func parseAccentTags(from text: String) -> [TextPart] {
+        var parts: [TextPart] = []
         var currentIndex = text.startIndex
+
         while currentIndex < text.endIndex {
             if let accentStartRange = text[currentIndex...].range(of: "<accent>") {
                 // Add text before the accent tag
                 let beforeAccent = String(text[currentIndex ..< accentStartRange.lowerBound])
-                let processedText = shouldCapitalize ? beforeAccent.uppercased() : beforeAccent
                 if !beforeAccent.isEmpty {
-                    let normalString = NSMutableAttributedString(string: processedText)
-                    normalString.addAttribute(.foregroundColor, value: UIColor(textColor), range: NSRange(location: 0, length: processedText.count))
-                    attributedString.append(normalString)
+                    parts.append(TextPart(text: beforeAccent, isAccented: false))
                 }
 
                 // Find the end of accent tag
                 if let accentEndRange = text[accentStartRange.upperBound...].range(of: "</accent>") {
                     // Get the accented text
                     let accentedText = String(text[accentStartRange.upperBound ..< accentEndRange.lowerBound])
-                    let processedAccentText = shouldCapitalize ? accentedText.uppercased() : accentedText
-                    let accentString = NSMutableAttributedString(string: processedAccentText)
-                    if let font = UIFont(name: accentFont, size: fontSize) {
-                        accentString.addAttributes(
-                            [
-                                .foregroundColor: UIColor(accentColor),
-                                .font: font,
-                            ], range: NSRange(location: 0, length: processedAccentText.count))
-                    }
-                    attributedString.append(accentString)
-
+                    parts.append(TextPart(text: accentedText, isAccented: true))
                     currentIndex = accentEndRange.upperBound
                 } else {
                     // No closing tag found, treat rest as normal text
                     let remainingText = String(text[accentStartRange.lowerBound...])
-                    let processedText = shouldCapitalize ? remainingText.uppercased() : remainingText
-                    let normalString = NSMutableAttributedString(string: processedText)
-                    normalString.addAttribute(.foregroundColor, value: UIColor(textColor), range: NSRange(location: 0, length: processedText.count))
-                    attributedString.append(normalString)
+                    parts.append(TextPart(text: remainingText, isAccented: false))
                     break
                 }
             } else {
                 // No more accent tags, add remaining text
                 let remainingText = String(text[currentIndex...])
-                let processedText = shouldCapitalize ? remainingText.uppercased() : remainingText
-                let normalString = NSMutableAttributedString(string: processedText)
-                normalString.addAttribute(.foregroundColor, value: UIColor(textColor), range: NSRange(location: 0, length: processedText.count))
-                attributedString.append(normalString)
+                parts.append(TextPart(text: remainingText, isAccented: false))
                 break
             }
         }
 
-        // Apply common attributes
-        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
-        attributedString.addAttribute(.baselineOffset, value: 0, range: NSRange(location: 0, length: attributedString.length))
+        return parts
+    }
+}
 
-        label.attributedText = attributedString
+private struct TextPart {
+    let text: String
+    let isAccented: Bool
+}
 
-        label.setContentHuggingPriority(.required, for: .vertical)
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
+private struct FlexibleTextView: View {
+    let parts: [TextPart]
+    let font: Font
+    let fontColor: Color
+    let accentColor: Color
+    let accentFont: Font?
+    let accentAction: (() -> Void)?
+
+    var body: some View {
+        Text(createAttributedString())
+            .environment(
+                \.openURL,
+                OpenURLAction { url in
+                    if url.absoluteString == "bitkit://accent-tap" {
+                        accentAction?()
+                        return .handled
+                    }
+                    return .systemAction
+                })
     }
 
-    func makeUIView(context _: Context) -> UILabel {
-        let label = UILabel()
-        updateLabel(label)
-        return label
-    }
+    private func createAttributedString() -> AttributedString {
+        var result = AttributedString()
 
-    func updateUIView(_ uiView: UILabel, context _: Context) {
-        updateLabel(uiView)
-    }
+        for part in parts {
+            var attributedPart = AttributedString(part.text)
 
-    static func dismantleUIView(_: UILabel, coordinator _: Coordinator) {}
+            if part.isAccented {
+                attributedPart.font = accentFont ?? font
+                attributedPart.foregroundColor = accentColor
+                if accentAction != nil {
+                    attributedPart.link = URL(string: "bitkit://accent-tap")
+                }
+            } else {
+                attributedPart.font = font
+                attributedPart.foregroundColor = fontColor
+            }
+
+            result.append(attributedPart)
+        }
+
+        return result
+    }
 }
 
 #Preview {
@@ -624,6 +604,15 @@ struct DisplayTextUIView: UIViewRepresentable {
         DisplayText("Display Style With An\n<accent>Accent</accent> Over Here")
             .background(Color.green.opacity(0.1))
             .padding(.bottom, 20)
+
+        BodyMText(
+            "This is body text with a\n<accent>tappable link</accent> inside",
+            accentAction: {
+                print("Accent text was tapped!")
+            }
+        )
+        .background(Color.purple.opacity(0.1))
+        .padding(.bottom, 20)
     }
     .padding()
 }

--- a/Bitkit/Views/Backup/BackupIntro.swift
+++ b/Bitkit/Views/Backup/BackupIntro.swift
@@ -10,42 +10,23 @@ struct BackupIntroView: View {
         let text = wallet.totalBalanceSats > 0 ? localizedString("security__backup_funds") : localizedString("security__backup_funds_no")
 
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("security__backup_wallet"))
-
-            VStack(spacing: 0) {
-                Spacer()
-
-                Image("safe")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: UIScreen.main.bounds.width * 0.8)
-                    .frame(maxHeight: 256)
-
-                DisplayText(localizedString("security__backup_title"), accentColor: .blueAccent)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                BodyMText(text)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                HStack(alignment: .center, spacing: 16) {
-                    CustomButton(
-                        title: localizedString("common__later"),
-                        variant: .secondary,
-                    ) {
-                        app.ignoreBackup()
-                        sheets.hideSheet()
-                    }
-
-                    CustomButton(
-                        title: localizedString("security__backup_button"),
-                    ) {
-                        navigationPath.append(.mnemonic)
-                    }
+            SheetIntro(
+                navTitle: localizedString("security__backup_wallet"),
+                title: localizedString("security__backup_title"),
+                description: text,
+                image: "safe",
+                continueText: localizedString("security__backup_button"),
+                cancelText: localizedString("common__later"),
+                accentColor: .blueAccent,
+                testID: "BackupIntroView",
+                onCancel: {
+                    app.ignoreBackup()
+                    sheets.hideSheet()
+                },
+                onContinue: {
+                    navigationPath.append(.mnemonic)
                 }
-                .padding(.top, 32)
-            }
-            .padding(.horizontal, 16)
+            )
         }
-        .padding(.horizontal, 16)
     }
 }

--- a/Bitkit/Views/Onboarding/CreateWalletView.swift
+++ b/Bitkit/Views/Onboarding/CreateWalletView.swift
@@ -15,10 +15,12 @@ struct CreateWalletView: View {
                     .frame(maxWidth: 311, maxHeight: 311)
                     .frame(maxWidth: .infinity, alignment: .center)
 
-                VStack(spacing: 0) {
+                VStack(spacing: 14) {
                     DisplayText(NSLocalizedString("onboarding__slide4_header", comment: ""), accentColor: .brandAccent)
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
                     BodyMText(NSLocalizedString("onboarding__slide4_text", comment: ""), accentFont: Fonts.bold)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .padding(.top, 48)
             }

--- a/Bitkit/Views/Onboarding/IntroView.swift
+++ b/Bitkit/Views/Onboarding/IntroView.swift
@@ -17,7 +17,7 @@ struct IntroView: View {
                 DisplayText(NSLocalizedString("onboarding__welcome_title", comment: ""))
 
                 BodyMText(NSLocalizedString("onboarding__welcome_text", comment: ""), textColor: .textSecondary, accentColor: .brandAccent)
-                    .padding(.top, 4)
+                    .padding(.top, 14)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/Bitkit/Views/Onboarding/OnboardingTab.swift
+++ b/Bitkit/Views/Onboarding/OnboardingTab.swift
@@ -20,6 +20,7 @@ struct OnboardingTab: View {
             VStack(spacing: 0) {
                 DisplayText(title, accentColor: accentColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.bottom, 14)
 
                 BodyMText(text)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Bitkit/Views/Onboarding/TermsView.swift
+++ b/Bitkit/Views/Onboarding/TermsView.swift
@@ -73,15 +73,15 @@ struct TermsView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             ScrollView(showsIndicators: false) {
-                VStack(spacing: 16) {
-                    DisplayText(NSLocalizedString("onboarding__tos_header", comment: ""))
+                VStack(alignment: .leading, spacing: 16) {
+                    DisplayText(localizedString("onboarding__tos_header"))
 
                     TosContent()
                         .font(Fonts.regular(size: 17))
                         .foregroundColor(.textSecondary)
-                        .padding(.bottom, 300)  // Extra padding for keeping it scrollable past footer
+                        .padding(.bottom, 300) // Extra padding for keeping it scrollable past footer
                 }
-                .padding(.top, 52)
+                .padding(.top, 48)
             }
             .clipped()
 

--- a/Bitkit/Views/OnboardingView.swift
+++ b/Bitkit/Views/OnboardingView.swift
@@ -63,9 +63,13 @@ struct OnboardingView: View {
             .frame(maxHeight: .infinity)
             .layoutPriority(1)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 14) {
                 DisplayText(title, textColor: titleColor, accentColor: accentColor)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
                 BodyMText(description)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             CustomButton(title: buttonText) {

--- a/Bitkit/Views/Security/PinCheckView.swift
+++ b/Bitkit/Views/Security/PinCheckView.swift
@@ -66,13 +66,9 @@ struct PinCheckView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            BodyMText(
-                explanation,
-                textColor: .textSecondary,
-                textAlignment: .left
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.bottom, 40)
+            BodyMText(explanation, textColor: .textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 40)
 
             if !errorMessage.isEmpty {
                 CaptionText(errorMessage, textColor: .brandAccent)

--- a/Bitkit/Views/Security/PinOnLaunchView.swift
+++ b/Bitkit/Views/Security/PinOnLaunchView.swift
@@ -134,16 +134,15 @@ struct PinOnLaunchView: View {
                 .padding(.bottom, 47)
 
             // Title text
-            BodyMText(
+            BodyMSBText(
                 NSLocalizedString("security__pin_enter", comment: ""),
                 textColor: .textPrimary,
-                textAlignment: .center
             )
             .padding(.bottom, 40)
 
             // Error message
             if !errorMessage.isEmpty {
-                CaptionText(errorMessage, textColor: .brandAccent)
+                BodySText(errorMessage, textColor: .brandAccent)
                     .padding(.bottom, 16)
             }
 

--- a/Bitkit/Views/Settings/AboutView.swift
+++ b/Bitkit/Views/Settings/AboutView.swift
@@ -16,7 +16,7 @@ struct AboutView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
             BodyMText(localizedString("settings__about__text"))
                 .padding(.vertical, 16)
                 .padding(.horizontal, 16)
@@ -48,12 +48,13 @@ struct AboutView: View {
 
             Spacer(minLength: 32)
 
-            VStack {
+            VStack(alignment: .center, spacing: 0) {
                 Image("logo")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(maxHeight: 82)
             }
+            .frame(maxWidth: .infinity)
             .padding(.horizontal, 16)
 
             Spacer(minLength: 32)

--- a/Bitkit/Views/Settings/GeneralSettingsView.swift
+++ b/Bitkit/Views/Settings/GeneralSettingsView.swift
@@ -6,51 +6,53 @@ struct GeneralSettingsView: View {
     @EnvironmentObject var app: AppViewModel
 
     var body: some View {
-        ScrollView {
-            NavigationLink(destination: LocalCurrencySettingsView()) {
-                SettingsListLabel(
-                    title: localizedString("settings__general__currency_local"),
-                    rightText: currency.selectedCurrency
-                )
-            }
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
+                NavigationLink(destination: LocalCurrencySettingsView()) {
+                    SettingsListLabel(
+                        title: localizedString("settings__general__currency_local"),
+                        rightText: currency.selectedCurrency
+                    )
+                }
 
-            NavigationLink(destination: DefaultUnitSettingsView()) {
-                SettingsListLabel(
-                    title: localizedString("settings__general__unit"),
-                    rightText: currency.primaryDisplay == .bitcoin ? currency.primaryDisplay.rawValue : currency.selectedCurrency
-                )
-            }
+                NavigationLink(destination: DefaultUnitSettingsView()) {
+                    SettingsListLabel(
+                        title: localizedString("settings__general__unit"),
+                        rightText: currency.primaryDisplay == .bitcoin ? currency.primaryDisplay.rawValue : currency.selectedCurrency
+                    )
+                }
 
-            NavigationLink(destination: TransactionSpeedSettingsView()) {
-                SettingsListLabel(
-                    title: localizedString("settings__general__speed"),
-                    rightText: walletViewModel.defaultTransactionSpeed.displayTitle
-                )
-            }
+                NavigationLink(destination: TransactionSpeedSettingsView()) {
+                    SettingsListLabel(
+                        title: localizedString("settings__general__speed"),
+                        rightText: walletViewModel.defaultTransactionSpeed.displayTitle
+                    )
+                }
 
-            NavigationLink(destination: Text("Coming soon")) {
-                SettingsListLabel(
-                    title: localizedString("settings__general__app_icon"),
-                    rightText: "Orange"
-                )
-            }
+                NavigationLink(destination: Text("Coming soon")) {
+                    SettingsListLabel(
+                        title: localizedString("settings__general__app_icon"),
+                        rightText: "Orange"
+                    )
+                }
 
-            NavigationLink(destination: TagSettingsView()) {
-                SettingsListLabel(
-                    title: localizedString("settings__general__tags")
-                )
-            }
+                NavigationLink(destination: TagSettingsView()) {
+                    SettingsListLabel(
+                        title: localizedString("settings__general__tags")
+                    )
+                }
 
-            NavigationLink(value: app.hasSeenWidgetsIntro ? Route.widgetsList : Route.widgetsIntro) {
-                SettingsListLabel(
-                    title: localizedString("settings__widgets__nav_title")
-                )
-            }
+                NavigationLink(value: app.hasSeenWidgetsIntro ? Route.widgetsList : Route.widgetsIntro) {
+                    SettingsListLabel(
+                        title: localizedString("settings__widgets__nav_title")
+                    )
+                }
 
-            NavigationLink(value: app.hasSeenQuickpayIntro ? Route.quickpay : Route.quickpayIntro) {
-                SettingsListLabel(
-                    title: localizedString("settings__quickpay__nav_title")
-                )
+                NavigationLink(value: app.hasSeenQuickpayIntro ? Route.quickpay : Route.quickpayIntro) {
+                    SettingsListLabel(
+                        title: localizedString("settings__quickpay__nav_title")
+                    )
+                }
             }
         }
         .navigationTitle(localizedString("settings__general_title"))

--- a/Bitkit/Views/Settings/Security/ChoosePinView.swift
+++ b/Bitkit/Views/Settings/Security/ChoosePinView.swift
@@ -15,8 +15,7 @@ struct ChoosePinView: View {
                 BodyMText(
                     pinToCheck == nil
                         ? NSLocalizedString("security__pin_choose_text", comment: "")
-                        : NSLocalizedString("security__pin_retype_text", comment: ""),
-                    textAlignment: .left
+                        : NSLocalizedString("security__pin_retype_text", comment: "")
                 )
             }
             .padding(32)

--- a/Bitkit/Views/Settings/Security/DisablePinView.swift
+++ b/Bitkit/Views/Settings/Security/DisablePinView.swift
@@ -18,9 +18,7 @@ struct DisablePinView: View {
                     NSLocalizedString("security__pin_disable_text", comment: ""),
                     textColor: .textSecondary
                 )
-                .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity, alignment: .center)
-
             }
             .padding(.horizontal, 16)
 

--- a/Bitkit/Views/Settings/Security/SecuritySetupIntro.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySetupIntro.swift
@@ -25,7 +25,6 @@ struct SecuritySetupIntro: View {
                     NSLocalizedString("security__pin_security_text", comment: ""),
                     textColor: .textSecondary,
                 )
-                .multilineTextAlignment(.center)
             }
 
             Spacer()

--- a/Bitkit/Views/Settings/Security/SecuritySetupSuccess.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySetupSuccess.swift
@@ -29,7 +29,6 @@ struct SecuritySetupSuccess: View {
                         : NSLocalizedString("security__success_no_bio", comment: ""),
                     textColor: .textSecondary,
                 )
-                .multilineTextAlignment(.center)
             }
             .padding(.horizontal, 32)
             .padding(.top, 32)

--- a/Bitkit/Views/Settings/Security/SetupBiometricsView.swift
+++ b/Bitkit/Views/Settings/Security/SetupBiometricsView.swift
@@ -30,8 +30,7 @@ struct SetupBiometricsView: View {
                     localizedString(
                         "security__bio_ask", comment: "",
                         variables: ["biometricsName": biometryTypeName]
-                    ),
-                    textAlignment: .left
+                    )
                 )
                 .padding(.horizontal, 32)
             }

--- a/Bitkit/Views/Settings/SettingsListView.swift
+++ b/Bitkit/Views/Settings/SettingsListView.swift
@@ -18,82 +18,84 @@ struct SettingsListView: View {
     @State private var cogTapCount = 0
 
     var body: some View {
-        ScrollView {
-            NavigationLink(value: Route.generalSettings) {
-                SettingsListLabel(
-                    title: NSLocalizedString("settings__general_title", comment: ""),
-                    iconName: "settings-gear"
-                )
-            }
-
-            NavigationLink(destination: SecurityPrivacySettingsView()) {
-                SettingsListLabel(
-                    title: NSLocalizedString("settings__security_title", comment: ""),
-                    iconName: "settings-shield"
-                )
-            }
-
-            NavigationLink(destination: Text("Coming soon")) {
-                SettingsListLabel(
-                    title: NSLocalizedString("settings__backup_title", comment: ""),
-                    iconName: "settings-clock"
-                )
-            }
-
-            NavigationLink(destination: Text("Coming soon")) {
-                SettingsListLabel(
-                    title: NSLocalizedString("settings__advanced_title", comment: ""),
-                    iconName: "settings-slider"
-                )
-            }
-
-            NavigationLink(destination: SupportView()) {
-                SettingsListLabel(
-                    title: NSLocalizedString("settings__support_title", comment: ""),
-                    iconName: "settings-chat"
-                )
-            }
-
-            NavigationLink(destination: AboutView()) {
-                SettingsListLabel(
-                    title: NSLocalizedString("settings__about_title", comment: ""),
-                    iconName: "settings-info"
-                )
-            }
-
-            if showDevSettings {
-                NavigationLink(destination: DevSettingsView()) {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
+                NavigationLink(value: Route.generalSettings) {
                     SettingsListLabel(
-                        title: NSLocalizedString("settings__dev_title", comment: ""),
-                        iconName: "settings-gear" //TODO: find icon for this
+                        title: NSLocalizedString("settings__general_title", comment: ""),
+                        iconName: "settings-gear"
                     )
                 }
+
+                NavigationLink(destination: SecurityPrivacySettingsView()) {
+                    SettingsListLabel(
+                        title: NSLocalizedString("settings__security_title", comment: ""),
+                        iconName: "settings-shield"
+                    )
+                }
+
+                NavigationLink(destination: Text("Coming soon")) {
+                    SettingsListLabel(
+                        title: NSLocalizedString("settings__backup_title", comment: ""),
+                        iconName: "settings-clock"
+                    )
+                }
+
+                NavigationLink(destination: Text("Coming soon")) {
+                    SettingsListLabel(
+                        title: NSLocalizedString("settings__advanced_title", comment: ""),
+                        iconName: "settings-slider"
+                    )
+                }
+
+                NavigationLink(destination: SupportView()) {
+                    SettingsListLabel(
+                        title: NSLocalizedString("settings__support_title", comment: ""),
+                        iconName: "settings-chat"
+                    )
+                }
+
+                NavigationLink(destination: AboutView()) {
+                    SettingsListLabel(
+                        title: NSLocalizedString("settings__about_title", comment: ""),
+                        iconName: "settings-info"
+                    )
+                }
+
+                if showDevSettings {
+                    NavigationLink(destination: DevSettingsView()) {
+                        SettingsListLabel(
+                            title: NSLocalizedString("settings__dev_title", comment: ""),
+                            iconName: "settings-gear" //TODO: find icon for this
+                        )
+                    }
+                }
+
+                // TODO: add to subview
+                // NavigationLink(destination: LightningSettingsView()) {
+                //     Label {
+                //         Text("Lightning")
+                //     } icon: {
+                //         Image(systemName: "bolt.fill")
+                //     }
+                // }
+
+                // NavigationLink(destination: ChannelOrders()) {
+                //     Label {
+                //         Text("Channel Orders")
+                //     } icon: {
+                //         Image(systemName: "list.bullet.rectangle")
+                //     }
+                // }
+
+                // NavigationLink(destination: LogView()) {
+                //     Label {
+                //         Text("Logs")
+                //     } icon: {
+                //         Image(systemName: "doc.text.fill")
+                //     }
+                // }
             }
-
-            // TODO: add to subview
-            // NavigationLink(destination: LightningSettingsView()) {
-            //     Label {
-            //         Text("Lightning")
-            //     } icon: {
-            //         Image(systemName: "bolt.fill")
-            //     }
-            // }
-
-            // NavigationLink(destination: ChannelOrders()) {
-            //     Label {
-            //         Text("Channel Orders")
-            //     } icon: {
-            //         Image(systemName: "list.bullet.rectangle")
-            //     }
-            // }
-
-            // NavigationLink(destination: LogView()) {
-            //     Label {
-            //         Text("Logs")
-            //     } icon: {
-            //         Image(systemName: "doc.text.fill")
-            //     }
-            // }
         }
         .navigationTitle(NSLocalizedString("settings__settings", comment: ""))
         .navigationBarTitleDisplayMode(.inline)

--- a/Bitkit/Views/Settings/TransactionSpeedSettingsView.swift
+++ b/Bitkit/Views/Settings/TransactionSpeedSettingsView.swift
@@ -33,7 +33,7 @@ struct TransactionSpeedSettingsRow: View {
                 Spacer()
 
                 if let customSetSpeed {
-                    BodyMText(customSetSpeed, textColor: .textPrimary, textAlignment: .right)
+                    BodyMText(customSetSpeed, textColor: .textPrimary)
                         .padding(.trailing, 8)
                 }
 

--- a/Bitkit/Views/Sheets/Sheet.swift
+++ b/Bitkit/Views/Sheets/Sheet.swift
@@ -38,13 +38,15 @@ struct SheetHeader: View {
                 Spacer()
             }
 
-            Spacer()
+            SubtitleText(title)
+                .frame(maxWidth: .infinity, alignment: .center)
 
-            SubtitleText(title, textAlignment: .center)
-
-            Spacer()
-
-            Spacer()
+            if showBackButton {
+                Spacer()
+                    .frame(width: 24, height: 24)
+            } else {
+                Spacer()
+            }
         }
         .padding(.bottom, 32)
     }

--- a/Bitkit/Views/Transfer/SettingUpView.swift
+++ b/Bitkit/Views/Transfer/SettingUpView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import BitkitCore
+import SwiftUI
 
 struct ProgressSteps: View {
     let steps: [String]
@@ -63,7 +63,7 @@ struct ProgressSteps: View {
                 }
             }
 
-            BodyMText(steps[currentStep], textColor: .textSecondary, textAlignment: .center)
+            BodyMText(steps[currentStep], textColor: .textSecondary)
         }
     }
 }

--- a/Bitkit/Views/Wallets/HomeView.swift
+++ b/Bitkit/Views/Wallets/HomeView.swift
@@ -42,7 +42,7 @@ struct HomeView: View {
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top)
+                    .padding(.top, 28)
                     .padding(.horizontal)
 
                     Suggestions()

--- a/Bitkit/Views/Widgets/WidgetDetailView.swift
+++ b/Bitkit/Views/Widgets/WidgetDetailView.swift
@@ -80,7 +80,7 @@ struct WidgetDetailView: View {
                 Button(action: {
                     navigation.navigate(.widgetEdit(id))
                 }) {
-                    HStack(spacing: 0) {
+                    HStack(alignment: .center, spacing: 0) {
                         BodyMText(localizedString("widgets__widget__edit"), textColor: .textPrimary)
 
                         Spacer()
@@ -96,6 +96,7 @@ struct WidgetDetailView: View {
                             .resizable()
                             .foregroundColor(.textSecondary)
                             .frame(width: 24, height: 24)
+                            .padding(.leading, 5)
                     }
                     .frame(maxWidth: .infinity)
                     .contentShape(Rectangle())


### PR DESCRIPTION
### Description

- refactor custom text views to use SwiftUI modifiers

For typography that has atypical line height (Display, Headline) `._lineHeightMultiple()` works (and doesn't cut off larger glyphs like before), but has to be used in environment otherwise there is a deprecation warning. Our custom font has extra padding at the bottom which is fine but to make it easier to match the spacing in Figma it is removed with negative `.padding()`

`BodyMText` was full width before (problematic), now it's inline by default. Hopefully I fixed all usage where it should be block size. Also `.lineLimit()` can be used now.

### Screenshot / Video

No visual changes hopefully
