### PR TITLE
refactor: format files

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,8 +1,0 @@
-{
-	"indentation": {
-		"spaces": 4
-	},
-	"lineLength": 150,
-	"spacesAroundRangeFormationOperators": true,
-	"spacesBeforeEndOfLineComments": 1
-}

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,13 @@
+# format options
+
+--header strip
+--maxwidth 150
+--stripunusedargs closure-only
+--swiftversion 5.10
+
+# rules
+
+--disable andOperator
+--disable consistentSwitchCaseSpacing
+--disable redundantReturn
+--enable isEmpty

--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -119,7 +119,7 @@ struct AppScene: View {
 
     @ViewBuilder
     private var initializingContent: some View {
-        if case .errorStarting(_) = wallet.nodeLifecycleState {
+        if case .errorStarting = wallet.nodeLifecycleState {
             WalletRestoreError()
         } else {
             InitializingWalletView(shouldFinish: $walletInitShouldFinish) {

--- a/Bitkit/BitkitApp.swift
+++ b/Bitkit/BitkitApp.swift
@@ -1,10 +1,3 @@
-//
-//  BitkitApp.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/06/27.
-//
-
 import SwiftUI
 
 class AppDelegate: NSObject, UIApplicationDelegate {

--- a/Bitkit/Components/Activity/ActivityList.swift
+++ b/Bitkit/Components/Activity/ActivityList.swift
@@ -21,11 +21,11 @@ struct ActivityList: View {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(groupedItems, id: \.self) { groupItem in
                     switch groupItem {
-                    case .header(let title):
+                    case let .header(title):
                         CaptionMText(title)
                             .padding(.top)
 
-                    case .activity(let item):
+                    case let .activity(item):
                         NavigationLink(value: Route.activityDetail(item)) {
                             ActivityRow(item: item)
                         }
@@ -34,8 +34,8 @@ struct ActivityList: View {
 
                         // Add divider if not the last item in the group
                         if let nextIndex = activity.groupedActivities.firstIndex(of: groupItem),
-                            nextIndex + 1 < activity.groupedActivities.count,
-                            case .activity = activity.groupedActivities[nextIndex + 1]
+                           nextIndex + 1 < activity.groupedActivities.count,
+                           case .activity = activity.groupedActivities[nextIndex + 1]
                         {
                             Divider()
                         }

--- a/Bitkit/Components/AmountInput.swift
+++ b/Bitkit/Components/AmountInput.swift
@@ -54,13 +54,11 @@ struct AmountInput: View {
                 .opacity(0)
                 .onChange(of: satsAmount) { newValue in
                     if primaryDisplay == .bitcoin {
-                        let filtered = {
-                            if currency.displayUnit == .modern {
-                                newValue.filter { "0123456789".contains($0) }
-                            } else {
-                                newValue.filter { "0123456789.".contains($0) }
-                            }
-                        }()
+                        let filtered = if currency.displayUnit == .modern {
+                            newValue.filter { "0123456789".contains($0) }
+                        } else {
+                            newValue.filter { "0123456789.".contains($0) }
+                        }
 
                         // Limit to 8 decimal places for classic
                         if currency.displayUnit == .classic {
@@ -107,7 +105,7 @@ struct AmountInput: View {
 
                         // Only convert if we have a valid number
                         if !fiatAmount.isEmpty, let fiatDouble = Double(fiatAmount),
-                            let convertedSats = currency.convert(fiatAmount: fiatDouble)
+                           let convertedSats = currency.convert(fiatAmount: fiatDouble)
                         {
                             satsAmount = String(convertedSats)
                             triggerOnSatsChange(convertedSats)
@@ -215,7 +213,8 @@ struct AmountInput: View {
                     vm.primaryDisplay = .bitcoin
                     vm.displayUnit = .modern
                     return vm
-                }())
+                }()
+            )
 
         AmountInput(primaryDisplay: .constant(.bitcoin), showConversion: true) { _ in }
             .environmentObject(
@@ -224,7 +223,8 @@ struct AmountInput: View {
                     vm.primaryDisplay = .bitcoin
                     vm.displayUnit = .modern
                     return vm
-                }())
+                }()
+            )
 
         AmountInput(primaryDisplay: .constant(.fiat)) { _ in }
             .environmentObject(
@@ -233,7 +233,8 @@ struct AmountInput: View {
                     vm.primaryDisplay = .fiat
                     vm.selectedCurrency = "USD"
                     return vm
-                }())
+                }()
+            )
 
         AmountInput(primaryDisplay: .constant(.fiat), showConversion: true) { _ in }
             .environmentObject(
@@ -242,7 +243,8 @@ struct AmountInput: View {
                     vm.primaryDisplay = .fiat
                     vm.selectedCurrency = "USD"
                     return vm
-                }())
+                }()
+            )
     }
     .padding()
     .preferredColorScheme(.dark)

--- a/Bitkit/Components/Button.swift
+++ b/Bitkit/Components/Button.swift
@@ -101,8 +101,8 @@ struct CustomButton: View {
         self.isDisabled = isDisabled
         self.isLoading = isLoading
         self.shouldExpand = shouldExpand
-        self.action = nil
-        self.destination = nil
+        action = nil
+        destination = nil
     }
 
     // Trailing closure initializer
@@ -124,11 +124,11 @@ struct CustomButton: View {
         self.isLoading = isLoading
         self.shouldExpand = shouldExpand
         self.action = action
-        self.destination = nil
+        destination = nil
     }
 
     // Navigation link initializer
-    init<D: View>(
+    init(
         title: String,
         variant: Variant = .primary,
         size: Size = .large,
@@ -136,7 +136,7 @@ struct CustomButton: View {
         isDisabled: Bool = false,
         isLoading: Bool = false,
         shouldExpand: Bool = false,
-        destination: D
+        destination: some View
     ) {
         self.title = title
         self.variant = variant
@@ -145,7 +145,7 @@ struct CustomButton: View {
         self.isDisabled = isDisabled
         self.isLoading = isLoading
         self.shouldExpand = shouldExpand
-        self.action = nil
+        action = nil
         self.destination = AnyView(destination)
     }
 
@@ -222,7 +222,7 @@ struct CustomButton: View {
 
     var body: some View {
         Group {
-            if let destination = destination {
+            if let destination {
                 NavigationLink(destination: destination) {
                     buttonContent
                 }
@@ -240,8 +240,9 @@ struct CustomButton: View {
                         if !isDisabled {
                             Haptics.play(.buttonTap)
                         }
-                    })
-            } else if let action = action {
+                    }
+                )
+            } else if let action {
                 Button {
                     guard !isLoading, !isDisabled else { return }
 
@@ -271,7 +272,7 @@ struct CustomButton: View {
 
     private var buttonContent: some View {
         HStack(spacing: 8) {
-            if let icon = icon, !isLoading {
+            if let icon, !isLoading {
                 icon
             }
 
@@ -294,7 +295,7 @@ struct CustomButton: View {
         .cornerRadius(size.cornerRadius)
         .overlay(
             Group {
-                if let borderColor = borderColor {
+                if let borderColor {
                     RoundedRectangle(cornerRadius: size.cornerRadius)
                         .stroke(borderColor, lineWidth: 2)
                 }

--- a/Bitkit/Components/CircularIcon.swift
+++ b/Bitkit/Components/CircularIcon.swift
@@ -7,7 +7,7 @@ struct CircularIcon: View {
 
     // Initializer for string icons
     init(icon: String, iconColor: Color = .white, backgroundColor: Color = .white10, size: CGFloat = 32) {
-        self.content = AnyView(
+        content = AnyView(
             Image(icon)
                 .resizable()
                 .scaledToFit()
@@ -19,8 +19,8 @@ struct CircularIcon: View {
     }
 
     // Initializer for view icons (direct View parameter)
-    init<Icon: View>(icon: Icon, backgroundColor: Color = .white10, size: CGFloat = 32) {
-        self.content = AnyView(icon)
+    init(icon: some View, backgroundColor: Color = .white10, size: CGFloat = 32) {
+        content = AnyView(icon)
         self.backgroundColor = backgroundColor
         self.size = size
     }

--- a/Bitkit/Components/CopyAddressCard.swift
+++ b/Bitkit/Components/CopyAddressCard.swift
@@ -96,7 +96,8 @@ struct CopyAddressCard: View {
         CopyAddressPair(title: "On-chain Address", address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", type: .onchain),
         CopyAddressPair(
             title: "Lightning Invoice", address: "lnbc1500n1p3hk3sppp5k54t9c4p4u4tdgj0y8tqjp3kzjak8jtr0fwvnl2dpl5pvrm9gxsdqqcqzpgxqyz5vqsp5",
-            type: .lightning),
+            type: .lightning
+        ),
     ])
     .preferredColorScheme(.dark)
 }

--- a/Bitkit/Components/Core/ButtonDetectionModifier.swift
+++ b/Bitkit/Components/Core/ButtonDetectionModifier.swift
@@ -10,7 +10,7 @@ private struct ButtonDetectionModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(
-                GeometryReader { geometry in
+                GeometryReader { _ in
                     Color.clear
                         .contentShape(Rectangle())
                         .gesture(
@@ -23,7 +23,7 @@ private struct ButtonDetectionModifier: ViewModifier {
                                     // Perform hit testing to determine what was tapped
                                     let hitTest = UIApplication.shared.connectedScenes
                                         .first(where: { $0 is UIWindowScene })
-                                        .flatMap({ $0 as? UIWindowScene })?.windows
+                                        .flatMap { $0 as? UIWindowScene }?.windows
                                         .first?
                                         .hitTest(location, with: nil)
 

--- a/Bitkit/Components/Core/ButtonLocationTracking.swift
+++ b/Bitkit/Components/Core/ButtonLocationTracking.swift
@@ -41,13 +41,13 @@ private struct ButtonLocationModifier: ViewModifier {
     }
 }
 
-extension View {
+public extension View {
     /// Tracks the location of a view in a specified coordinate space
     /// - Parameters:
     ///   - coordinateSpace: The name of the coordinate space to track the view in
     ///   - onLocationChanged: Callback when the view's location changes
     /// - Returns: A view that tracks its location in the specified coordinate space
-    public func trackButtonLocation(
+    func trackButtonLocation(
         in coordinateSpace: String,
         onLocationChanged: @escaping (CGRect) -> Void
     ) -> some View {
@@ -55,13 +55,14 @@ extension View {
             ButtonLocationModifier(
                 coordinateSpace: coordinateSpace,
                 onLocationChanged: onLocationChanged
-            ))
+            )
+        )
     }
 
     /// Tracks the location of a view in the default "dragSpace" coordinate space
     /// - Parameter onLocationChanged: Callback when the view's location changes
     /// - Returns: A view that tracks its location in the drag space
-    public func trackButtonLocation(onLocationChanged: @escaping (CGRect) -> Void) -> some View {
+    func trackButtonLocation(onLocationChanged: @escaping (CGRect) -> Void) -> some View {
         trackButtonLocation(in: "dragSpace", onLocationChanged: onLocationChanged)
     }
 }

--- a/Bitkit/Components/Core/DraggableItem.swift
+++ b/Bitkit/Components/Core/DraggableItem.swift
@@ -156,7 +156,7 @@ struct DraggableItem<Content: View, ID: Hashable>: View {
                     onDragChanged(dragOffset)
                 }
             }
-            .onEnded { gesture in
+            .onEnded { _ in
                 if isDragging && shouldHandleDrag {
                     let verticalOffset = CGSize(width: 0, height: dragOffset.height)
                     onDragEnded(verticalOffset)

--- a/Bitkit/Components/Core/DraggableList.swift
+++ b/Bitkit/Components/Core/DraggableList.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 /// Helper component that implements reorderable list functionality
 struct DraggableList<Data, ID, Content>: View
-where Data: RandomAccessCollection, ID: Hashable, Content: View, Data.Element: Identifiable {
+    where Data: RandomAccessCollection, ID: Hashable, Content: View, Data.Element: Identifiable
+{
     /// The data to render in the list
     let data: Data
 
@@ -101,7 +102,7 @@ where Data: RandomAccessCollection, ID: Hashable, Content: View, Data.Element: I
                             }
                         }
                     },
-                    onDragEnded: { finalAmount in
+                    onDragEnded: { _ in
                         if draggedItemID == nil { return }
 
                         // Find the source index for the dragged item
@@ -150,7 +151,7 @@ where Data: RandomAccessCollection, ID: Hashable, Content: View, Data.Element: I
 
         // If we're not dragging or don't have a predicted destination, no offset
         guard let draggedIndex = getIndexForID(draggedItemID ?? id),
-            let predictedIndex = predictedDestinationIndex
+              let predictedIndex = predictedDestinationIndex
         else {
             return .zero
         }

--- a/Bitkit/Components/DrawerView.swift
+++ b/Bitkit/Components/DrawerView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-//TODO: maybe move to a separate file
+// TODO: maybe move to a separate file
 enum DrawerMenuItem: Int, CaseIterable, Identifiable, Hashable {
     case wallet
     case activity
@@ -88,7 +88,7 @@ struct DrawerView: View {
             if showMenu {
                 GeometryReader { geometry in
                     VStack(alignment: .leading, spacing: 0) {
-                        ForEach(DrawerMenuItem.allCases.filter { $0.isMainMenuItem }) { item in
+                        ForEach(DrawerMenuItem.allCases.filter(\.isMainMenuItem)) { item in
                             Button(action: {
                                 navigation.activeDrawerMenuItem = item
                                 closeMenu()
@@ -109,7 +109,7 @@ struct DrawerView: View {
                             .onChanged { value in
                                 currentDragOffset = max(0, value.translation.width)
                             }
-                            .onEnded { value in
+                            .onEnded { _ in
                                 let drawerWidth = geometry.size.width * 0.5
                                 let closeCompletionThreshold = drawerWidth - 100
 

--- a/Bitkit/Components/EmptyStateView.swift
+++ b/Bitkit/Components/EmptyStateView.swift
@@ -51,7 +51,7 @@ struct EmptyStateView: View {
             .frame(maxWidth: .infinity)
             .padding(.bottom, 115)
             .overlay {
-                if let onClose = onClose {
+                if let onClose {
                     VStack {
                         Button(action: {
                             Haptics.play(.buttonTap)

--- a/Bitkit/Components/Home/Suggestions.swift
+++ b/Bitkit/Components/Home/Suggestions.swift
@@ -165,7 +165,8 @@ struct Suggestions: View {
                 ) { card in
                     SuggestionCard(
                         data: card,
-                        onDismiss: { dismissCard(card) })
+                        onDismiss: { dismissCard(card) }
+                    )
                 }
                 .id("suggestions-\(filteredCards.count)-\(suggestionsManager.dismissedIds.count)")
                 .frame(height: cardSize)
@@ -179,7 +180,8 @@ struct Suggestions: View {
                         variables: [
                             "appStoreUrl": Env.appStoreUrl,
                             "playStoreUrl": Env.playStoreUrl,
-                        ])
+                        ]
+                    ),
                 ])
             }
         }
@@ -211,7 +213,7 @@ struct Suggestions: View {
             route = app.hasSeenTransferToSpendingIntro ? .fundingOptions : .transferIntro
         }
 
-        if let route = route {
+        if let route {
             navigation.navigate(route)
         }
     }

--- a/Bitkit/Components/MoneyCell.swift
+++ b/Bitkit/Components/MoneyCell.swift
@@ -27,8 +27,9 @@ struct MoneyCell: View {
 }
 
 // MARK: - Preview Helpers
-extension MoneyCell {
-    fileprivate static func previewCurrencyVM(
+
+private extension MoneyCell {
+    static func previewCurrencyVM(
         primaryDisplay: PrimaryDisplay,
         currency: String,
         displayUnit: BitcoinDisplayUnit = .modern
@@ -40,7 +41,7 @@ extension MoneyCell {
         return vm
     }
 
-    fileprivate static func previewSettingsVM(hideBalance: Bool = false) -> SettingsViewModel {
+    static func previewSettingsVM(hideBalance: Bool = false) -> SettingsViewModel {
         let vm = SettingsViewModel()
         vm.hideBalance = hideBalance
         return vm

--- a/Bitkit/Components/MoneyStack.swift
+++ b/Bitkit/Components/MoneyStack.swift
@@ -12,6 +12,7 @@ struct MoneyStack: View {
     @EnvironmentObject var settings: SettingsViewModel
 
     // MARK: - Constants
+
     private let springAnimation = Animation.spring(response: 0.3, dampingFraction: 0.8)
 
     var body: some View {
@@ -116,8 +117,9 @@ struct MoneyStack: View {
 }
 
 // MARK: - Helper Views
-extension MoneyStack {
-    fileprivate var eyeIconButton: some View {
+
+private extension MoneyStack {
+    var eyeIconButton: some View {
         Button(action: revealBalance) {
             Image("eye")
                 .resizable()
@@ -129,8 +131,9 @@ extension MoneyStack {
 }
 
 // MARK: - Helper Methods
-extension MoneyStack {
-    fileprivate func revealBalance() {
+
+private extension MoneyStack {
+    func revealBalance() {
         withAnimation(springAnimation) {
             settings.hideBalance = false
         }
@@ -139,9 +142,10 @@ extension MoneyStack {
 }
 
 // MARK: - Helper View Modifier
+
 extension View {
     @ViewBuilder
-    func conditionalGesture<G: Gesture>(_ condition: Bool, gesture: () -> G) -> some View {
+    func conditionalGesture(_ condition: Bool, gesture: () -> some Gesture) -> some View {
         if condition {
             self.gesture(gesture())
         } else {
@@ -151,8 +155,9 @@ extension View {
 }
 
 // MARK: - Preview Helpers
-extension MoneyStack {
-    fileprivate static func previewCurrencyVM(
+
+private extension MoneyStack {
+    static func previewCurrencyVM(
         primaryDisplay: PrimaryDisplay,
         currency: String,
         displayUnit: BitcoinDisplayUnit = .modern
@@ -164,7 +169,7 @@ extension MoneyStack {
         return vm
     }
 
-    fileprivate static func previewSettingsVM(hideBalance: Bool = false) -> SettingsViewModel {
+    static func previewSettingsVM(hideBalance: Bool = false) -> SettingsViewModel {
         let vm = SettingsViewModel()
         vm.hideBalance = hideBalance
         return vm

--- a/Bitkit/Components/MoneyText.swift
+++ b/Bitkit/Components/MoneyText.swift
@@ -28,6 +28,7 @@ struct MoneyText: View {
     @EnvironmentObject var settings: SettingsViewModel
 
     // MARK: - Computed Properties
+
     private var unit: PrimaryDisplay {
         unitType == .secondary ? (currency.primaryDisplay == .bitcoin ? .fiat : .bitcoin) : currency.primaryDisplay
     }
@@ -61,15 +62,16 @@ struct MoneyText: View {
 }
 
 // MARK: - Helper Views
-extension MoneyText {
 
+extension MoneyText {
     @ViewBuilder
     private func textComponent(_ text: String) -> some View {
         switch size {
         case .display:
             DisplayText(
                 // Cap symbol font weight to ExtraBold
-                text, textColor: color, accentColor: symbolColor ?? .textSecondary, accentFont: size == .display ? Fonts.extraBold : nil)
+                text, textColor: color, accentColor: symbolColor ?? .textSecondary, accentFont: size == .display ? Fonts.extraBold : nil
+            )
         case .title:
             TitleText(text, textColor: color, accentColor: symbolColor ?? .textSecondary)
         case .bodyMSB:
@@ -83,6 +85,7 @@ extension MoneyText {
 }
 
 // MARK: - Helper Methods
+
 extension MoneyText {
     private var fiatSymbol: String {
         guard let converted = currency.convert(sats: UInt64(abs(sats))) else { return "$" }
@@ -107,8 +110,9 @@ extension MoneyText {
 }
 
 // MARK: - Preview Helpers
-extension MoneyText {
-    fileprivate static func previewCurrencyVM(
+
+private extension MoneyText {
+    static func previewCurrencyVM(
         primaryDisplay: PrimaryDisplay,
         currency: String,
         displayUnit: BitcoinDisplayUnit = .modern
@@ -120,7 +124,7 @@ extension MoneyText {
         return vm
     }
 
-    fileprivate static func previewSettingsVM(hideBalance: Bool = false) -> SettingsViewModel {
+    static func previewSettingsVM(hideBalance: Bool = false) -> SettingsViewModel {
         let vm = SettingsViewModel()
         vm.hideBalance = hideBalance
         return vm

--- a/Bitkit/Components/NodeStateView.swift
+++ b/Bitkit/Components/NodeStateView.swift
@@ -1,10 +1,3 @@
-//
-//  NodeStateView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/04.
-//
-
 import LDKNode
 import SwiftUI
 
@@ -12,12 +5,12 @@ import SwiftUI
 extension LightningBalance {
     var channelIdString: String {
         switch self {
-        case .contentiousClaimable(let channelId, _, _, _, _, _),
-            .maybePreimageClaimableHtlc(let channelId, _, _, _, _),
-            .counterpartyRevokedOutputClaimable(let channelId, _, _),
-            .claimableOnChannelClose(let channelId, _, _, _, _, _, _, _),
-            .claimableAwaitingConfirmations(let channelId, _, _, _, _),
-            .maybeTimeoutClaimableHtlc(let channelId, _, _, _, _, _):
+        case let .contentiousClaimable(channelId, _, _, _, _, _),
+             let .maybePreimageClaimableHtlc(channelId, _, _, _, _),
+             let .counterpartyRevokedOutputClaimable(channelId, _, _),
+             let .claimableOnChannelClose(channelId, _, _, _, _, _, _, _),
+             let .claimableAwaitingConfirmations(channelId, _, _, _, _),
+             let .maybeTimeoutClaimableHtlc(channelId, _, _, _, _, _):
             return channelId
         }
     }
@@ -29,7 +22,7 @@ struct IdentifiableLightningBalance: Identifiable {
     let balance: LightningBalance
 
     init(_ balance: LightningBalance) {
-        self.id = balance.channelIdString
+        id = balance.channelIdString
         self.balance = balance
     }
 }
@@ -225,7 +218,7 @@ struct LightningBalanceRow: View {
     private var balanceTypeString: String {
         switch balance {
         case .claimableOnChannelClose: return "Claimable on Channel Close"
-        case .claimableAwaitingConfirmations(_, _, _, let confirmationHeight, _):
+        case let .claimableAwaitingConfirmations(_, _, _, confirmationHeight, _):
             return "Claimable Awaiting Confirmations (Height: \(confirmationHeight))"
         case .contentiousClaimable: return "Contentious Claimable"
         case .maybeTimeoutClaimableHtlc: return "Maybe Timeout Claimable HTLC"
@@ -236,12 +229,12 @@ struct LightningBalanceRow: View {
 
     private var amountString: String {
         switch balance {
-        case .claimableOnChannelClose(_, _, let amount, _, _, _, _, _),
-            .claimableAwaitingConfirmations(_, _, let amount, _, _),
-            .contentiousClaimable(_, _, let amount, _, _, _),
-            .maybeTimeoutClaimableHtlc(_, _, let amount, _, _, _),
-            .maybePreimageClaimableHtlc(_, _, let amount, _, _),
-            .counterpartyRevokedOutputClaimable(_, _, let amount):
+        case let .claimableOnChannelClose(_, _, amount, _, _, _, _, _),
+             let .claimableAwaitingConfirmations(_, _, amount, _, _),
+             let .contentiousClaimable(_, _, amount, _, _, _),
+             let .maybeTimeoutClaimableHtlc(_, _, amount, _, _, _),
+             let .maybePreimageClaimableHtlc(_, _, amount, _, _),
+             let .counterpartyRevokedOutputClaimable(_, _, amount):
             return "\(amount)"
         }
     }

--- a/Bitkit/Components/NumPad.swift
+++ b/Bitkit/Components/NumPad.swift
@@ -1,10 +1,3 @@
-//
-//  NumPad.swift
-//  Bitkit
-//
-//  Created by Assistant on 2024/12/19.
-//
-
 import SwiftUI
 
 struct NumPad: View {
@@ -47,6 +40,7 @@ struct NumPad: View {
         }
     }
 }
+
 private struct NumPadButton: View {
     let text: String
     let height: CGFloat

--- a/Bitkit/Components/NumberPadActionButton.swift
+++ b/Bitkit/Components/NumberPadActionButton.swift
@@ -1,10 +1,3 @@
-//
-//  NumberPadActionButton.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/12.
-//
-
 import SwiftUI
 
 enum NumberPadActionButtonVariant {

--- a/Bitkit/Components/PinInput.swift
+++ b/Bitkit/Components/PinInput.swift
@@ -1,10 +1,3 @@
-//
-//  PinInputView.swift
-//  Bitkit
-//
-//  Created by Assistant on 2024/12/19.
-//
-
 import SwiftUI
 
 struct PinInput: View {

--- a/Bitkit/Components/QR.swift
+++ b/Bitkit/Components/QR.swift
@@ -1,10 +1,3 @@
-//
-//  QR.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/08/23.
-//
-
 import CoreImage.CIFilterBuiltins
 import SwiftUI
 
@@ -29,7 +22,7 @@ struct QR: View {
                 .background(Color.white)
                 .cornerRadius(8)
 
-            if let imageAsset = imageAsset {
+            if let imageAsset {
                 ZStack {
                     Circle()
                         .fill(Color.white)
@@ -74,15 +67,17 @@ struct QR: View {
         VStack(spacing: 20) {
             QR(
                 content:
-                    "bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?lightning=lnbc1500n1p3hk3sppp5k54t9c4p4u4tdgj0y8tqjp3kzjak8jtr0fwvnl2dpl5pvrm9gxsdqqcqzpgxqyz5vqsp5usxefww9jeqxv4ujmfwqhynz3rgf4x4k8kmjkjy8mkzctxt5vvq9qyyssqy4lgd8nj3vxjmnqyfgxnz3gqhykj8rd9v4xnz970m2cfqsz3vh7qwg0o4jj2mcwhzguktgc8hm8zmnwnp6f5ke4h8dkwrm8fqz2cpgqqqqqqqqlgqqqq",
-                imageAsset: "btc-and-ln")
+                "bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?lightning=lnbc1500n1p3hk3sppp5k54t9c4p4u4tdgj0y8tqjp3kzjak8jtr0fwvnl2dpl5pvrm9gxsdqqcqzpgxqyz5vqsp5usxefww9jeqxv4ujmfwqhynz3rgf4x4k8kmjkjy8mkzctxt5vvq9qyyssqy4lgd8nj3vxjmnqyfgxnz3gqhykj8rd9v4xnz970m2cfqsz3vh7qwg0o4jj2mcwhzguktgc8hm8zmnwnp6f5ke4h8dkwrm8fqz2cpgqqqqqqqqlgqqqq",
+                imageAsset: "btc-and-ln"
+            )
 
             QR(content: "bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", imageAsset: "btc")
 
             QR(
                 content:
-                    "lnbc1500n1p3hk3sppp5k54t9c4p4u4tdgj0y8tqjp3kzjak8jtr0fwvnl2dpl5pvrm9gxsdqqcqzpgxqyz5vqsp5usxefww9jeqxv4ujmfwqhynz3rgf4x4k8kmjkjy8mkzctxt5vvq9qyyssqy4lgd8nj3vxjmnqyfgxnz3gqhykj8rd9v4xnz970m2cfqsz3vh7qwg0o4jj2mcwhzguktgc8hm8zmnwnp6f5ke4h8dkwrm8fqz2cpgqqqqqqqqlgqqqq",
-                imageAsset: "ln")
+                "lnbc1500n1p3hk3sppp5k54t9c4p4u4tdgj0y8tqjp3kzjak8jtr0fwvnl2dpl5pvrm9gxsdqqcqzpgxqyz5vqsp5usxefww9jeqxv4ujmfwqhynz3rgf4x4k8kmjkjy8mkzctxt5vvq9qyyssqy4lgd8nj3vxjmnqyfgxnz3gqhykj8rd9v4xnz970m2cfqsz3vh7qwg0o4jj2mcwhzguktgc8hm8zmnwnp6f5ke4h8dkwrm8fqz2cpgqqqqqqqqlgqqqq",
+                imageAsset: "ln"
+            )
 
             QR(content: "bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq")
         }

--- a/Bitkit/Components/RectangleButton.swift
+++ b/Bitkit/Components/RectangleButton.swift
@@ -26,13 +26,13 @@ struct RectangleButton: View {
 
     private var backgroundColor: Color {
         if isPressed {
-            return .white.opacity(0.16)  // white16
+            return .white.opacity(0.16) // white16
         }
-        return .white.opacity(0.1)  // white10
+        return .white.opacity(0.1) // white10
     }
 
     var body: some View {
-        if let action = action {
+        if let action {
             Button {
                 guard !isLoading, !isDisabled else { return }
 
@@ -76,7 +76,7 @@ struct RectangleButton: View {
 
             Spacer(minLength: 0)
 
-            if let trailingContent = trailingContent {
+            if let trailingContent {
                 trailingContent
             }
         }

--- a/Bitkit/Components/SeedTextField.swift
+++ b/Bitkit/Components/SeedTextField.swift
@@ -48,12 +48,10 @@ struct SeedTextField: View {
                 .onSubmit {
                     focusedField = isLastField ? nil : index + 1
                 }
-
         }
         .frame(minHeight: 46)
         .padding(.horizontal, 16)
         .background(Color.white10)
         .cornerRadius(8)
-
     }
 }

--- a/Bitkit/Components/SegmentedControl.swift
+++ b/Bitkit/Components/SegmentedControl.swift
@@ -17,13 +17,13 @@ struct SegmentedControl<T: Hashable & CustomStringConvertible>: View {
     @Namespace private var underlineNamespace
 
     init(selectedTab: Binding<T>, tabs: [T], activeColor: Color = .brandAccent) {
-        self._selectedTab = selectedTab
-        self.tabItems = tabs.map { TabItem($0) }
-        self.defaultActiveColor = activeColor
+        _selectedTab = selectedTab
+        tabItems = tabs.map { TabItem($0) }
+        defaultActiveColor = activeColor
     }
 
     init(selectedTab: Binding<T>, tabItems: [TabItem<T>], defaultActiveColor: Color = .brandAccent) {
-        self._selectedTab = selectedTab
+        _selectedTab = selectedTab
         self.tabItems = tabItems
         self.defaultActiveColor = defaultActiveColor
     }

--- a/Bitkit/Components/SettingsListLabel.swift
+++ b/Bitkit/Components/SettingsListLabel.swift
@@ -1,10 +1,3 @@
-//
-//  SettingsListLabel.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/08/23.
-//
-
 import SwiftUI
 
 enum SettingsListRightIcon {
@@ -39,7 +32,7 @@ struct SettingsListLabel: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(alignment: .center, spacing: 0) {
-                if let iconName = iconName {
+                if let iconName {
                     Label {
                         BodyMText(title, textColor: .textPrimary)
                     } icon: {
@@ -52,18 +45,18 @@ struct SettingsListLabel: View {
 
                 Spacer()
 
-                if let toggle = toggle {
+                if let toggle {
                     Toggle("", isOn: toggle)
                         .toggleStyle(SwitchToggleStyle(tint: .brandAccent))
                         .labelsHidden()
                         .disabled(disabled ?? false)
                 } else {
-                    if let rightText = rightText {
+                    if let rightText {
                         BodyMText(rightText, textColor: .textPrimary)
                             .padding(.trailing, 5)
                     }
 
-                    if let rightIcon = rightIcon {
+                    if let rightIcon {
                         switch rightIcon {
                         case .chevron:
                             Image("chevron")

--- a/Bitkit/Components/SheetIntro.swift
+++ b/Bitkit/Components/SheetIntro.swift
@@ -70,7 +70,7 @@ struct SheetIntro: View {
 
     @ViewBuilder
     private var buttonStack: some View {
-        if let cancelText = cancelText, let onCancel = onCancel {
+        if let cancelText, let onCancel {
             HStack(alignment: .center, spacing: 16) {
                 CustomButton(
                     title: cancelText,

--- a/Bitkit/Components/SwipeButton.swift
+++ b/Bitkit/Components/SwipeButton.swift
@@ -1,10 +1,3 @@
-//
-//  SwipeButton.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/11/20.
-//
-
 import SwiftUI
 
 struct SwipeButton: View {

--- a/Bitkit/Components/TabBar.swift
+++ b/Bitkit/Components/TabBar.swift
@@ -49,7 +49,8 @@ struct TabBar: View {
                                 BodySSBText(localizedString("wallet__send"))
                             }
                             .foregroundColor(.white)
-                        })
+                        }
+                    )
                     Spacer()
                     Spacer()
                     Spacer()
@@ -66,7 +67,8 @@ struct TabBar: View {
                                 BodySSBText(localizedString("wallet__receive"))
                             }
                             .foregroundColor(.white)
-                        })
+                        }
+                    )
                     Spacer()
                 }
                 .frame(height: 56)

--- a/Bitkit/Components/Tag.swift
+++ b/Bitkit/Components/Tag.swift
@@ -28,7 +28,7 @@ struct Tag: View {
         HStack(spacing: 0) {
             BodySSBText(value).lineLimit(1)
 
-            if let onDelete = onDelete {
+            if let onDelete {
                 Button(action: onDelete) {
                     Image(icon == .close ? "x-mark" : "trash")
                         .resizable()
@@ -50,7 +50,7 @@ struct Tag: View {
     }
 
     var body: some View {
-        if let onPress = onPress {
+        if let onPress {
             Button(action: onPress) {
                 tagContent
             }

--- a/Bitkit/Components/TextField.swift
+++ b/Bitkit/Components/TextField.swift
@@ -10,7 +10,7 @@ struct TextField: View {
         self.placeholder = placeholder
         self.backgroundColor = backgroundColor
         self.font = font
-        self._text = text
+        _text = text
     }
 
     var body: some View {

--- a/Bitkit/Components/ToastView.swift
+++ b/Bitkit/Components/ToastView.swift
@@ -1,10 +1,3 @@
-//
-//  ToastView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/20.
-//
-
 import SwiftUI
 import UIKit
 
@@ -66,7 +59,6 @@ struct ToastView: View {
         case .error: return .redAccent
         }
     }
-
 }
 
 #Preview {

--- a/Bitkit/Components/WalletBalanceView.swift
+++ b/Bitkit/Components/WalletBalanceView.swift
@@ -44,7 +44,7 @@ struct WalletBalanceView: View {
         HStack {
             WalletBalanceView(
                 type: .onchain,
-                sats: 123456
+                sats: 123_456
             )
 
             Divider()
@@ -52,7 +52,7 @@ struct WalletBalanceView: View {
 
             WalletBalanceView(
                 type: .lightning,
-                sats: 123456
+                sats: 123_456
             )
         }
         .environmentObject(
@@ -61,7 +61,8 @@ struct WalletBalanceView: View {
                 vm.primaryDisplay = .bitcoin
                 vm.displayUnit = .modern
                 return vm
-            }())
+            }()
+        )
 
         Spacer()
 
@@ -69,7 +70,7 @@ struct WalletBalanceView: View {
         HStack {
             WalletBalanceView(
                 type: .onchain,
-                sats: 123456
+                sats: 123_456
             )
 
             Divider()
@@ -77,7 +78,7 @@ struct WalletBalanceView: View {
 
             WalletBalanceView(
                 type: .lightning,
-                sats: 123456
+                sats: 123_456
             )
         }
         .environmentObject(
@@ -87,7 +88,8 @@ struct WalletBalanceView: View {
                 vm.selectedCurrency = "USD"
                 vm.displayUnit = .modern
                 return vm
-            }())
+            }()
+        )
 
         Spacer()
 
@@ -95,7 +97,7 @@ struct WalletBalanceView: View {
         HStack {
             WalletBalanceView(
                 type: .onchain,
-                sats: 123456
+                sats: 123_456
             )
 
             Divider()
@@ -103,7 +105,7 @@ struct WalletBalanceView: View {
 
             WalletBalanceView(
                 type: .lightning,
-                sats: 123456
+                sats: 123_456
             )
         }
         .environmentObject(
@@ -113,7 +115,8 @@ struct WalletBalanceView: View {
                 vm.selectedCurrency = "EUR"
                 vm.displayUnit = .modern
                 return vm
-            }())
+            }()
+        )
 
         Spacer()
 
@@ -121,7 +124,7 @@ struct WalletBalanceView: View {
         HStack {
             WalletBalanceView(
                 type: .onchain,
-                sats: 123456
+                sats: 123_456
             )
 
             Divider()
@@ -129,7 +132,7 @@ struct WalletBalanceView: View {
 
             WalletBalanceView(
                 type: .lightning,
-                sats: 123456
+                sats: 123_456
             )
         }
         .environmentObject(
@@ -138,7 +141,8 @@ struct WalletBalanceView: View {
                 vm.primaryDisplay = .bitcoin
                 vm.displayUnit = .classic
                 return vm
-            }())
+            }()
+        )
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding()

--- a/Bitkit/Components/Widgets/BaseWidget.swift
+++ b/Bitkit/Components/Widgets/BaseWidget.swift
@@ -28,8 +28,7 @@ enum WidgetState {
 // MARK: - Widget Content Builder
 
 /// Helper for building common widget content patterns
-struct WidgetContentBuilder {
-
+enum WidgetContentBuilder {
     /// Creates a standard loading view
     static func loadingView() -> some View {
         ProgressView()
@@ -121,8 +120,7 @@ struct BaseWidget<Content: View>: View {
     }
 
     var body: some View {
-        Button {
-        } label: {
+        Button {} label: {
             VStack(spacing: 0) {
                 if settings.showWidgetTitles || isEditing {
                     HStack {

--- a/Bitkit/Components/Widgets/BlocksWidget.swift
+++ b/Bitkit/Components/Widgets/BlocksWidget.swift
@@ -17,7 +17,7 @@ struct BlocksWidgetOptions: Codable, Equatable {
 /// A widget that displays Bitcoin block information
 struct BlocksWidget: View {
     /// Configuration options for the widget
-    var options: BlocksWidgetOptions = BlocksWidgetOptions()
+    var options: BlocksWidgetOptions = .init()
 
     /// Flag indicating if the widget is in editing mode
     var isEditing: Bool = false

--- a/Bitkit/Components/Widgets/CalculatorWidget.swift
+++ b/Bitkit/Components/Widgets/CalculatorWidget.swift
@@ -215,8 +215,8 @@ struct CalculatorWidget: View {
     private func sanitizeFiatInput(_ input: String) -> String {
         let processed =
             input
-            .replacingOccurrences(of: ",", with: ".")
-            .replacingOccurrences(of: " ", with: "")
+                .replacingOccurrences(of: ",", with: ".")
+                .replacingOccurrences(of: " ", with: "")
 
         let components = processed.components(separatedBy: ".")
         if components.count > 2 {
@@ -288,8 +288,8 @@ struct CalculatorWidget: View {
         // Convert comma to dot and remove spaces
         let processed =
             input
-            .replacingOccurrences(of: ",", with: ".")
-            .replacingOccurrences(of: " ", with: "")
+                .replacingOccurrences(of: ",", with: ".")
+                .replacingOccurrences(of: " ", with: "")
 
         // Check if input matches valid pattern: digits, optional dot, up to 2 decimal digits
         let validPattern = "^\\d*\\.?\\d{0,2}$"

--- a/Bitkit/Components/Widgets/FactsWidget.swift
+++ b/Bitkit/Components/Widgets/FactsWidget.swift
@@ -7,11 +7,11 @@ struct FactsWidgetOptions: Codable, Equatable {
 
 struct FactsWidget: View {
     /// Configuration options for the widget
-    var options: FactsWidgetOptions = FactsWidgetOptions()
+    var options: FactsWidgetOptions = .init()
 
     /// Flag indicating if the widget is in editing mode
     var isEditing: Bool = false
-    
+
     /// Callback to signal when editing should end
     var onEditingEnd: (() -> Void)?
 
@@ -39,7 +39,7 @@ struct FactsWidget: View {
         self.options = options
         self.isEditing = isEditing
         self.onEditingEnd = onEditingEnd
-        self._viewModel = StateObject(wrappedValue: viewModel)
+        _viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {

--- a/Bitkit/Components/Widgets/NewsWidget.swift
+++ b/Bitkit/Components/Widgets/NewsWidget.swift
@@ -10,7 +10,7 @@ struct NewsWidgetOptions: Codable, Equatable {
 /// A widget that displays a news article
 struct NewsWidget: View {
     /// Configuration options for the widget
-    var options: NewsWidgetOptions = NewsWidgetOptions()
+    var options: NewsWidgetOptions = .init()
 
     /// Flag indicating if the widget is in editing mode
     var isEditing: Bool = false

--- a/Bitkit/Components/Widgets/PriceWidget.swift
+++ b/Bitkit/Components/Widgets/PriceWidget.swift
@@ -11,7 +11,7 @@ struct PriceWidgetOptions: Codable, Equatable {
 /// A widget that displays cryptocurrency price information with chart
 struct PriceWidget: View {
     /// Configuration options for the widget
-    var options: PriceWidgetOptions = PriceWidgetOptions()
+    var options: PriceWidgetOptions = .init()
 
     /// Flag indicating if the widget is in editing mode
     var isEditing: Bool = false

--- a/Bitkit/Components/Widgets/WeatherWidget.swift
+++ b/Bitkit/Components/Widgets/WeatherWidget.swift
@@ -10,9 +10,9 @@ struct WeatherWidgetOptions: Codable, Equatable {
 
 /// Fee condition enum matching the React Native implementation
 enum FeeCondition: String, Codable {
-    case good = "good"
-    case average = "average"
-    case poor = "poor"
+    case good
+    case average
+    case poor
 
     var title: String {
         switch self {
@@ -58,7 +58,7 @@ struct WeatherData: Codable {
 /// A widget that displays Bitcoin fee weather information
 struct WeatherWidget: View {
     /// Configuration options for the widget
-    var options: WeatherWidgetOptions = WeatherWidgetOptions()
+    var options: WeatherWidgetOptions = .init()
 
     /// Flag indicating if the widget is in editing mode
     var isEditing: Bool = false

--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -1,10 +1,3 @@
-//
-//  Env.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/01.
-//
-
 import BitkitCore
 import Foundation
 import LDKNode
@@ -23,7 +16,7 @@ enum Env {
     }
 
     // {Team ID}.{Keychain Group}
-    static let keychainGroup = "KYH47R284B.to.bitkit" //TODO: needs to change for regtest/mainnet so we don't use same group
+    static let keychainGroup = "KYH47R284B.to.bitkit" // TODO: needs to change for regtest/mainnet so we don't use same group
 
     #if targetEnvironment(simulator)
         static let isSim = true
@@ -107,13 +100,13 @@ enum Env {
         case .regtest:
             return
                 appStorageUrl
-                .appendingPathComponent("regtest")
-                .appendingPathComponent("wallet\(walletIndex)/ldk")
+                    .appendingPathComponent("regtest")
+                    .appendingPathComponent("wallet\(walletIndex)/ldk")
         case .bitcoin:
             return
                 appStorageUrl
-                .appendingPathComponent("bitcoin")
-                .appendingPathComponent("wallet\(walletIndex)/electrs")
+                    .appendingPathComponent("bitcoin")
+                    .appendingPathComponent("wallet\(walletIndex)/electrs")
         case .testnet:
             fatalError("Testnet network not implemented")
         case .signet:
@@ -126,13 +119,13 @@ enum Env {
         case .regtest:
             return
                 appStorageUrl
-                .appendingPathComponent("regtest")
-                .appendingPathComponent("wallet\(walletIndex)/core")
+                    .appendingPathComponent("regtest")
+                    .appendingPathComponent("wallet\(walletIndex)/core")
         case .bitcoin:
             return
                 appStorageUrl
-                .appendingPathComponent("bitcoin")
-                .appendingPathComponent("wallet\(walletIndex)/core")
+                    .appendingPathComponent("bitcoin")
+                    .appendingPathComponent("wallet\(walletIndex)/core")
         case .testnet:
             fatalError("Testnet network not implemented")
         case .signet:
@@ -159,7 +152,7 @@ enum Env {
         case .regtest:
             return [
                 // Staging Blocktank node
-                .init(nodeId: "028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc", host: "34.65.86.104", port: 9400)
+                .init(nodeId: "028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc", host: "34.65.86.104", port: 9400),
             ]
         case .bitcoin:
             return []

--- a/Bitkit/Extensions/ChannelDetails+Mock.swift
+++ b/Bitkit/Extensions/ChannelDetails+Mock.swift
@@ -6,7 +6,7 @@ extension ChannelDetails {
         isChannelReady: Bool = true,
         isUsable: Bool = true,
         isAnnounced: Bool = false,
-        channelValueSats: UInt64 = 100000,
+        channelValueSats: UInt64 = 100_000,
         outboundCapacityMsat: UInt64 = 50_000_000, // 50,000 sats in msat
         inboundCapacityMsat: UInt64 = 50_000_000, // 50,000 sats in msat
         shortChannelId: UInt64? = 123_456_789
@@ -45,7 +45,14 @@ extension ChannelDetails {
             forceCloseSpendDelay: nil,
             inboundHtlcMinimumMsat: 1000,
             inboundHtlcMaximumMsat: inboundCapacityMsat > 0 ? inboundCapacityMsat : nil,
-            config: .init(forwardingFeeProportionalMillionths: 0, forwardingFeeBaseMsat: 0, cltvExpiryDelta: 0, maxDustHtlcExposure: .feeRateMultiplier(multiplier: 0), forceCloseAvoidanceMaxFeeSatoshis: 0, acceptUnderpayingHtlcs: true)
+            config: .init(
+                forwardingFeeProportionalMillionths: 0,
+                forwardingFeeBaseMsat: 0,
+                cltvExpiryDelta: 0,
+                maxDustHtlcExposure: .feeRateMultiplier(multiplier: 0),
+                forceCloseAvoidanceMaxFeeSatoshis: 0,
+                acceptUnderpayingHtlcs: true
+            )
         )
     }
 }

--- a/Bitkit/Extensions/FeeRates.swift
+++ b/Bitkit/Extensions/FeeRates.swift
@@ -1,24 +1,17 @@
-// //
-// //  BitkitFeeRate.swift
-// //  Bitkit
-// //
-// //  Created by Jason van den Berg on 2025/05/01.
-// //
-
-import Foundation
 import BitkitCore
+import Foundation
 
 // // Extension to provide LDK-node compatible fee rates
-extension FeeRates {
-    public func getSatsPerVbyte(for speed: TransactionSpeed) -> UInt32 {
+public extension FeeRates {
+    func getSatsPerVbyte(for speed: TransactionSpeed) -> UInt32 {
         switch speed {
         case .fast:
-            return self.fast
+            return fast
         case .medium:
-            return self.mid
+            return mid
         case .slow:
-            return self.slow
-        case .custom(let customRate):
+            return slow
+        case let .custom(customRate):
             return customRate
         }
     }

--- a/Bitkit/Extensions/HexBytes.swift
+++ b/Bitkit/Extensions/HexBytes.swift
@@ -1,10 +1,3 @@
-//
-//  String.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/24.
-//
-
 import Foundation
 
 extension Data {

--- a/Bitkit/Extensions/IBtChannel+Mock.swift
+++ b/Bitkit/Extensions/IBtChannel+Mock.swift
@@ -1,5 +1,5 @@
-import Foundation
 import BitkitCore
+import Foundation
 
 extension IBtChannel {
     static func mock(state: BtOpenChannelState = .opening) -> IBtChannel {

--- a/Bitkit/Extensions/IcJitEntry+Mock.swift
+++ b/Bitkit/Extensions/IcJitEntry+Mock.swift
@@ -1,10 +1,10 @@
-import Foundation
 import BitkitCore
+import Foundation
 
 extension IcJitEntry {
     static func mock(
         state: CJitStateEnum = .created,
-        channelSizeSat: UInt64 = 100000,
+        channelSizeSat: UInt64 = 100_000,
         feeSat: UInt64 = 1000,
         channelExpiryWeeks: UInt32 = 6,
         channel: IBtChannel? = nil
@@ -40,4 +40,4 @@ extension IcJitEntry {
             createdAt: "2024-10-21T12:00:00Z"
         )
     }
-} 
+}

--- a/Bitkit/Extensions/NodeStatus.swift
+++ b/Bitkit/Extensions/NodeStatus.swift
@@ -1,10 +1,3 @@
-//
-//  NodeStatus.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/04.
-//
-
 import Foundation
 import LDKNode
 import SwiftUI
@@ -12,9 +5,9 @@ import SwiftUI
 extension NodeStatus {
     var debugState: String {
         var debug = """
-            Running: \(isRunning ? "✅" : "❌")
-            Current best block \(currentBestBlock.height)
-            """
+        Running: \(isRunning ? "✅" : "❌")
+        Current best block \(currentBestBlock.height)
+        """
 
         if let latestLightningWalletSyncTimestamp {
             debug += "\nLightning synced \(Date(timeIntervalSince1970: TimeInterval(latestLightningWalletSyncTimestamp)).description)\n"
@@ -43,7 +36,7 @@ extension NodeLifecycleState {
             return "warning"
         }
     }
-    
+
     var statusColor: Color {
         switch self {
         case .running:

--- a/Bitkit/Extensions/PaymentDetails.swift
+++ b/Bitkit/Extensions/PaymentDetails.swift
@@ -1,10 +1,3 @@
-//
-//  PaymentDetails.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/04.
-//
-
 import Foundation
 import LDKNode
 

--- a/Bitkit/Extensions/UIScreen.swift
+++ b/Bitkit/Extensions/UIScreen.swift
@@ -1,10 +1,3 @@
-//
-//  UIScreen.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/08/23.
-//
-
 import UIKit
 
 extension UIScreen {

--- a/Bitkit/Extensions/View+SafeArea.swift
+++ b/Bitkit/Extensions/View+SafeArea.swift
@@ -5,7 +5,7 @@ import UIKit
 struct BottomSafeAreaPadding: ViewModifier {
     var hasHomeIndicator: Bool {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-            let window = windowScene.windows.first
+              let window = windowScene.windows.first
         else {
             return false
         }

--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -217,9 +217,9 @@ struct MainNavView: View {
             switch screenValue {
             case .activityList:
                 AllActivityView()
-            case .activityDetail(let activity):
+            case let .activityDetail(activity):
                 ActivityItemView(item: activity)
-            case .activityExplorer(let activity):
+            case let .activityExplorer(activity):
                 ActivityExplorerView(item: activity)
             case .buyBitcoin:
                 BuyBitcoinView()
@@ -243,19 +243,19 @@ struct MainNavView: View {
                 SpendingAmount()
             case .spendingConfirm:
                 SpendingConfirm()
-            case .spendingAdvanced(let order):
+            case let .spendingAdvanced(order):
                 SpendingAdvancedView(order: order)
-            case .transferLearnMore(let order):
+            case let .transferLearnMore(order):
                 TransferLearnMoreView(order: order)
             case .settingUp:
                 SettingUpView()
             case .fundingAdvanced:
                 FundAdvancedOptions()
-            case .fundManual(let nodeUri):
+            case let .fundManual(nodeUri):
                 FundManualSetupView(initialNodeUri: nodeUri)
             case .fundManualSuccess:
                 FundManualSuccessView()
-            case .lnurlChannel(let channelData):
+            case let .lnurlChannel(channelData):
                 LnurlChannel(channelData: channelData)
             case .savingsIntro:
                 SavingsIntroView()
@@ -279,7 +279,7 @@ struct MainNavView: View {
                 ShopIntro()
             case .shopDiscover:
                 ShopDiscover()
-            case .shopMain(let page):
+            case let .shopMain(page):
                 ShopMain(page: page)
 
             // Widgets
@@ -287,9 +287,9 @@ struct MainNavView: View {
                 WidgetsIntroView()
             case .widgetsList:
                 WidgetsListView()
-            case .widgetDetail(let widgetType):
+            case let .widgetDetail(widgetType):
                 WidgetDetailView(id: widgetType)
-            case .widgetEdit(let widgetType):
+            case let .widgetEdit(widgetType):
                 WidgetEditView(id: widgetType)
 
             // Settings
@@ -426,6 +426,6 @@ struct BackToWalletToolbar: ViewModifier {
 
 extension View {
     func backToWalletButton() -> some View {
-        self.modifier(BackToWalletToolbar())
+        modifier(BackToWalletToolbar())
     }
 }

--- a/Bitkit/Managers/LanguageManager.swift
+++ b/Bitkit/Managers/LanguageManager.swift
@@ -11,15 +11,15 @@ final class LanguageManager: ObservableObject {
 
     private init() {
         // Initialize stored properties first
-        self.currentLanguage = .english
+        currentLanguage = .english
 
         // Then set the actual current language
         let deviceLanguageCode = Locale.current.language.languageCode?.identifier ?? "en"
 
         if selectedLanguageCode.isEmpty {
-            self.currentLanguage = SupportedLanguage.language(for: deviceLanguageCode)
+            currentLanguage = SupportedLanguage.language(for: deviceLanguageCode)
         } else {
-            self.currentLanguage = SupportedLanguage.language(for: selectedLanguageCode)
+            currentLanguage = SupportedLanguage.language(for: selectedLanguageCode)
         }
     }
 

--- a/Bitkit/Managers/TimedSheets/HighBalanceTimedSheet.swift
+++ b/Bitkit/Managers/TimedSheets/HighBalanceTimedSheet.swift
@@ -33,12 +33,11 @@ struct HighBalanceTimedSheet: TimedSheetItem {
         let totalBalance = UInt64(walletViewModel.totalBalanceSats)
 
         // Check if threshold is reached
-        let thresholdReached: Bool
-        if let usdConversion = currencyViewModel.convert(sats: totalBalance, to: "USD") {
-            thresholdReached = Double(truncating: usdConversion.value as NSDecimalNumber) > Self.BALANCE_THRESHOLD_USD
+        let thresholdReached: Bool = if let usdConversion = currencyViewModel.convert(sats: totalBalance, to: "USD") {
+            Double(truncating: usdConversion.value as NSDecimalNumber) > Self.BALANCE_THRESHOLD_USD
         } else {
             // Fallback to sats if exchange rates not available
-            thresholdReached = totalBalance > Self.BALANCE_THRESHOLD_SATS
+            totalBalance > Self.BALANCE_THRESHOLD_SATS
         }
 
         return isTimeoutOver && thresholdReached && belowMaxWarnings

--- a/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
+++ b/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
@@ -149,7 +149,7 @@ class TimedSheetManager: ObservableObject {
 
     /// Check the queue and show the highest priority sheet that should be shown
     private func checkAndShowNextSheet() async {
-        guard let sheetViewModel = sheetViewModel else {
+        guard let sheetViewModel else {
             Logger.error("SheetViewModel not configured for TimedSheetManager")
             return
         }

--- a/Bitkit/Managers/ToastWindowManager.swift
+++ b/Bitkit/Managers/ToastWindowManager.swift
@@ -58,8 +58,8 @@ class ToastWindowManager: ObservableObject {
 
         window.rootViewController = hostingController
 
-        self.toastWindow = window
-        self.toastHostingController = hostingController
+        toastWindow = window
+        toastHostingController = hostingController
     }
 }
 

--- a/Bitkit/Models/BlocktankNotificationType.swift
+++ b/Bitkit/Models/BlocktankNotificationType.swift
@@ -1,10 +1,3 @@
-//
-//  BlocktankNotificationType.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/16.
-//
-
 import Foundation
 
 enum BlocktankNotificationType: String {
@@ -15,6 +8,6 @@ enum BlocktankNotificationType: String {
     case wakeToTimeout
 
     var feature: String {
-        return "blocktank.\(self.rawValue)"
+        return "blocktank.\(rawValue)"
     }
 }

--- a/Bitkit/Models/LnPeer.swift
+++ b/Bitkit/Models/LnPeer.swift
@@ -1,10 +1,3 @@
-//
-//  LnPeer.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/01.
-//
-
 import Foundation
 
 enum LnPeerError: Error {
@@ -27,7 +20,7 @@ struct LnPeer {
     let nodeId: String
     let host: String
     let port: UInt16
-    
+
     var address: String {
         return "\(host):\(port)"
     }
@@ -45,12 +38,12 @@ struct LnPeer {
         }
 
         nodeId = String(parts[0])
-        
+
         let addressParts = parts[1].split(separator: ":")
         guard addressParts.count == 2, let port = UInt16(addressParts[1]) else {
             throw LnPeerError.invalidAddressFormat
         }
-        
+
         host = String(addressParts[0])
         self.port = port
     }

--- a/Bitkit/Models/NodeLifecycleState.swift
+++ b/Bitkit/Models/NodeLifecycleState.swift
@@ -1,10 +1,3 @@
-//
-//  NodeLifecycleState.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/04.
-//
-
 import LDKNode
 
 enum NodeLifecycleState: Equatable {
@@ -25,7 +18,7 @@ enum NodeLifecycleState: Equatable {
             return "Running"
         case .stopping:
             return "Stopping"
-        case .errorStarting(let cause):
+        case let .errorStarting(cause):
             return "Error starting: \(cause.localizedDescription)"
         case .initializing:
             return "Setting up wallet..."
@@ -52,12 +45,12 @@ enum NodeLifecycleState: Equatable {
     static func == (lhs: NodeLifecycleState, rhs: NodeLifecycleState) -> Bool {
         switch (lhs, rhs) {
         case (.stopped, .stopped),
-            (.starting, .starting),
-            (.running, .running),
-            (.stopping, .stopping),
-            (.initializing, .initializing):
+             (.starting, .starting),
+             (.running, .running),
+             (.stopping, .stopping),
+             (.initializing, .initializing):
             return true
-        case (.errorStarting(let lhsCause), .errorStarting(let rhsCause)):
+        case let (.errorStarting(lhsCause), .errorStarting(rhsCause)):
             return lhsCause.localizedDescription == rhsCause.localizedDescription
         default:
             return false

--- a/Bitkit/Models/ReceivedTxSheetDetails.swift
+++ b/Bitkit/Models/ReceivedTxSheetDetails.swift
@@ -1,10 +1,3 @@
-//
-//  ReceivedTxSheetDetails.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/18.
-//
-
 import Foundation
 
 struct ReceivedTxSheetDetails: Codable {

--- a/Bitkit/Models/Toast.swift
+++ b/Bitkit/Models/Toast.swift
@@ -1,10 +1,3 @@
-//
-//  Toast.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/10.
-//
-
 import Foundation
 
 struct Toast: Equatable {

--- a/Bitkit/Models/TransactionSpeed.swift
+++ b/Bitkit/Models/TransactionSpeed.swift
@@ -14,8 +14,8 @@ public enum TransactionSpeed: Equatable, RawRepresentable {
         } else if rawValue == "slow" {
             self = .slow
         } else if rawValue.starts(with: "custom_"),
-            let rateStr = rawValue.split(separator: "_").last,
-            let rate = UInt32(rateStr)
+                  let rateStr = rawValue.split(separator: "_").last,
+                  let rate = UInt32(rateStr)
         {
             self = .custom(satsPerVByte: rate)
         } else {
@@ -31,14 +31,14 @@ public enum TransactionSpeed: Equatable, RawRepresentable {
             return "medium"
         case .slow:
             return "slow"
-        case .custom(let satsPerVByte):
+        case let .custom(satsPerVByte):
             return "custom_\(satsPerVByte)"
         }
     }
 
     public var customSetSpeed: String? {
         switch self {
-        case .custom(let satsPerVByte):
+        case let .custom(satsPerVByte):
             return "\(satsPerVByte) \(NSLocalizedString("common__sat_vbyte_compact", comment: ""))"
         default:
             return nil
@@ -53,7 +53,7 @@ public enum TransactionSpeed: Equatable, RawRepresentable {
             return NSLocalizedString("fee__normal__title", comment: "")
         case .slow:
             return NSLocalizedString("fee__slow__title", comment: "")
-        case .custom(_):
+        case .custom:
             return NSLocalizedString("fee__custom__title", comment: "")
         }
     }
@@ -114,7 +114,7 @@ public enum TransactionSpeed: Equatable, RawRepresentable {
         switch (lhs, rhs) {
         case (.fast, .fast), (.medium, .medium), (.slow, .slow):
             return true
-        case (.custom(let lhsRate), .custom(let rhsRate)):
+        case let (.custom(lhsRate), .custom(rhsRate)):
             return lhsRate == rhsRate
         default:
             return false

--- a/Bitkit/Models/WalletType.swift
+++ b/Bitkit/Models/WalletType.swift
@@ -1,10 +1,3 @@
-//
-//  WalletType.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2025/04/04.
-//
-
 import Foundation
 
 enum WalletType {
@@ -28,4 +21,4 @@ enum WalletType {
             return "ln"
         }
     }
-} 
+}

--- a/Bitkit/Services/AppUpdateService.swift
+++ b/Bitkit/Services/AppUpdateService.swift
@@ -63,7 +63,7 @@ class AppUpdateService: ObservableObject {
     /// Get the current app build number
     private func getCurrentBuildNumber() -> Int {
         guard let buildString = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
-            let buildNumber = Int(buildString)
+              let buildNumber = Int(buildString)
         else {
             Logger.error("Could not get current build number", context: "AppUpdateService")
             return 0

--- a/Bitkit/Services/CurrencyService.swift
+++ b/Bitkit/Services/CurrencyService.swift
@@ -43,7 +43,7 @@ class CurrencyService {
 
     func loadCachedRates() -> [FxRate]? {
         guard let data = cache.data(forKey: cacheKey),
-            let rates = try? JSONDecoder().decode([FxRate].self, from: data)
+              let rates = try? JSONDecoder().decode([FxRate].self, from: data)
         else {
             return nil
         }
@@ -99,7 +99,7 @@ extension CurrencyService {
     }
 
     func getAvailableCurrencies(from rates: [FxRate]) -> [String] {
-        rates.map { $0.quote }
+        rates.map(\.quote)
     }
 
     func getCurrentRate(for currency: String, from rates: [FxRate]) -> FxRate? {

--- a/Bitkit/Services/MigrationsService.swift
+++ b/Bitkit/Services/MigrationsService.swift
@@ -1,12 +1,5 @@
-//
-//  MigrationsService.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/23.
-//
-
 import Foundation
-import LightningDevKit  // TODO: remove this when we no longer need it to read funding_tx and index from monitors
+import LightningDevKit // TODO: remove this when we no longer need it to read funding_tx and index from monitors
 import SQLite
 
 typealias Expression = SQLite.Expression
@@ -55,7 +48,8 @@ extension MigrationsService {
                 t.column(snCol)
                 t.column(keyCol)
                 t.column(valueCol)
-            })
+            }
+        )
 
         // TODO: use create statement directly from LDK-node instead
         // CREATE TABLE IF NOT EXISTS {} (
@@ -81,10 +75,9 @@ extension MigrationsService {
             // MARK: get funding_tx and index using plain LDK
 
             // https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#definition-of-channel_id
-            guard
-                let channelMonitor = Bindings.readThirtyTwoBytesChannelMonitor(
-                    ser: [UInt8](monitor), argA: keysManager.asEntropySource(), argB: keysManager.asSignerProvider()
-                ).getValue()?.1
+            guard let channelMonitor = Bindings.readThirtyTwoBytesChannelMonitor(
+                ser: [UInt8](monitor), argA: keysManager.asEntropySource(), argB: keysManager.asSignerProvider()
+            ).getValue()?.1
             else {
                 Logger.error("Could not read channel monitor using readThirtyTwoBytesChannelMonitor")
                 throw AppError(serviceError: .ldkToLdkNodeMigration)

--- a/Bitkit/Services/NotificationService.swift
+++ b/Bitkit/Services/NotificationService.swift
@@ -21,7 +21,7 @@ class NotificationService: ObservableObject {
                 Logger.debug("Push notification permission granted, requesting device token")
                 // Request a fresh token - it will be automatically registered when received
                 self.requestDeviceToken()
-            } else if let error = error {
+            } else if let error {
                 Logger.error("Push notification permission denied: \(error)")
             } else {
                 Logger.debug("Push notification permission denied by user")
@@ -55,7 +55,7 @@ class NotificationService: ObservableObject {
         let result = try await CoreService.shared.blocktank.registerDeviceForNotifications(
             deviceToken: deviceToken,
             publicKey: keypair.publicKey.hex,
-            features: Env.pushNotificationFeatures.map { $0.feature },
+            features: Env.pushNotificationFeatures.map(\.feature),
             nodeId: nodeId,
             isoTimestamp: isoTimestamp,
             signature: signature

--- a/Bitkit/Services/ServiceQueue.swift
+++ b/Bitkit/Services/ServiceQueue.swift
@@ -1,10 +1,3 @@
-//
-//  ServiceQueue.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/04.
-//
-
 import Foundation
 
 /// Handles app services each on it's own dedicated queue
@@ -69,7 +62,9 @@ class ServiceQueue {
     ///   - execute: The function
     ///   - functionName: The name of the function for logging
     /// - Returns: The result of the async function
-    static func background<T>(_ service: ServiceTypes, _ execute: @escaping () async throws -> T, functionName: String = #function) async throws -> T {
+    static func background<T>(_ service: ServiceTypes, _ execute: @escaping () async throws -> T,
+                              functionName: String = #function) async throws -> T
+    {
         let startTime = CFAbsoluteTimeGetCurrent()
 
         return try await withCheckedThrowingContinuation { continuation in

--- a/Bitkit/Services/Widgets/NewsService.swift
+++ b/Bitkit/Services/Widgets/NewsService.swift
@@ -117,8 +117,8 @@ class NewsService {
         // Get a random article from the last 10
         let recentArticles =
             articles
-            .sorted { $0.published > $1.published }
-            .prefix(10)
+                .sorted { $0.published > $1.published }
+                .prefix(10)
 
         guard let article = recentArticles.randomElement() else {
             Logger.error("No articles available after filtering")

--- a/Bitkit/Services/Widgets/PriceService.swift
+++ b/Bitkit/Services/Widgets/PriceService.swift
@@ -59,7 +59,7 @@ public let tradingPairs: [TradingPair] = [
 ]
 
 // Convenience array for just the pair names
-public let tradingPairNames: [String] = tradingPairs.map { $0.name }
+public let tradingPairNames: [String] = tradingPairs.map(\.name)
 
 // MARK: - Helper Models
 
@@ -81,7 +81,7 @@ class PriceWidgetCache {
 
     private init() {}
 
-    func set<T: Codable>(_ value: T, forKey key: String) {
+    func set(_ value: some Codable, forKey key: String) {
         do {
             let data = try encoder.encode(value)
             userDefaults.set(data, forKey: "price_widget_cache_\(key)")
@@ -189,7 +189,7 @@ class PriceService {
         // Fetch historical data
         let candles = try await fetchCandles(ticker: ticker, period: period)
         let sortedCandles = candles.sorted { $0.timestamp < $1.timestamp }
-        let pastValues = sortedCandles.map { $0.close }
+        let pastValues = sortedCandles.map(\.close)
 
         // Fetch latest price
         let latestPrice = try await fetchLatestPrice(ticker: ticker)

--- a/Bitkit/Services/Widgets/WeatherService.swift
+++ b/Bitkit/Services/Widgets/WeatherService.swift
@@ -27,7 +27,7 @@ class WeatherService {
     private let coreService: CoreService
 
     private init() {
-        self.coreService = CoreService.shared
+        coreService = CoreService.shared
     }
 
     /// Fetches weather data from mempool.space API and fee estimates
@@ -101,7 +101,7 @@ class WeatherService {
         let (data, response) = try await URLSession.shared.data(from: url)
 
         guard let httpResponse = response as? HTTPURLResponse,
-            httpResponse.statusCode == 200
+              httpResponse.statusCode == 200
         else {
             throw URLError(.badServerResponse)
         }
@@ -115,11 +115,12 @@ class WeatherService {
             throw URLError(
                 .resourceUnavailable,
                 userInfo: [
-                    NSLocalizedDescriptionKey: "Historical fee data is unavailable"
-                ])
+                    NSLocalizedDescriptionKey: "Historical fee data is unavailable",
+                ]
+            )
         }
 
-        let historical = history.map { $0.avgFee_50 }
+        let historical = history.map(\.avgFee_50)
         let sorted = historical.sorted()
 
         let lowThreshold = sorted[Int(Double(sorted.count) * percentileLow)]

--- a/Bitkit/Styles/Colors.swift
+++ b/Bitkit/Styles/Colors.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 extension Color {
     // MARK: - Accents
+
     static let brandAccent = Color(hex: 0xFF4400)
     static let blueAccent = Color(hex: 0x0085FF)
     static let greenAccent = Color(hex: 0x75BF72)
@@ -10,16 +11,19 @@ extension Color {
     static let yellowAccent = Color(hex: 0xFFD200)
 
     // MARK: - Base
+
     static let customBlack = Color.black
     static let customWhite = Color.white
 
     // MARK: - Gray Base
+
     static let gray6 = Color(hex: 0x101010)
     static let gray5 = Color(hex: 0x1C1C1D)
     static let gray3 = Color(hex: 0x48484A)
     static let gray2 = Color(hex: 0x636366)
 
     // MARK: - Alpha Colors
+
     static let black50 = Color.black.opacity(0.5)
     static let black92 = Color.black.opacity(0.92)
     static let white06 = Color.white.opacity(0.06)
@@ -53,6 +57,7 @@ extension Color {
 }
 
 // MARK: - Text Colors
+
 extension Color {
     static let textPrimary = Color(
         uiColor: UIColor { traitCollection in
@@ -62,7 +67,8 @@ extension Color {
             default:
                 return UIColor(Color.black92)
             }
-        })
+        }
+    )
 
     static let textSecondary = Color(
         uiColor: UIColor { traitCollection in
@@ -72,10 +78,12 @@ extension Color {
             default:
                 return UIColor(Color.black50)
             }
-        })
+        }
+    )
 }
 
 // MARK: - Hex Initializer
+
 extension Color {
     init(hex: UInt, alpha: Double = 1) {
         self.init(

--- a/Bitkit/Styles/SheetStyles.swift
+++ b/Bitkit/Styles/SheetStyles.swift
@@ -3,14 +3,13 @@ import SwiftUI
 extension View {
     /// Applies a standard dark gradient background for sheet views
     func sheetBackground() -> some View {
-        self
-            .background(
-                LinearGradient(
-                    gradient: Gradient(colors: [Color.white.opacity(0.08), Color.white.opacity(0.012)]),
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
+        background(
+            LinearGradient(
+                gradient: Gradient(colors: [Color.white.opacity(0.08), Color.white.opacity(0.012)]),
+                startPoint: .top,
+                endPoint: .bottom
             )
-            .background(Color.black)
+        )
+        .background(Color.black)
     }
 }

--- a/Bitkit/Styles/StyleGuideView.swift
+++ b/Bitkit/Styles/StyleGuideView.swift
@@ -45,7 +45,8 @@ struct StyleGuideView: View {
                     "Click here to visit <accent>Google</accent> website", accentColor: .brandAccent,
                     accentAction: {
                         UIApplication.shared.open(URL(string: "https://www.google.com")!)
-                    })
+                    }
+                )
 
                 Divider()
 
@@ -73,14 +74,16 @@ struct StyleGuideView: View {
                         ("Purple Accent", Color.purpleAccent),
                         ("Red Accent", Color.redAccent),
                         ("Yellow Accent", Color.yellowAccent),
-                    ])
+                    ]
+                )
 
                 colorGroup(
                     title: "Text Colors",
                     colors: [
                         ("Text Primary", Color.textPrimary),
                         ("Text Secondary", Color.textSecondary),
-                    ])
+                    ]
+                )
 
                 colorGroup(
                     title: "Gray Scale",
@@ -89,7 +92,8 @@ struct StyleGuideView: View {
                         ("Gray 5", Color.gray5),
                         ("Gray 3", Color.gray3),
                         ("Gray 2", Color.gray2),
-                    ])
+                    ]
+                )
             }
         }
     }

--- a/Bitkit/Styles/TextStyle.swift
+++ b/Bitkit/Styles/TextStyle.swift
@@ -523,7 +523,8 @@ struct AccentedText: View {
         } else {
             // Use a flexible layout that allows tap gestures
             FlexibleTextView(
-                parts: parts, font: font, fontColor: fontColor, accentColor: accentColor, accentFont: accentFont, accentAction: accentAction)
+                parts: parts, font: font, fontColor: fontColor, accentColor: accentColor, accentFont: accentFont, accentAction: accentAction
+            )
         }
     }
 
@@ -586,7 +587,8 @@ private struct FlexibleTextView: View {
                         return .handled
                     }
                     return .systemAction
-                })
+                }
+            )
     }
 
     private func createAttributedString() -> AttributedString {

--- a/Bitkit/Utilities/AddressChecker.swift
+++ b/Bitkit/Utilities/AddressChecker.swift
@@ -1,8 +1,3 @@
-//
-//  AddressChecker.swift
-//  Bitkit
-//
-
 import Foundation
 
 struct AddressStats: Codable {
@@ -34,15 +29,16 @@ class AddressChecker {
         guard let url = URL(string: "\(Env.esploraServerUrl)/address/\(address)") else {
             throw AddressCheckerError.invalidUrl
         }
-        
+
         do {
             let (data, response) = try await URLSession.shared.data(from: url)
-            
+
             guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
+                  httpResponse.statusCode == 200
+            else {
                 throw AddressCheckerError.invalidResponse
             }
-            
+
             let decoder = JSONDecoder()
             return try decoder.decode(AddressInfo.self, from: data)
         } catch let error as DecodingError {

--- a/Bitkit/Utilities/BIP39.swift
+++ b/Bitkit/Utilities/BIP39.swift
@@ -1,11 +1,9 @@
-// Adapted from https://github.com/pengpengliu/BIP39
-
 // TODO: move to bitkit-core
 
 import CryptoKit
 import Foundation
 
-public struct BIP39 {
+public enum BIP39 {
     public static let wordlist = [
         "abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd", "abuse", "access", "accident", "account", "accuse",
         "achieve", "acid", "acoustic", "acquire", "across", "act", "action", "actor", "actress", "actual", "adapt", "add", "addict", "address",
@@ -196,7 +194,7 @@ public struct BIP39 {
 
     // Mnemonic -> Entropy
     private static func toEntropy(_ phrase: [String]) throws -> [UInt8] {
-        let bits = phrase.map { (word) -> String in
+        let bits = phrase.map { word -> String in
             let index = wordlist.firstIndex(of: word)!
             var str = String(index, radix: 2)
             while str.count < 11 {

--- a/Bitkit/Utilities/BlockExplorerHelper.swift
+++ b/Bitkit/Utilities/BlockExplorerHelper.swift
@@ -1,26 +1,18 @@
-//
-//  BlockExplorerHelper.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2025/06/27.
-//
-
 import Foundation
 import LDKNode
 import UIKit
 
 enum BlockExplorerService: String, CaseIterable {
-    case blockstream = "blockstream"
-    case mempool = "mempool"
+    case blockstream
+    case mempool
 }
 
 enum BlockExplorerType: String {
-    case tx = "tx"
-    case address = "address"
+    case tx
+    case address
 }
 
-struct BlockExplorerHelper {
-
+enum BlockExplorerHelper {
     /// Generates a block explorer URL for the given ID and type
     /// - Parameters:
     ///   - id: The transaction ID or address to look up
@@ -34,7 +26,6 @@ struct BlockExplorerHelper {
         network: LDKNode.Network = Env.network,
         service: BlockExplorerService = .mempool
     ) -> String {
-
         let isTestnet = network != .bitcoin
 
         switch service {

--- a/Bitkit/Utilities/Crypto.swift
+++ b/Bitkit/Utilities/Crypto.swift
@@ -1,10 +1,3 @@
-//
-//  Crypto.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/13.
-//
-
 import CryptoKit
 import Foundation
 import secp256k1

--- a/Bitkit/Utilities/CurrencyFormatter.swift
+++ b/Bitkit/Utilities/CurrencyFormatter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct CurrencyFormatter {
+enum CurrencyFormatter {
     static func format(_ amount: Decimal, currency: String) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency

--- a/Bitkit/Utilities/DateFormatterHelpers.swift
+++ b/Bitkit/Utilities/DateFormatterHelpers.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 /// Utility class for creating properly internationalized date formatters
-struct DateFormatterHelpers {
-
+enum DateFormatterHelpers {
     /// Creates a date formatter with proper locale settings
     /// - Parameters:
     ///   - dateStyle: The date style to use
@@ -108,7 +107,7 @@ struct DateFormatterHelpers {
     static func getActivityGroupHeader(for date: Date) -> String {
         let calendar = Calendar.current
         let now = Date()
-        
+
         // Check if it's today
         if calendar.isDateInToday(date) {
             // Use DateFormatter with relative formatting to get "Today"
@@ -119,7 +118,7 @@ struct DateFormatterHelpers {
             formatter.timeStyle = .none
             return formatter.string(from: date)
         }
-        
+
         // Check if it's yesterday
         if calendar.isDateInYesterday(date) {
             let formatter = DateFormatter()
@@ -129,12 +128,12 @@ struct DateFormatterHelpers {
             formatter.timeStyle = .none
             return formatter.string(from: date)
         }
-        
+
         // For this week, this month, this year, and earlier - use custom logic
         let beginningOfWeek = calendar.dateInterval(of: .weekOfYear, for: now)?.start ?? now
         let beginningOfMonth = calendar.dateInterval(of: .month, for: now)?.start ?? now
         let beginningOfYear = calendar.dateInterval(of: .year, for: now)?.start ?? now
-        
+
         if date >= beginningOfWeek {
             // This week - return localized "This week"
             return localizedString("wallet__activity_group_week", comment: "Activity group header for current week")
@@ -159,7 +158,6 @@ struct DateFormatterHelpers {
 
 /// Extension to provide common date formatting patterns
 extension DateFormatter {
-
     /// Convenience initializer for internationalized date formatter
     /// - Parameters:
     ///   - dateStyle: Date style

--- a/Bitkit/Utilities/Errors.swift
+++ b/Bitkit/Utilities/Errors.swift
@@ -1,10 +1,3 @@
-//
-//  Errors.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/04.
-//
-
 import Foundation
 import LDKNode
 
@@ -129,46 +122,46 @@ struct AppError: LocalizedError {
 
     private init(ldkBuildError: BuildError) {
         switch ldkBuildError as BuildError {
-        case .InvalidChannelMonitor(message: let ldkMessage):
+        case let .InvalidChannelMonitor(message: ldkMessage):
             message = "Invalid channel monitor"
             debugMessage = ldkMessage
-        case .InvalidSeedBytes(message: let ldkMessage):
+        case let .InvalidSeedBytes(message: ldkMessage):
             message = "Invalid seed bytes"
             debugMessage = ldkMessage
-        case .InvalidSeedFile(message: let ldkMessage):
+        case let .InvalidSeedFile(message: ldkMessage):
             message = "Invalid seed file"
             debugMessage = ldkMessage
-        case .InvalidSystemTime(message: let ldkMessage):
+        case let .InvalidSystemTime(message: ldkMessage):
             message = "Invalid system time"
             debugMessage = ldkMessage
-        case .InvalidListeningAddresses(message: let ldkMessage):
+        case let .InvalidListeningAddresses(message: ldkMessage):
             message = "Invalid listening addresses"
             debugMessage = ldkMessage
-        case .ReadFailed(message: let ldkMessage):
+        case let .ReadFailed(message: ldkMessage):
             message = "Read failed"
             debugMessage = ldkMessage
-        case .WriteFailed(message: let ldkMessage):
+        case let .WriteFailed(message: ldkMessage):
             message = "Write failed"
             debugMessage = ldkMessage
-        case .StoragePathAccessFailed(message: let ldkMessage):
+        case let .StoragePathAccessFailed(message: ldkMessage):
             message = "Storage path access failed"
             debugMessage = ldkMessage
-        case .KvStoreSetupFailed(message: let ldkMessage):
+        case let .KvStoreSetupFailed(message: ldkMessage):
             message = "KV store setup failed"
             debugMessage = ldkMessage
-        case .WalletSetupFailed(message: let ldkMessage):
+        case let .WalletSetupFailed(message: ldkMessage):
             message = "Wallet setup failed"
             debugMessage = ldkMessage
-        case .LoggerSetupFailed(message: let ldkMessage):
+        case let .LoggerSetupFailed(message: ldkMessage):
             message = "Logger setup failed"
             debugMessage = ldkMessage
-        case .InvalidNodeAlias(message: let ldkMessage):
+        case let .InvalidNodeAlias(message: ldkMessage):
             message = ldkMessage
             debugMessage = nil
-        case .InvalidAnnouncementAddresses(message: let ldkMessage):
+        case let .InvalidAnnouncementAddresses(message: ldkMessage):
             message = ldkMessage
             debugMessage = nil
-        case .NetworkMismatch(message: let ldkMessage):
+        case let .NetworkMismatch(message: ldkMessage):
             message = ldkMessage
             debugMessage = nil
         }
@@ -176,176 +169,176 @@ struct AppError: LocalizedError {
 
     private init(ldkError: NodeError) {
         switch ldkError as NodeError {
-        case .AlreadyRunning(message: let ldkMessage):
+        case let .AlreadyRunning(message: ldkMessage):
             message = "Node is already running"
             debugMessage = ldkMessage
-        case .NotRunning(message: let ldkMessage):
+        case let .NotRunning(message: ldkMessage):
             message = "Node is not running"
             debugMessage = ldkMessage
-        case .OnchainTxCreationFailed(message: let ldkMessage):
+        case let .OnchainTxCreationFailed(message: ldkMessage):
             message = "Failed to create onchain transaction"
             debugMessage = ldkMessage
-        case .ConnectionFailed(message: let ldkMessage):
+        case let .ConnectionFailed(message: ldkMessage):
             message = "Failed to connect to node"
             debugMessage = ldkMessage
-        case .InvoiceCreationFailed(message: let ldkMessage):
+        case let .InvoiceCreationFailed(message: ldkMessage):
             message = "Failed to create invoice"
             debugMessage = ldkMessage
-        case .InvoiceRequestCreationFailed(message: let ldkMessage):
+        case let .InvoiceRequestCreationFailed(message: ldkMessage):
             message = "Failed to create invoice request"
             debugMessage = ldkMessage
-        case .OfferCreationFailed(message: let ldkMessage):
+        case let .OfferCreationFailed(message: ldkMessage):
             message = "Failed to create offer"
             debugMessage = ldkMessage
-        case .RefundCreationFailed(message: let ldkMessage):
+        case let .RefundCreationFailed(message: ldkMessage):
             message = "Failed to create refund"
             debugMessage = ldkMessage
-        case .PaymentSendingFailed(message: let ldkMessage):
+        case let .PaymentSendingFailed(message: ldkMessage):
             //            message = "Failed to send payment. \(ldkMessage)"
             message = ldkMessage
             debugMessage = ldkMessage
-        case .ProbeSendingFailed(message: let ldkMessage):
+        case let .ProbeSendingFailed(message: ldkMessage):
             message = "Failed to send probe"
             debugMessage = ldkMessage
-        case .ChannelCreationFailed(message: let ldkMessage):
+        case let .ChannelCreationFailed(message: ldkMessage):
             message = "Failed to create channel"
             debugMessage = ldkMessage
-        case .ChannelClosingFailed(message: let ldkMessage):
+        case let .ChannelClosingFailed(message: ldkMessage):
             message = "Failed to close channel"
             debugMessage = ldkMessage
-        case .ChannelConfigUpdateFailed(message: let ldkMessage):
+        case let .ChannelConfigUpdateFailed(message: ldkMessage):
             message = "Failed to update channel config"
             debugMessage = ldkMessage
-        case .PersistenceFailed(message: let ldkMessage):
+        case let .PersistenceFailed(message: ldkMessage):
             message = "Failed to persist data"
             debugMessage = ldkMessage
-        case .FeerateEstimationUpdateFailed(message: let ldkMessage):
+        case let .FeerateEstimationUpdateFailed(message: ldkMessage):
             message = "Failed to update feerate estimation"
             debugMessage = ldkMessage
-        case .FeerateEstimationUpdateTimeout(message: let ldkMessage):
+        case let .FeerateEstimationUpdateTimeout(message: ldkMessage):
             message = "Failed to update feerate estimation due to timeout"
             debugMessage = ldkMessage
-        case .WalletOperationFailed(message: let ldkMessage):
+        case let .WalletOperationFailed(message: ldkMessage):
             message = "Failed to perform wallet operation"
             debugMessage = ldkMessage
-        case .WalletOperationTimeout(message: let ldkMessage):
+        case let .WalletOperationTimeout(message: ldkMessage):
             message = "Failed to perform wallet operation due to timeout"
             debugMessage = ldkMessage
-        case .OnchainTxSigningFailed(message: let ldkMessage):
+        case let .OnchainTxSigningFailed(message: ldkMessage):
             message = "Failed to sign onchain transaction"
             debugMessage = ldkMessage
-        case .TxSyncFailed(message: let ldkMessage):
+        case let .TxSyncFailed(message: ldkMessage):
             message = "Failed to sync transaction"
             debugMessage = ldkMessage
-        case .TxSyncTimeout(message: let ldkMessage):
+        case let .TxSyncTimeout(message: ldkMessage):
             message = "Failed to sync transaction due to timeout"
             debugMessage = ldkMessage
-        case .GossipUpdateFailed(message: let ldkMessage):
+        case let .GossipUpdateFailed(message: ldkMessage):
             message = "Failed to update gossip"
             debugMessage = ldkMessage
-        case .GossipUpdateTimeout(message: let ldkMessage):
+        case let .GossipUpdateTimeout(message: ldkMessage):
             message = "Failed to update gossip due to timeout"
             debugMessage = ldkMessage
-        case .LiquidityRequestFailed(message: let ldkMessage):
+        case let .LiquidityRequestFailed(message: ldkMessage):
             message = "Failed to request liquidity"
             debugMessage = ldkMessage
-        case .InvalidAddress(message: let ldkMessage):
+        case let .InvalidAddress(message: ldkMessage):
             message = "Invalid address"
             debugMessage = ldkMessage
-        case .InvalidSocketAddress(message: let ldkMessage):
+        case let .InvalidSocketAddress(message: ldkMessage):
             message = "Invalid socket address"
             debugMessage = ldkMessage
-        case .InvalidPublicKey(message: let ldkMessage):
+        case let .InvalidPublicKey(message: ldkMessage):
             message = "Invalid public key"
             debugMessage = ldkMessage
-        case .InvalidSecretKey(message: let ldkMessage):
+        case let .InvalidSecretKey(message: ldkMessage):
             message = "Invalid secret key"
             debugMessage = ldkMessage
-        case .InvalidOfferId(message: let ldkMessage):
+        case let .InvalidOfferId(message: ldkMessage):
             message = "Invalid offer ID"
             debugMessage = ldkMessage
-        case .InvalidNodeId(message: let ldkMessage):
+        case let .InvalidNodeId(message: ldkMessage):
             message = "Invalid node ID"
             debugMessage = ldkMessage
-        case .InvalidPaymentId(message: let ldkMessage):
+        case let .InvalidPaymentId(message: ldkMessage):
             message = "Invalid payment ID"
             debugMessage = ldkMessage
-        case .InvalidPaymentHash(message: let ldkMessage):
+        case let .InvalidPaymentHash(message: ldkMessage):
             message = "Invalid payment hash"
             debugMessage = ldkMessage
-        case .InvalidPaymentPreimage(message: let ldkMessage):
+        case let .InvalidPaymentPreimage(message: ldkMessage):
             message = "Invalid payment preimage"
             debugMessage = ldkMessage
-        case .InvalidPaymentSecret(message: let ldkMessage):
+        case let .InvalidPaymentSecret(message: ldkMessage):
             message = "Invalid payment secret"
             debugMessage = ldkMessage
-        case .InvalidAmount(message: let ldkMessage):
+        case let .InvalidAmount(message: ldkMessage):
             message = "Invalid amount"
             debugMessage = ldkMessage
-        case .InvalidInvoice(message: let ldkMessage):
+        case let .InvalidInvoice(message: ldkMessage):
             message = "Invalid invoice"
             debugMessage = ldkMessage
-        case .InvalidOffer(message: let ldkMessage):
+        case let .InvalidOffer(message: ldkMessage):
             message = "Invalid offer"
             debugMessage = ldkMessage
-        case .InvalidRefund(message: let ldkMessage):
+        case let .InvalidRefund(message: ldkMessage):
             message = "Invalid refund"
             debugMessage = ldkMessage
-        case .InvalidChannelId(message: let ldkMessage):
+        case let .InvalidChannelId(message: ldkMessage):
             message = "Invalid channel ID"
             debugMessage = ldkMessage
-        case .InvalidNetwork(message: let ldkMessage):
+        case let .InvalidNetwork(message: ldkMessage):
             message = "Invalid network"
             debugMessage = ldkMessage
-        case .DuplicatePayment(message: let ldkMessage):
+        case let .DuplicatePayment(message: ldkMessage):
             message = "Duplicate payment"
             debugMessage = ldkMessage
-        case .UnsupportedCurrency(message: let ldkMessage):
+        case let .UnsupportedCurrency(message: ldkMessage):
             message = "Unsupported currency"
             debugMessage = ldkMessage
-        case .InsufficientFunds(message: let ldkMessage):
+        case let .InsufficientFunds(message: ldkMessage):
             message = "Insufficient funds"
             debugMessage = ldkMessage
-        case .LiquiditySourceUnavailable(message: let ldkMessage):
+        case let .LiquiditySourceUnavailable(message: ldkMessage):
             message = "Liquidity source unavailable"
             debugMessage = ldkMessage
-        case .LiquidityFeeTooHigh(message: let ldkMessage):
+        case let .LiquidityFeeTooHigh(message: ldkMessage):
             message = "Liquidity fee too high"
             debugMessage = ldkMessage
-        case .UriParameterParsingFailed(message: let ldkMessage):
+        case let .UriParameterParsingFailed(message: ldkMessage):
             message = "Uri parameter parsing failed"
             debugMessage = ldkMessage
-        case .InvalidUri(message: let ldkMessage):
+        case let .InvalidUri(message: ldkMessage):
             message = "Invalid URI"
             debugMessage = ldkMessage
-        case .InvalidQuantity(message: let ldkMessage):
+        case let .InvalidQuantity(message: ldkMessage):
             message = "Invalid quantity"
             debugMessage = ldkMessage
-        case .InvalidNodeAlias(message: let ldkMessage):
+        case let .InvalidNodeAlias(message: ldkMessage):
             message = "Invalid node alias"
             debugMessage = ldkMessage
-        case .InvalidCustomTlvs(message: let ldkMessage):
+        case let .InvalidCustomTlvs(message: ldkMessage):
             message = "Invalid custom TLVs"
             debugMessage = ldkMessage
-        case .InvalidDateTime(message: let ldkMessage):
+        case let .InvalidDateTime(message: ldkMessage):
             message = "Invalid date time"
             debugMessage = ldkMessage
-        case .InvalidFeeRate(message: let ldkMessage):
+        case let .InvalidFeeRate(message: ldkMessage):
             message = "Invalid fee rate"
             debugMessage = ldkMessage
-        case .CannotRbfFundingTransaction(let ldkMessage):
+        case let .CannotRbfFundingTransaction(ldkMessage):
             message = "Cannot RBF funding transaction"
             debugMessage = ldkMessage
-        case .TransactionNotFound(let ldkMessage):
+        case let .TransactionNotFound(ldkMessage):
             message = "Transaction not found"
             debugMessage = ldkMessage
-        case .TransactionAlreadyConfirmed(let ldkMessage):
+        case let .TransactionAlreadyConfirmed(ldkMessage):
             message = "Transaction already confirmed"
             debugMessage = ldkMessage
-        case .NoSpendableOutputs(let ldkMessage):
+        case let .NoSpendableOutputs(ldkMessage):
             message = "No spendable outputs"
             debugMessage = ldkMessage
-        case .CoinSelectionFailed(let ldkMessage):
+        case let .CoinSelectionFailed(ldkMessage):
             message = "Coin selection failed"
             debugMessage = ldkMessage
         }

--- a/Bitkit/Utilities/Haptics.swift
+++ b/Bitkit/Utilities/Haptics.swift
@@ -1,10 +1,3 @@
-//
-//  Haptics.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/09.
-//
-
 import CoreHaptics
 import UIKit
 
@@ -12,7 +5,7 @@ class Haptics {
     private static var engine: CHHapticEngine?
     private static var player: CHHapticPatternPlayer?
     private static var lastHapticTime: TimeInterval = 0
-    private static let minimumHapticInterval: TimeInterval = 0.1  // 100ms
+    private static let minimumHapticInterval: TimeInterval = 0.1 // 100ms
 
     private static func shouldAllowHaptic() -> Bool {
         let currentTime = Date().timeIntervalSince1970
@@ -57,7 +50,9 @@ class Haptics {
                     eventType: .hapticContinuous,
                     parameters: [approachIntensity, approachSharpness],
                     relativeTime: 0,
-                    duration: duration * 0.3))
+                    duration: duration * 0.3
+                )
+            )
 
             // Middle section split into three parts
             // First part of peak (building up)
@@ -68,7 +63,9 @@ class Haptics {
                     eventType: .hapticContinuous,
                     parameters: [peak1Intensity, peak1Sharpness],
                     relativeTime: duration * 0.3,
-                    duration: duration * 0.133))
+                    duration: duration * 0.133
+                )
+            )
 
             // Second part of peak (maximum)
             let peak2Intensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.35)
@@ -78,7 +75,9 @@ class Haptics {
                     eventType: .hapticContinuous,
                     parameters: [peak2Intensity, peak2Sharpness],
                     relativeTime: duration * 0.433,
-                    duration: duration * 0.134))
+                    duration: duration * 0.134
+                )
+            )
 
             // Third part of peak (reducing)
             let peak3Intensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.25)
@@ -88,7 +87,9 @@ class Haptics {
                     eventType: .hapticContinuous,
                     parameters: [peak3Intensity, peak3Sharpness],
                     relativeTime: duration * 0.567,
-                    duration: duration * 0.133))
+                    duration: duration * 0.133
+                )
+            )
 
             // Soft ending (flying away)
             let departIntensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.15)
@@ -98,7 +99,9 @@ class Haptics {
                     eventType: .hapticContinuous,
                     parameters: [departIntensity, departSharpness],
                     relativeTime: duration * 0.7,
-                    duration: duration * 0.3))
+                    duration: duration * 0.3
+                )
+            )
 
             let pattern = try CHHapticPattern(events: events, parameters: [])
             player = try engine?.makePlayer(with: pattern)
@@ -136,7 +139,7 @@ class Haptics {
                 }
             }
 
-            engine?.stoppedHandler = { reason in
+            engine?.stoppedHandler = { _ in
                 engine = nil
             }
 
@@ -146,6 +149,7 @@ class Haptics {
 }
 
 // MARK: add aliases for common haptic feedback here
+
 extension UIImpactFeedbackGenerator.FeedbackStyle {
     static var copiedToClipboard: UIImpactFeedbackGenerator.FeedbackStyle { .soft }
     static var pastedFromClipboard: UIImpactFeedbackGenerator.FeedbackStyle { .medium }

--- a/Bitkit/Utilities/Keychain.swift
+++ b/Bitkit/Utilities/Keychain.swift
@@ -1,10 +1,3 @@
-//
-//  Keychain.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/29.
-//
-
 import Foundation
 import Security
 
@@ -18,9 +11,9 @@ enum KeychainEntryType {
 
     var storageKey: String {
         switch self {
-        case .bip39Mnemonic(let index):
+        case let .bip39Mnemonic(index):
             return "bip39_mnemonic_\(index)"
-        case .bip39Passphrase(let index):
+        case let .bip39Passphrase(index):
             return "bip39_passphrase_\(index)"
         case .pushNotificationPrivateKey:
             return "push_notification_private_key"
@@ -46,7 +39,8 @@ class Keychain {
         // Don't allow accidentally overwriting keys
         guard try load(key: key) == nil else {
             Logger.error(
-                "Key \(key.storageKey) already exists in keychain. Explicity delete key before attempting to update value.", context: "Keychain")
+                "Key \(key.storageKey) already exists in keychain. Explicity delete key before attempting to update value.", context: "Keychain"
+            )
             throw KeychainError.failedToSaveAlreadyExists
         }
 

--- a/Bitkit/Utilities/LocalizeHelpers.swift
+++ b/Bitkit/Utilities/LocalizeHelpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Centralized localization helper with English fallback support
-struct LocalizationHelper {
+enum LocalizationHelper {
     private static let notFoundValue = "___NOTFOUND___"
 
     /// Gets the current language code from user preferences

--- a/Bitkit/Utilities/Logger.swift
+++ b/Bitkit/Utilities/Logger.swift
@@ -1,10 +1,3 @@
-//
-//  Logger.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/16.
-//
-
 import Foundation
 
 class Logger {
@@ -16,11 +9,11 @@ class Logger {
         dateFormatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         let timestamp = dateFormatter.string(from: Date())
-        
+
         let baseDir = Env.logDirectory
         let contextPrefix = Env.currentExecutionContext.filenamePrefix
         let sessionLogPath = "\(baseDir)/bitkit_\(contextPrefix)_\(timestamp).log"
-        
+
         // Create directory if it doesn't exist
         let directory = URL(fileURLWithPath: baseDir)
         if !FileManager.default.fileExists(atPath: directory.path) {
@@ -37,54 +30,54 @@ class Logger {
         }
 
         print("Bitkit logger initialized with session log: \(sessionLogPath)")
-        
+
         return sessionLogPath
     }()
-    
+
     static func info(_ message: Any, context: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         handle("INFOℹ️: \(message)", context: context, file: file, function: function, line: line)
     }
-    
+
     static func debug(_ message: Any, context: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         handle("DEBUG: \(message)", context: context, file: file, function: function, line: line)
     }
-    
+
     static func warn(_ message: Any, context: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         handle("WARN⚠️: \(message)", context: context, file: file, function: function, line: line)
     }
-    
+
     static func error(_ message: Any, context: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         handle("ERROR❌: \(message)", context: context, file: file, function: function, line: line)
     }
-    
+
     static func test(_ message: Any, context: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         handle("🧪🧪🧪: \(message)", context: context, file: file, function: function, line: line)
     }
-    
+
     static func performance(_ message: Any, context: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         handle("PERF: \(message)", context: context, file: file, function: function, line: line)
     }
-    
+
     private static func handle(_ message: Any, context: String = "", file: String = #file, function: String = #function, line: Int = #line) {
         let fileName = URL(fileURLWithPath: file).lastPathComponent
         let line = "\(message) \(context == "" ? "" : "- \(context) ")[\(fileName): \(function) line: \(line)]"
-        
+
         print(line)
-        
+
         queue.async {
             writeToFile(line)
         }
     }
-    
+
     private static func writeToFile(_ message: String) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         let timestamp = dateFormatter.string(from: Date())
         let logMessage = "[\(timestamp) UTC] \(message)\n"
-        
+
         let logFilePath = sessionLogFile
-        
+
         // Write to file
         if FileManager.default.fileExists(atPath: logFilePath) {
             if let fileHandle = try? FileHandle(forWritingTo: URL(fileURLWithPath: logFilePath)) {
@@ -102,47 +95,49 @@ class Logger {
             }
         }
     }
-    
-    //Cleans up both bitkit and ldk log files
+
+    // Cleans up both bitkit and ldk log files
     static func cleanUpOldLogFiles(maxTotalSizeMB: Int = 20) {
         queue.async {
             let baseDir = Env.logDirectory
-            
+
             let fileManager = FileManager.default
-            guard let fileURLs = try? fileManager.contentsOfDirectory(at: URL(fileURLWithPath: baseDir), 
+            guard let fileURLs = try? fileManager.contentsOfDirectory(at: URL(fileURLWithPath: baseDir),
                                                                       includingPropertiesForKeys: [.creationDateKey, .fileSizeKey],
-                                                                      options: .skipsHiddenFiles) else {
+                                                                      options: .skipsHiddenFiles)
+            else {
                 return
             }
-            
+
             // Filter log files and get their sizes and creation dates
             var logFiles: [(url: URL, size: UInt64, date: Date)] = []
             var totalSize: UInt64 = 0
-            
+
             for fileURL in fileURLs {
                 if fileURL.pathExtension == "log" {
                     guard let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path),
                           let creationDate = attributes[.creationDate] as? Date,
-                          let fileSize = attributes[.size] as? UInt64 else {
+                          let fileSize = attributes[.size] as? UInt64
+                    else {
                         continue
                     }
-                    
+
                     logFiles.append((fileURL, fileSize, creationDate))
                     totalSize += fileSize
                 }
             }
-            
+
             // Sort by creation date (oldest first)
             logFiles.sort { $0.date < $1.date }
-            
+
             // Delete oldest files until we're under the size limit
-            let maxSizeBytes: UInt64 = UInt64(maxTotalSizeMB) * 1024 * 1024
-            
+            let maxSizeBytes = UInt64(maxTotalSizeMB) * 1024 * 1024
+
             for logFile in logFiles {
                 if totalSize <= maxSizeBytes {
                     break
                 }
-                
+
                 do {
                     try fileManager.removeItem(at: logFile.url)
                     totalSize -= logFile.size

--- a/Bitkit/Utilities/ScenePhase.swift
+++ b/Bitkit/Utilities/ScenePhase.swift
@@ -1,10 +1,3 @@
-//
-//  ScenePhase.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/08/15.
-//
-
 import SwiftUI
 import UIKit
 
@@ -95,9 +88,9 @@ private struct HandleLightningStateOnScenePhaseChange: ViewModifier {
         backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "StopLightningNode") {
             // This closure is called if the task expires
             Logger.debug("Background task for stopping Lightning node expired before completion")
-            if self.backgroundTaskID != .invalid {
-                UIApplication.shared.endBackgroundTask(self.backgroundTaskID)
-                self.backgroundTaskID = .invalid
+            if backgroundTaskID != .invalid {
+                UIApplication.shared.endBackgroundTask(backgroundTaskID)
+                backgroundTaskID = .invalid
             }
         }
 
@@ -114,7 +107,7 @@ private struct HandleLightningStateOnScenePhaseChange: ViewModifier {
                 Logger.debug("Background task ended after successful node stop")
             }
 
-            //If we're stopped and we're not in the background, we need to start again
+            // If we're stopped and we're not in the background, we need to start again
             if scenePhase == .active {
                 try await startNodeIfNeeded()
             }

--- a/Bitkit/Utilities/StartupHandler.swift
+++ b/Bitkit/Utilities/StartupHandler.swift
@@ -1,10 +1,3 @@
-//
-//  Startup.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/31.
-//
-
 import LDKNode
 import SwiftUI
 

--- a/Bitkit/ViewModels/ActivityItemViewModel.swift
+++ b/Bitkit/ViewModels/ActivityItemViewModel.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import BitkitCore
+import SwiftUI
 
 @MainActor
 class ActivityItemViewModel: ObservableObject {
@@ -10,12 +10,12 @@ class ActivityItemViewModel: ObservableObject {
     @Published private(set) var activityId: String
 
     init(item: Activity) {
-        self.activity = item
-        self.activityId = {
+        activity = item
+        activityId = {
             switch item {
-            case .lightning(let activity):
+            case let .lightning(activity):
                 return activity.id
-            case .onchain(let activity):
+            case let .onchain(activity):
                 return activity.id
             }
         }()
@@ -49,25 +49,29 @@ class ActivityItemViewModel: ObservableObject {
             } else {
                 // Activity not found by ID - it might have been replaced by RBF
                 // Try to find a replacement activity by txId for onchain activities
-                if case .onchain(let onchainActivity) = activity {
+                if case let .onchain(onchainActivity) = activity {
                     Logger.debug("Activity \(activityId) not found, looking for RBF replacement", context: "ActivityItemViewModel.refreshActivity")
-                    
+
                     // Try multiple times with delay to allow sync to complete
-                    for attempt in 1...3 {
+                    for attempt in 1 ... 3 {
                         Logger.debug("Attempt \(attempt) to find RBF replacement", context: "ActivityItemViewModel.refreshActivity")
-                        
+
                         // Get all recent activities to find potential replacement
                         let recentActivities = try await coreService.activity.get(filter: .onchain, limit: 50)
-                        
+
                         // Look for a boosted transaction that could be our replacement
                         for recentActivity in recentActivities {
-                            if case .onchain(let recentOnchain) = recentActivity {
+                            if case let .onchain(recentOnchain) = recentActivity {
                                 // Check if this is a boosted transaction with same value and type
-                                if recentOnchain.isBoosted && 
-                                   recentOnchain.txType == onchainActivity.txType &&
-                                   recentOnchain.value == onchainActivity.value &&
-                                   recentOnchain.timestamp >= onchainActivity.timestamp {
-                                    Logger.info("Found RBF replacement activity: \(recentOnchain.id)", context: "ActivityItemViewModel.refreshActivity")
+                                if recentOnchain.isBoosted &&
+                                    recentOnchain.txType == onchainActivity.txType &&
+                                    recentOnchain.value == onchainActivity.value &&
+                                    recentOnchain.timestamp >= onchainActivity.timestamp
+                                {
+                                    Logger.info(
+                                        "Found RBF replacement activity: \(recentOnchain.id)",
+                                        context: "ActivityItemViewModel.refreshActivity"
+                                    )
                                     activity = recentActivity
                                     activityId = recentOnchain.id
                                     await loadTags()
@@ -75,14 +79,20 @@ class ActivityItemViewModel: ObservableObject {
                                 }
                             }
                         }
-                        
+
                         // If not found and not the last attempt, wait and try again
                         if attempt < 3 {
-                            Logger.debug("RBF replacement not found on attempt \(attempt), waiting 2 seconds", context: "ActivityItemViewModel.refreshActivity")
+                            Logger.debug(
+                                "RBF replacement not found on attempt \(attempt), waiting 2 seconds",
+                                context: "ActivityItemViewModel.refreshActivity"
+                            )
                             try await Task.sleep(nanoseconds: 2_000_000_000) // 2 second delay
                         }
                     }
-                    Logger.warn("No RBF replacement found for activity \(activityId) after 3 attempts", context: "ActivityItemViewModel.refreshActivity")
+                    Logger.warn(
+                        "No RBF replacement found for activity \(activityId) after 3 attempts",
+                        context: "ActivityItemViewModel.refreshActivity"
+                    )
                 }
             }
         } catch {

--- a/Bitkit/ViewModels/ActivityListViewModel.swift
+++ b/Bitkit/ViewModels/ActivityListViewModel.swift
@@ -1,13 +1,6 @@
-//
-//  ActivityListViewModel.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/12/17.
-//
-
+import BitkitCore
 import Combine
 import SwiftUI
-import BitkitCore
 
 @MainActor
 class ActivityListViewModel: ObservableObject {
@@ -35,7 +28,7 @@ class ActivityListViewModel: ObservableObject {
     @Published private(set) var recentlyUsedTags: [String] = []
 
     // Persistent storage for recently used tags
-    @AppStorage("recentlyUsedTags") private var recentlyUsedTagsData: Data = Data()
+    @AppStorage("recentlyUsedTags") private var recentlyUsedTagsData: Data = .init()
 
     private func updateAvailableTags() async {
         do {
@@ -91,12 +84,12 @@ class ActivityListViewModel: ObservableObject {
         // Setup search text subscription with debounce
         searchCancellable =
             $searchText
-            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
-            .sink { [weak self] _ in
-                Task { [weak self] in
-                    await self?.updateFilteredActivities()
+                .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    Task { [weak self] in
+                        await self?.updateFilteredActivities()
+                    }
                 }
-            }
 
         // Setup date range subscription
         dateRangeCancellable = Publishers.CombineLatest($startDate, $endDate)
@@ -109,11 +102,11 @@ class ActivityListViewModel: ObservableObject {
         // Setup tags subscription
         tagsCancellable =
             $selectedTags
-            .sink { [weak self] _ in
-                Task { [weak self] in
-                    await self?.updateFilteredActivities()
+                .sink { [weak self] _ in
+                    Task { [weak self] in
+                        await self?.updateFilteredActivities()
+                    }
                 }
-            }
 
         Task {
             await syncState()
@@ -273,12 +266,11 @@ extension ActivityListViewModel {
         var earlier: [Activity] = []
 
         for activity in activities {
-            let timestamp: UInt64
-            switch activity {
-            case .lightning(let ln):
-                timestamp = ln.timestamp
-            case .onchain(let on):
-                timestamp = on.timestamp
+            let timestamp: UInt64 = switch activity {
+            case let .lightning(ln):
+                ln.timestamp
+            case let .onchain(on):
+                on.timestamp
             }
 
             let activityDate = Date(timeIntervalSince1970: TimeInterval(timestamp))
@@ -304,10 +296,9 @@ extension ActivityListViewModel {
         if !today.isEmpty {
             let headerDate =
                 today.first.map { activity in
-                    let timestamp: UInt64
-                    switch activity {
-                    case .lightning(let ln): timestamp = ln.timestamp
-                    case .onchain(let on): timestamp = on.timestamp
+                    let timestamp: UInt64 = switch activity {
+                    case let .lightning(ln): ln.timestamp
+                    case let .onchain(on): on.timestamp
                     }
                     return Date(timeIntervalSince1970: TimeInterval(timestamp))
                 } ?? now
@@ -318,10 +309,9 @@ extension ActivityListViewModel {
         if !yesterday.isEmpty {
             let headerDate =
                 yesterday.first.map { activity in
-                    let timestamp: UInt64
-                    switch activity {
-                    case .lightning(let ln): timestamp = ln.timestamp
-                    case .onchain(let on): timestamp = on.timestamp
+                    let timestamp: UInt64 = switch activity {
+                    case let .lightning(ln): ln.timestamp
+                    case let .onchain(on): on.timestamp
                     }
                     return Date(timeIntervalSince1970: TimeInterval(timestamp))
                 } ?? beginningOfYesterday
@@ -332,10 +322,9 @@ extension ActivityListViewModel {
         if !thisWeek.isEmpty {
             let headerDate =
                 thisWeek.first.map { activity in
-                    let timestamp: UInt64
-                    switch activity {
-                    case .lightning(let ln): timestamp = ln.timestamp
-                    case .onchain(let on): timestamp = on.timestamp
+                    let timestamp: UInt64 = switch activity {
+                    case let .lightning(ln): ln.timestamp
+                    case let .onchain(on): on.timestamp
                     }
                     return Date(timeIntervalSince1970: TimeInterval(timestamp))
                 } ?? beginningOfWeek
@@ -346,10 +335,9 @@ extension ActivityListViewModel {
         if !thisMonth.isEmpty {
             let headerDate =
                 thisMonth.first.map { activity in
-                    let timestamp: UInt64
-                    switch activity {
-                    case .lightning(let ln): timestamp = ln.timestamp
-                    case .onchain(let on): timestamp = on.timestamp
+                    let timestamp: UInt64 = switch activity {
+                    case let .lightning(ln): ln.timestamp
+                    case let .onchain(on): on.timestamp
                     }
                     return Date(timeIntervalSince1970: TimeInterval(timestamp))
                 } ?? beginningOfMonth
@@ -360,10 +348,9 @@ extension ActivityListViewModel {
         if !thisYear.isEmpty {
             let headerDate =
                 thisYear.first.map { activity in
-                    let timestamp: UInt64
-                    switch activity {
-                    case .lightning(let ln): timestamp = ln.timestamp
-                    case .onchain(let on): timestamp = on.timestamp
+                    let timestamp: UInt64 = switch activity {
+                    case let .lightning(ln): ln.timestamp
+                    case let .onchain(on): on.timestamp
                     }
                     return Date(timeIntervalSince1970: TimeInterval(timestamp))
                 } ?? beginningOfYear
@@ -374,10 +361,9 @@ extension ActivityListViewModel {
         if !earlier.isEmpty {
             let headerDate =
                 earlier.first.map { activity in
-                    let timestamp: UInt64
-                    switch activity {
-                    case .lightning(let ln): timestamp = ln.timestamp
-                    case .onchain(let on): timestamp = on.timestamp
+                    let timestamp: UInt64 = switch activity {
+                    case let .lightning(ln): ln.timestamp
+                    case let .onchain(on): on.timestamp
                     }
                     return Date(timeIntervalSince1970: TimeInterval(timestamp))
                 } ?? Date.distantPast

--- a/Bitkit/ViewModels/BlocktankViewModel.swift
+++ b/Bitkit/ViewModels/BlocktankViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  BlocktankViewModel.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/12.
-//
-
 import BitkitCore
 import SwiftUI
 
@@ -57,19 +50,19 @@ class BlocktankViewModel: ObservableObject {
         stopPolling()
 
         refreshTimer = Timer.scheduledTimer(withTimeInterval: Env.blocktankOrderRefreshInterval, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            self.refreshTask?.cancel()
-            self.refreshTask = Task { @MainActor [weak self] in
-                guard let self = self else { return }
-                try? await self.refreshOrders()
+            guard let self else { return }
+            refreshTask?.cancel()
+            refreshTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                try? await refreshOrders()
             }
         }
 
         // Initial refresh
         refreshTask?.cancel()
         refreshTask = Task { @MainActor [weak self] in
-            guard let self = self else { return }
-            try? await self.refreshOrders()
+            guard let self else { return }
+            try? await refreshOrders()
         }
     }
 
@@ -223,7 +216,7 @@ class BlocktankViewModel: ObservableObject {
 
         // Get current rates
         guard let rates = currencyService.loadCachedRates(),
-            let eurRate = currencyService.getCurrentRate(for: "EUR", from: rates)
+              let eurRate = currencyService.getCurrentRate(for: "EUR", from: rates)
         else {
             Logger.error("Failed to get EUR rate for lspBalance calculation")
             throw CustomServiceError.currencyRateUnavailable

--- a/Bitkit/ViewModels/CurrencyViewModel.swift
+++ b/Bitkit/ViewModels/CurrencyViewModel.swift
@@ -65,19 +65,19 @@ class CurrencyViewModel: ObservableObject {
         stopPolling()
 
         refreshTimer = Timer.scheduledTimer(withTimeInterval: Env.fxRateRefreshInterval, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            self.refreshTask?.cancel()
-            self.refreshTask = Task { @MainActor [weak self] in
-                guard let self = self else { return }
-                await self.refresh()
+            guard let self else { return }
+            refreshTask?.cancel()
+            refreshTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                await refresh()
             }
         }
 
         // Initial refresh
         refreshTask?.cancel()
         refreshTask = Task { @MainActor [weak self] in
-            guard let self = self else { return }
-            await self.refresh()
+            guard let self else { return }
+            await refresh()
         }
     }
 

--- a/Bitkit/ViewModels/SettingsViewModel.swift
+++ b/Bitkit/ViewModels/SettingsViewModel.swift
@@ -1,17 +1,10 @@
-//
-//  SettingsViewModel.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/12/19.
-//
-
 import LDKNode
 import SwiftUI
 import UserNotifications
 
 enum CoinSelectionMethod: String, CaseIterable {
-    case manual = "manual"
-    case autopilot = "autopilot"
+    case manual
+    case autopilot
 }
 
 extension CoinSelectionAlgorithm {
@@ -59,12 +52,13 @@ class SettingsViewModel: ObservableObject {
             }
         }
     }
+
     @AppStorage("defaultTransactionSpeed") var defaultTransactionSpeed: TransactionSpeed = .medium
     @AppStorage("hideBalance") var hideBalance: Bool = false
     @AppStorage("hideBalanceOnOpen") var hideBalanceOnOpen: Bool = false
     @AppStorage("readClipboard") var readClipboard: Bool = false
     @AppStorage("warnWhenSendingOver100") var warnWhenSendingOver100: Bool = false
-    @AppStorage("showRecentlyPaidContacts") var showRecentlyPaidContacts: Bool = true //TODO: probably not going to be in anytime soon
+    @AppStorage("showRecentlyPaidContacts") var showRecentlyPaidContacts: Bool = true // TODO: probably not going to be in anytime soon
     @AppStorage("requirePinOnLaunch") var requirePinOnLaunch: Bool = true
     @AppStorage("requirePinWhenIdle") var requirePinWhenIdle: Bool = false
     @AppStorage("requirePinForPayments") var requirePinForPayments: Bool = false

--- a/Bitkit/ViewModels/SheetViewModel.swift
+++ b/Bitkit/ViewModels/SheetViewModel.swift
@@ -33,9 +33,9 @@ class SheetViewModel: ObservableObject {
             hideSheet()
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
-                guard let self = self else { return }
-                self.activeSheetConfiguration = SheetConfiguration(id: id, data: data)
-                self.playHaptics(for: id)
+                guard let self else { return }
+                activeSheetConfiguration = SheetConfiguration(id: id, data: data)
+                playHaptics(for: id)
 
                 // Notify timed sheet manager
                 Task { @MainActor in

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  WalletViewModel.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/06/28.
-//
-
 import BitkitCore
 import LDKNode
 import SwiftUI
@@ -213,7 +206,8 @@ class WalletViewModel: ObservableObject {
         }
 
         let txid = try await lightningService.send(
-            address: address, sats: sats, satsPerVbyte: selectedFeeRateSatsPerVByte, utxosToSpend: selectedUtxo)
+            address: address, sats: sats, satsPerVbyte: selectedFeeRateSatsPerVByte, utxosToSpend: selectedUtxo
+        )
         Task {
             // Best to auto sync on chain so we have latest state
             try await sync()
@@ -274,7 +268,7 @@ class WalletViewModel: ObservableObject {
         // Add event listener for this specific payment
         addOnEvent(id: eventId) { event in
             switch event {
-            case .paymentSuccessful(let paymentId, let paymentHash, _, _):
+            case let .paymentSuccessful(paymentId, paymentHash, _, _):
                 if paymentHash == hash {
                     self.removeOnEvent(id: eventId)
                     onSuccess()
@@ -349,12 +343,12 @@ class WalletViewModel: ObservableObject {
 
         if channels?.count ?? 0 > 0 {
             if forceRefreshBolt11 || bolt11.isEmpty {
-                bolt11 = try await self.createInvoice(amountSats: amountSats, note: invoiceNote)
+                bolt11 = try await createInvoice(amountSats: amountSats, note: invoiceNote)
             } else {
-                //Existing invoice needs to be checked for expiry
-                if case .lightning(let lightningInvoice) = try await decode(invoice: bolt11) {
+                // Existing invoice needs to be checked for expiry
+                if case let .lightning(lightningInvoice) = try await decode(invoice: bolt11) {
                     if lightningInvoice.isExpired {
-                        bolt11 = try await self.createInvoice(amountSats: amountSats, note: invoiceNote)
+                        bolt11 = try await createInvoice(amountSats: amountSats, note: invoiceNote)
                     }
                 }
             }
@@ -388,7 +382,7 @@ class WalletViewModel: ObservableObject {
 
         syncTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                guard let self = self else { return }
+                guard let self else { return }
                 if self.nodeLifecycleState == .running {
                     self.syncState()
                 }

--- a/Bitkit/ViewModels/Widgets/PriceViewModel.swift
+++ b/Bitkit/ViewModels/Widgets/PriceViewModel.swift
@@ -31,9 +31,8 @@ class PriceViewModel: ObservableObject {
             do {
                 // First, try to get cached data immediately (no loading state)
                 if let cachedData = try? await priceService.fetchPriceData(pairs: pairs, period: period, returnCachedImmediately: true),
-                    !cachedData.isEmpty
+                   !cachedData.isEmpty
                 {
-
                     if !Task.isCancelled {
                         dataByPeriod[period] = cachedData
                         error = nil
@@ -109,7 +108,7 @@ class PriceViewModel: ObservableObject {
             guard !data.isEmpty else { continue }
 
             // Extract pairs from current data
-            let pairs = data.map { $0.name }
+            let pairs = data.map(\.name)
 
             do {
                 // Always fetch fresh data for background updates (no cache)

--- a/Bitkit/ViewModels/Widgets/WeatherViewModel.swift
+++ b/Bitkit/ViewModels/Widgets/WeatherViewModel.swift
@@ -140,8 +140,8 @@ class WeatherViewModel: ObservableObject {
         let usdGoodThreshold = Decimal(1.0) // $1 USD threshold for good condition
 
         // Check USD threshold first using currency conversion
-        if let currencyViewModel = currencyViewModel,
-            let converted = currencyViewModel.convert(sats: UInt64(feeRate), to: "USD")
+        if let currencyViewModel,
+           let converted = currencyViewModel.convert(sats: UInt64(feeRate), to: "USD")
         {
             if converted.value <= usdGoodThreshold {
                 return .good
@@ -160,8 +160,8 @@ class WeatherViewModel: ObservableObject {
 
     /// Formats fee amount using CurrencyViewModel - throws error if conversion fails
     private func formatFeeAmount(_ fee: Int) throws -> String {
-        guard let currencyViewModel = currencyViewModel,
-            let converted = currencyViewModel.convert(sats: UInt64(fee))
+        guard let currencyViewModel,
+              let converted = currencyViewModel.convert(sats: UInt64(fee))
         else {
             throw AppError(message: "Currency conversion unavailable", debugMessage: "Failed to convert \(fee) satoshis to fiat currency")
         }

--- a/Bitkit/ViewModels/WidgetsViewModel.swift
+++ b/Bitkit/ViewModels/WidgetsViewModel.swift
@@ -28,8 +28,7 @@ func getDefaultOptions(for type: WidgetType) -> Any {
 }
 
 // Empty options for widgets that don't have customization yet
-struct EmptyWidgetOptions: Codable, Equatable {
-}
+struct EmptyWidgetOptions: Codable, Equatable {}
 
 // MARK: - Widget Metadata
 
@@ -39,9 +38,9 @@ struct WidgetMetadata {
     let icon: String
 
     init(type: WidgetType, fiatSymbol: String = "$") {
-        self.name = localizedString("widgets__\(type.rawValue)__name")
-        self.description = localizedString("widgets__\(type.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
-        self.icon = "\(type.rawValue)-widget"
+        name = localizedString("widgets__\(type.rawValue)__name")
+        description = localizedString("widgets__\(type.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
+        icon = "\(type.rawValue)-widget"
     }
 }
 
@@ -144,12 +143,12 @@ struct PlaceholderWidget: View {
 // MARK: - Widget Types
 
 enum WidgetType: String, CaseIterable, Codable {
-    case price = "price"
-    case news = "news"
-    case blocks = "blocks"
-    case facts = "facts"
-    case calculator = "calculator"
-    case weather = "weather"
+    case price
+    case news
+    case blocks
+    case facts
+    case calculator
+    case weather
 }
 
 // MARK: - WidgetsViewModel
@@ -159,7 +158,7 @@ class WidgetsViewModel: ObservableObject {
     @Published var savedWidgets: [Widget] = []
 
     // Single AppStorage key for widgets with their options
-    @AppStorage("savedWidgets") private var savedWidgetsData: Data = Data()
+    @AppStorage("savedWidgets") private var savedWidgetsData: Data = .init()
 
     // In-memory storage for saved widgets with options
     private var savedWidgetsWithOptions: [SavedWidget] = []
@@ -203,8 +202,8 @@ class WidgetsViewModel: ObservableObject {
     /// Reorder widgets
     func reorderWidgets(from sourceIndex: Int, to destinationIndex: Int) {
         guard sourceIndex != destinationIndex,
-            sourceIndex >= 0, sourceIndex < savedWidgets.count,
-            destinationIndex >= 0, destinationIndex < savedWidgets.count
+              sourceIndex >= 0, sourceIndex < savedWidgets.count,
+              destinationIndex >= 0, destinationIndex < savedWidgets.count
         else { return }
 
         let savedWidget = savedWidgetsWithOptions.remove(at: sourceIndex)
@@ -229,8 +228,8 @@ class WidgetsViewModel: ObservableObject {
     func getOptions<T: Codable>(for type: WidgetType, as optionsType: T.Type) -> T {
         // Find the saved widget with this type
         if let savedWidget = savedWidgetsWithOptions.first(where: { $0.type == type }),
-            let optionsData = savedWidget.optionsData,
-            let options = try? JSONDecoder().decode(optionsType, from: optionsData)
+           let optionsData = savedWidget.optionsData,
+           let options = try? JSONDecoder().decode(optionsType, from: optionsData)
         {
             return options
         }
@@ -240,7 +239,7 @@ class WidgetsViewModel: ObservableObject {
     }
 
     /// Save options for a specific widget type
-    func saveOptions<T: Codable>(_ options: T, for type: WidgetType) {
+    func saveOptions(_ options: some Codable, for type: WidgetType) {
         do {
             let optionsData = try JSONEncoder().encode(options)
 

--- a/Bitkit/Views/Backup/BackupConfirmMnemonic.swift
+++ b/Bitkit/Views/Backup/BackupConfirmMnemonic.swift
@@ -65,7 +65,7 @@ struct BackupConfirmMnemonic: View {
                         title: localizedString("common__continue"),
                         isDisabled: selectedWords != mnemonic,
                     ) {
-                        if let passphrase = passphrase, !passphrase.isEmpty {
+                        if let passphrase, !passphrase.isEmpty {
                             navigationPath.append(.confirmPassphrase(passphrase: passphrase))
                         } else {
                             navigationPath.append(.reminder)
@@ -91,8 +91,8 @@ struct BackupConfirmMnemonic: View {
         if pressedIndices.contains(index) {
             // Only allow unselecting if it's the last incorrect word
             if let wordIndex = selectedWords.firstIndex(of: word),
-                wordIndex == selectedWords.count - 1, // Must be the last word
-                selectedWords[wordIndex] != mnemonic[wordIndex]
+               wordIndex == selectedWords.count - 1, // Must be the last word
+               selectedWords[wordIndex] != mnemonic[wordIndex]
             {
                 selectedWords.removeLast()
                 pressedIndices.remove(index)

--- a/Bitkit/Views/Backup/BackupMnemonic.swift
+++ b/Bitkit/Views/Backup/BackupMnemonic.swift
@@ -78,8 +78,8 @@ struct BackupMnemonicView: View {
                     ) {
                         let route =
                             passphrase.isEmpty
-                            ? BackupRoute.confirmMnemonic(mnemonic: mnemonic, passphrase: passphrase)
-                            : BackupRoute.passphrase(mnemonic: mnemonic, passphrase: passphrase)
+                                ? BackupRoute.confirmMnemonic(mnemonic: mnemonic, passphrase: passphrase)
+                                : BackupRoute.passphrase(mnemonic: mnemonic, passphrase: passphrase)
                         navigationPath.append(route)
                     }
                 }
@@ -105,10 +105,11 @@ struct BackupMnemonicView: View {
                 app.toast(
                     type: .error,
                     title: localizedString("security__mnemonic_error"),
-                    description: localizedString("security__mnemonic_error_description"))
+                    description: localizedString("security__mnemonic_error_description")
+                )
             }
 
-            self.passphrase = try Keychain.loadString(key: .bip39Passphrase(index: 0)) ?? ""
+            passphrase = try Keychain.loadString(key: .bip39Passphrase(index: 0)) ?? ""
         } catch {
             app.toast(
                 type: .error,

--- a/Bitkit/Views/Backup/BackupSheet.swift
+++ b/Bitkit/Views/Backup/BackupSheet.swift
@@ -16,7 +16,7 @@ struct BackupConfig {
     let initialRoute: BackupRoute
 
     init(view: BackupRoute = .intro) {
-        self.initialRoute = view
+        initialRoute = view
     }
 }
 
@@ -52,11 +52,11 @@ struct BackupSheet: View {
             BackupIntroView(navigationPath: $navigationPath)
         case .mnemonic:
             BackupMnemonicView(navigationPath: $navigationPath)
-        case .passphrase(let mnemonic, let passphrase):
+        case let .passphrase(mnemonic, passphrase):
             BackupPassphrase(navigationPath: $navigationPath, mnemonic: mnemonic, passphrase: passphrase)
-        case .confirmMnemonic(let mnemonic, let passphrase):
+        case let .confirmMnemonic(mnemonic, passphrase):
             BackupConfirmMnemonic(navigationPath: $navigationPath, mnemonic: mnemonic, passphrase: passphrase)
-        case .confirmPassphrase(let passphrase):
+        case let .confirmPassphrase(passphrase):
             BackupConfirmPassphrase(navigationPath: $navigationPath, passphrase: passphrase)
         case .reminder:
             BackupReminder(navigationPath: $navigationPath)

--- a/Bitkit/Views/Onboarding/CreateWalletWithPassphraseView.swift
+++ b/Bitkit/Views/Onboarding/CreateWalletWithPassphraseView.swift
@@ -58,7 +58,8 @@ struct CreateWalletWithPassphraseView: View {
                         #selector(UIResponder.resignFirstResponder),
                         to: nil,
                         from: nil,
-                        for: nil)
+                        for: nil
+                    )
                 }
         )
     }

--- a/Bitkit/Views/Onboarding/InitializingWalletView.swift
+++ b/Bitkit/Views/Onboarding/InitializingWalletView.swift
@@ -1,10 +1,3 @@
-//
-//  InitializingWalletView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/01/17.
-//
-
 import SwiftUI
 
 struct InitializingWalletView: View {
@@ -58,7 +51,7 @@ struct InitializingWalletView: View {
         Haptics.rocket(duration: 2.5)
 
         // Single continuous animation with custom timing
-        let totalDuration: Double = 2.5
+        let totalDuration = 2.5
         let finalX = geometry.size.width / 2 + 128
         let finalY = -(geometry.size.height * 0.3)
 
@@ -104,19 +97,18 @@ struct InitializingWalletView: View {
                             let baseIncrement: Double = shouldFinish ? 1.2 : 0.5
 
                             // Progressive slowdown if shouldFinish is false
-                            let increment: Double
-                            if !shouldFinish {
+                            let increment: Double = if !shouldFinish {
                                 if percentage >= 80 {
-                                    increment = baseIncrement * 0.125 // Halved three times (0.5 * 0.5 * 0.5)
+                                    baseIncrement * 0.125 // Halved three times (0.5 * 0.5 * 0.5)
                                 } else if percentage >= 70 {
-                                    increment = baseIncrement * 0.25 // Halved twice (0.5 * 0.5)
+                                    baseIncrement * 0.25 // Halved twice (0.5 * 0.5)
                                 } else if percentage >= 60 {
-                                    increment = baseIncrement * 0.5 // Halved once
+                                    baseIncrement * 0.5 // Halved once
                                 } else {
-                                    increment = baseIncrement
+                                    baseIncrement
                                 }
                             } else {
-                                increment = baseIncrement
+                                baseIncrement
                             }
 
                             percentage = min(percentage + increment, 100)

--- a/Bitkit/Views/Onboarding/RestoreWalletView.swift
+++ b/Bitkit/Views/Onboarding/RestoreWalletView.swift
@@ -60,7 +60,7 @@ struct RestoreWalletView: View {
         switch BIP39.validate(phrase: currentWords) {
         case .success:
             return nil
-        case .failure(let error):
+        case let .failure(error):
             return error
         }
     }
@@ -88,7 +88,7 @@ struct RestoreWalletView: View {
     }
 
     private var currentFocusedWord: String {
-        guard let focusedField = focusedField else { return "" }
+        guard let focusedField else { return "" }
         if focusedField == 0 {
             return firstFieldText
         }
@@ -222,7 +222,7 @@ struct RestoreWalletView: View {
         Group {
             if focusedField != nil {
                 SeedInputAccessory(currentWord: currentFocusedWord) { selectedWord in
-                    if let focusedField = focusedField {
+                    if let focusedField {
                         if focusedField == 0 {
                             firstFieldText = selectedWord
                         } else {
@@ -256,9 +256,9 @@ struct RestoreWalletView: View {
     private func handlePastedWords(_ pastedText: String) {
         let pastedWords =
             pastedText
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .components(separatedBy: .whitespaces)
-            .filter { !$0.isEmpty }
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .components(separatedBy: .whitespaces)
+                .filter { !$0.isEmpty }
 
         // Check if it's a valid 12 or 24 word phrase
         guard pastedWords.count == 12 || pastedWords.count == 24 else { return }

--- a/Bitkit/Views/Onboarding/TermsView.swift
+++ b/Bitkit/Views/Onboarding/TermsView.swift
@@ -1,10 +1,3 @@
-//
-//  TermsView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/12/11.
-//
-
 import SwiftUI
 
 private struct ScrollViewShadow: View {

--- a/Bitkit/Views/Onboarding/Tos.swift
+++ b/Bitkit/Views/Onboarding/Tos.swift
@@ -54,7 +54,6 @@ struct TosContent: View {
                     Text(
                         "1.3 The purchase, access or use of any of the Bitkit Services is void where such access or use is prohibited by, would constitute a violation of, or would be subject to penalties under applicable Laws, and shall not be the basis for the assertion or recognition of any interest, right, remedy, power, or privilege."
                     )
-
                 }
 
                 // Definitions
@@ -260,7 +259,6 @@ struct TosContent: View {
                     Text(
                         "2.2 Unless otherwise specified in these Terms, words importing the singular include the plural and vice versa and words importing gender include all genders. The word \"include\", \"includes\" or \"including\" will be interpreted on an inclusive basis and be deemed to be followed by the words \"without limitation\"."
                     )
-
                 }
 
                 // Bitkit Services
@@ -286,7 +284,6 @@ struct TosContent: View {
                     Text(
                         "3.4 You may use the Bitkit Services solely in accordance with these Terms. You shall not take any steps to circumvent, avoid, bypass or obviate, directly or indirectly, the intent of these Terms."
                     )
-
                 }
 
                 // Bitkit Wallet
@@ -332,7 +329,6 @@ struct TosContent: View {
                     Text(
                         "4.2.5 When you send Supported Assets from your Bitkit Wallet to an external wallet (**\"Wallet Outbound Transfers\"**), such transfers are executed by you on your instruction. You should verify all transaction information prior to submitting instructions. Synonym shall bear no liability or responsibility in the event you enter an incorrect blockchain destination address, incorrect destination tag/memo, or if you send your Digital Assets to an incompatible wallet. We do not guarantee the identity or value received by a recipient of a Wallet Outbound Transfer. Wallet Asset Transfers cannot be reversed once they have been broadcast to the relevant Supported Asset Network, although they may be in a pending state, and designated accordingly, while the transaction is processed by network operators. Synonym does not control any Digital Asset network and makes no guarantees that a Wallet Asset Transfer will be confirmed by the network. We may cancel or refuse to process any pending Wallet Outbound Transfers as required by Law or any court or other authority to which Synonym is subject in any jurisdiction. Additionally, we may require you to wait some amount of time after completion of a transaction before permitting you to use further Bitkit Services and/or before permitting you to engage in transactions beyond certain volume limits."
                     )
-
                 }
 
                 // Lightning Connection Services
@@ -432,7 +428,6 @@ struct TosContent: View {
                     Text(
                         "5.5.8 You agree that any Fees are non-refundable, in whole or in part, even if your Blocktank Connection is closed prior to Connection Duration."
                     )
-
                 }
 
                 // Slashtags
@@ -472,7 +467,6 @@ struct TosContent: View {
                     Text(
                         "6.4 Slashtags can be used to create and to receive social profiles and dynamic content through the Bitkit Wallet. This content is User Content as described below and is not moderated, endorsed or verified by Synonym. Accordingly, it may contain content which is defamatory, obscene, indecent, abusive, offensive, harassing, violent, hateful, inflammatory, or otherwise objectionable. It may also violate Law, these Terms or the rights of any Person, including the intellectual property rights of any Person. User Content may be misleading, contain misstatements of fact or omit to state facts that a User might consider important."
                     )
-
                 }
 
                 // Content
@@ -548,7 +542,6 @@ struct TosContent: View {
                     Text(
                         "7.3.3 You access and use the Fiat Expressions entirely at your sole risk, and Synonym will not be responsible for any actions you take based on the Fiat Expressions."
                     )
-
                 }
 
                 // Feedback
@@ -558,7 +551,6 @@ struct TosContent: View {
                     Text(
                         "8.1 You may choose to, or we may invite you to, submit comments or ideas about the Bitkit Services, including without limitation about how to improve the Bitkit Services or our products (**\"Ideas\"**). By submitting any Idea, you agree that your disclosure is gratuitous, unsolicited and without restriction and will not place Synonym under any fiduciary or other obligation, and that Synonym and its Associates are free to use the Idea without any additional compensation to you, and/or to disclose the Idea on a non-confidential basis or otherwise to anyone and you grant Synonym and its Associates a worldwide, perpetual, irrevocable, non-exclusive, royalty-free license (with the right to sublicense) to any Intellectual Property Rights you may have in such Idea to use, including to improve the Bitkit Services, copy, reproduce, modify, publish, transmit, broadcast, display, and distribute. You further acknowledge that, by acceptance of your submission, Synonym does not waive any rights to use similar or related ideas previously known to Synonym, or developed by its employees, or obtained from sources other than you."
                     )
-
                 }
 
                 // Third Party Services
@@ -580,7 +572,6 @@ struct TosContent: View {
                     Text(
                         "9.3 WE MAKE NO WARRANTIES OR REPRESENTATIONS, EXPRESS OR IMPLIED, ABOUT LINKED THIRD PARTY SERVICES, THE THIRD PARTIES THEY ARE OWNED AND OPERATED BY, THE INFORMATION CONTAINED ON THEM, ASSETS AVAILABLE THROUGH THEM, OR THE SUITABILITY, PRIVACY, OR SECURITY OF THEIR PRODUCTS OR SERVICES. YOU ACKNOWLEDGE SOLE RESPONSIBILITY FOR AND ASSUME ALL RISK ARISING FROM YOUR USE OF THIRD-PARTY SERVICES, THIRD-PARTY WEBSITES, APPLICATIONS, OR RESOURCES, INCLUDING RISK OF LOSS FOR ASSETS TRADED THROUGH SUCH THIRD-PARTY SERVICES. IN NO EVENT WILL SYNONYM BE LIABLE FOR ANY DAMAGES ARISING OUT OF OR RELATING TO THIRD PARTY SERVICES. THIS SECTION OPERATES IN ADDITION TO ANY LIMITATION OF LIABILITY EXPRESSED ELSEWHERE IN THIS USER AGREEMENT."
                     )
-
                 }
 
                 // Prohibited Uses
@@ -654,7 +645,6 @@ struct TosContent: View {
                     Text(
                         "Any use as described in this Section 10 shall constitute a **\"Prohibited Use\"**. You must assure that any Wallet Asset Transfer, Routed Payment or other use by you of the Connection or the Bitkit Services is not a Prohibited Use. If Synonym determines or suspects that you have engaged in any Prohibited Use, Synonym may address such Prohibited Use through an appropriate sanction, in its sole and absolute discretion. Such sanction may include, without limitation: (i) force closing any active Blocktank Connection associated with you; (ii) making a report to any Government, law enforcement, or other authorities, without providing any notice of you about any such report; or (iii) suspending or terminating your access to any Bitkit Services. **In addition, should your actions or inaction result in Loss being suffered by Synonym or any of its Associates, you shall pay an amount to Synonym or the Associate so as to render Synonym or the Associate whole, including the amount of taxes or penalties that might be imposed on Synonym or the Associate.**"
                     )
-
                 }
 
                 // Information Obligations
@@ -668,7 +658,6 @@ struct TosContent: View {
                     Text(
                         "11.1 Synonym may, from time to time, request information regarding your use of any Bitkit Service. All information provided to Synonym must be true, accurate and not misleading in all respects. **In the event that there are any changes to any information provided to Synonym, you must inform Synonym of such changes in writing through **support@synonym.to** prior to such changes taking effect. Synonym reserves the right to cease to allow you to access the Bitkit Services at any time, including as a result of any change in information provided or a failure to provide any information when requested.**"
                     )
-
                 }
 
                 // Privacy
@@ -682,7 +671,6 @@ struct TosContent: View {
                     Text(
                         "12.1 The Bitkit Privacy Statement (available at bitkit.to/privacy-policy/) describes how Synonym handles any personal information and data that you provide to us when using the Bitkit Services. You acknowledge and agree that you have carefully read and understand the Synonym Privacy Statement."
                     )
-
                 }
 
                 // Representations, Warranties and Covenants
@@ -764,7 +752,6 @@ struct TosContent: View {
                     Text(
                         "13.1.17 you will accurately and promptly inform Synonym if you know or have reason to know whether any of the foregoing representations or warranties no longer is correct or becomes incorrect."
                     )
-
                 }
 
                 // No Representation by Synonym
@@ -790,7 +777,6 @@ struct TosContent: View {
                     Text(
                         "14.2.3 the functionality of the Lightning Network or any other Digital Asset network or protocol (including any technical glitch, malfunction, code error, failure, delay, default, or security breach thereof)."
                     )
-
                 }
 
                 // Mobile Application
@@ -824,7 +810,6 @@ struct TosContent: View {
                     Text(
                         "Fiat Expressions viewed through the Bitkit Wallet incorporate data available through the CoinGecko Application Programming Interface (together with its related documentation, the **\"CoinGecko API\"**). The CoinGecko API is the property of Gecko Labs Pte. Ltd. (**\"CoinGecko\"**), and your use of the CoinGecko API must comply with the then-current CoinGecko API Terms of Service. CoinGecko has no obligation or liability to you for your usage of the CoinGecko API through the Bitkit Wallet. Synonym, and not CoinGecko, is solely responsible for the Bitkit Wallet."
                     )
-
                 }
 
                 // Tax
@@ -838,7 +823,6 @@ struct TosContent: View {
                     Text(
                         "16.1 It is your sole responsibility to determine whether and to what extent taxes and tax reporting obligations may apply to you (including any goods and services tax) with respect to the transactions carried out through the Bitkit Services and you shall timely pay all such taxes and shall file all returns, reports, and disclosures required by applicable Law. You agree to indemnify and hold Synonym and its Associates harmless from and against any and all taxes (other than income or similar taxes on income earned by Synonym in providing the Bitkit Services) payable with respect to any transactions carried out through the Bitkit Services."
                     )
-
                 }
 
                 // No Insurance or Regulatory Oversight
@@ -852,7 +836,6 @@ struct TosContent: View {
                     Text(
                         "17.1 Synonym is not registered as a money services business or money transmitter in the British Virgin Islands or elsewhere. You accept that any balance standing in, or Routed Payment through, the Bitkit Wallet is not subject to regulatory oversight, protections or insurance provided by any Person. In addition, whilst Synonym may maintain insurance for its own benefit in connection with its business, the insurance, if maintained, is solely for the benefit of Synonym and does not guarantee or insure any User in any way."
                     )
-
                 }
 
                 // Responsibilities, Limitation of Liability and Indemnity
@@ -878,7 +861,6 @@ struct TosContent: View {
                     Text(
                         "18.3 To the fullest extent permissible by Law, the maximum aggregate monetary liability of Synonym under these Terms shall in no event exceed the fees paid by you to Synonym (if any) in respect of the Bitkit Services in relation to which the liability has arisen."
                     )
-
                 }
 
                 // Force Majeure
@@ -892,7 +874,6 @@ struct TosContent: View {
                     Text(
                         "19.1 Synonym is not responsible for Losses caused by delay or failure of Synonym, the Bitkit Wallet, the Blocktank Node or any Connection, including when the delay or failure is due to fires; strikes; floods; power outages or failures; acts of God or the state's enemies; disease pandemics; acts of any Government or Government Official; any and all market movements, shifts, or volatility; computer, server, protocol or internet malfunctions; security breaches or cyberattacks; criminal acts; delays or defaults caused by common carriers; acts or omissions of other Persons; or, any other delays, defaults, failures or interruptions that cannot reasonably be foreseen or provided against by Synonym."
                     )
-
                 }
 
                 // Arbitration
@@ -936,7 +917,6 @@ struct TosContent: View {
                     Text(
                         "**20.6 **JURY TRIAL WAIVER**. TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, THE PARTIES HEREBY IRREVOCABLY AND UNCONDITIONALLY WAIVE ALL RIGHT TO TRIAL BY JURY IN ANY LEGAL ACTION OR PROCEEDING OF ANY KIND WHATSOEVER ARISING OUT OF OR RELATING TO THESE TERMS OR ANY BREACH THEREOF, ANY USE OR ATTEMPTED USE OF THE BITKIT SERVICES BY YOU, AND/OR ANY OTHER MATTER INVOLVING THE USER AND SYNONYM.**"
                     )
-
                 }
 
                 // Miscellaneous

--- a/Bitkit/Views/Scanner/ScannerView.swift
+++ b/Bitkit/Views/Scanner/ScannerView.swift
@@ -23,9 +23,9 @@ struct ScannerView: View {
         ZStack {
             // Full screen scanner
             CodeScannerView(codeTypes: [.qr], shouldVibrateOnSuccess: false, isTorchOn: isFlashlightOn) { response in
-                if case .success(let result) = response {
+                if case let .success(result) = response {
                     handleScan(result.string)
-                } else if case .failure(let error) = response {
+                } else if case let .failure(error) = response {
                     Logger.error(error, context: "Failed to scan QR code")
                     app.toast(error)
                 }
@@ -139,7 +139,8 @@ struct ScannerView: View {
             app.toast(
                 type: .warning,
                 title: localizedString("wallet__send_clipboard_empty_title"),
-                description: localizedString("wallet__send_clipboard_empty_text"))
+                description: localizedString("wallet__send_clipboard_empty_text")
+            )
             return
         }
 
@@ -147,11 +148,11 @@ struct ScannerView: View {
     }
 
     func handleImageSelection(_ item: PhotosPickerItem?) async {
-        guard let item = item else { return }
+        guard let item else { return }
 
         do {
             guard let data = try await item.loadTransferable(type: Data.self),
-                let image = UIImage(data: data)
+                  let image = UIImage(data: data)
             else {
                 app.toast(
                     type: .error,
@@ -172,10 +173,10 @@ struct ScannerView: View {
             }
 
             let request = VNDetectBarcodesRequest { request, error in
-                if let error = error {
+                if let error {
                     Logger.error(error, context: "QR detection failed")
                     DispatchQueue.main.async {
-                        self.app.toast(
+                        app.toast(
                             type: .error,
                             title: "Detection Error",
                             description: "Failed to process the image for QR codes."
@@ -187,7 +188,7 @@ struct ScannerView: View {
                 guard let results = request.results as? [VNBarcodeObservation] else {
                     Logger.error("No barcode results found")
                     DispatchQueue.main.async {
-                        self.app.toast(
+                        app.toast(
                             type: .error,
                             title: "No QR Code Found",
                             description: "Sorry. Bitkit wasn't able to detect a QR code in this image."
@@ -199,10 +200,10 @@ struct ScannerView: View {
                 let qrResults = results.filter { $0.symbology == .qr }
 
                 guard let firstResult = qrResults.first,
-                    let payload = firstResult.payloadStringValue
+                      let payload = firstResult.payloadStringValue
                 else {
                     DispatchQueue.main.async {
-                        self.app.toast(
+                        app.toast(
                             type: .error,
                             title: "No QR Code Found",
                             description: "Sorry. Bitkit wasn't able to detect a QR code in this image."
@@ -212,7 +213,7 @@ struct ScannerView: View {
                 }
 
                 DispatchQueue.main.async {
-                    self.handleScan(payload)
+                    handleScan(payload)
                 }
             }
 
@@ -235,5 +236,4 @@ struct ScannerView: View {
 
         selectedItem = nil
     }
-
 }

--- a/Bitkit/Views/Security/AuthCheck.swift
+++ b/Bitkit/Views/Security/AuthCheck.swift
@@ -78,7 +78,8 @@ struct AuthCheck: View {
         if remainingAttempts == 1 {
             // Last attempt warning
             errorMessage = NSLocalizedString(
-                "security__pin_last_attempt", comment: "Last attempt. Entering the wrong PIN again will reset your wallet.")
+                "security__pin_last_attempt", comment: "Last attempt. Entering the wrong PIN again will reset your wallet."
+            )
         } else {
             // Show remaining attempts
             errorMessage = localizedString(

--- a/Bitkit/Views/Settings/AboutView.swift
+++ b/Bitkit/Views/Settings/AboutView.swift
@@ -12,7 +12,8 @@ struct AboutView: View {
     private var shareText: String {
         return localizedString(
             "settings__about__shareText",
-            variables: ["appStoreUrl": Env.appStoreUrl, "playStoreUrl": Env.playStoreUrl])
+            variables: ["appStoreUrl": Env.appStoreUrl, "playStoreUrl": Env.playStoreUrl]
+        )
     }
 
     var body: some View {

--- a/Bitkit/Views/Settings/Advanced/AddressViewer.swift
+++ b/Bitkit/Views/Settings/Advanced/AddressViewer.swift
@@ -1,10 +1,3 @@
-//
-//  AddressViewer.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2025/07/10.
-//
-
 import BitkitCore
 import SwiftUI
 
@@ -49,7 +42,7 @@ struct AddressViewer: View {
     // Get the index of the currently selected address
     private var selectedAddressIndex: Int {
         if !selectedAddress.isEmpty,
-            let index = addresses.firstIndex(where: { $0.address == selectedAddress })
+           let index = addresses.firstIndex(where: { $0.address == selectedAddress })
         {
             return index
         }
@@ -98,7 +91,6 @@ struct AddressViewer: View {
 
                     Spacer()
                 }
-
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 24)
@@ -111,7 +103,8 @@ struct AddressViewer: View {
                     .foregroundColor(.white64)
                 TextField(
                     NSLocalizedString("common__search", comment: ""), text: $searchText, backgroundColor: .clear,
-                    font: .custom(Fonts.regular, size: 17))
+                    font: .custom(Fonts.regular, size: 17)
+                )
             }
             .frame(height: 48)
             .padding(.horizontal)
@@ -293,7 +286,7 @@ struct AddressViewer: View {
             }
 
             // Automatically check balances for newly loaded addresses
-            await checkBalancesForNewAddresses(accountAddresses.unused.map { $0.address })
+            await checkBalancesForNewAddresses(accountAddresses.unused.map(\.address))
 
         } catch {
             await MainActor.run {
@@ -324,7 +317,7 @@ struct AddressViewer: View {
             }
 
             // Automatically check balances for newly loaded addresses
-            await checkBalancesForNewAddresses(accountAddresses.unused.map { $0.address })
+            await checkBalancesForNewAddresses(accountAddresses.unused.map(\.address))
 
         } catch {
             await MainActor.run {
@@ -340,7 +333,7 @@ struct AddressViewer: View {
         isLoadingBalances = true
 
         do {
-            let addressStrings = addresses.map { $0.address }
+            let addressStrings = addresses.map(\.address)
             let balances = try await CoreService.shared.utility.getMultipleAddressBalances(addresses: addressStrings)
 
             await MainActor.run {
@@ -404,7 +397,7 @@ struct AddressRow: View {
             Spacer()
 
             // Balance (only show if available)
-            if let balance = balance {
+            if let balance {
                 MoneyText(
                     sats: Int(balance),
                     size: .caption,

--- a/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
+++ b/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
@@ -20,7 +20,7 @@ struct AdvancedSettingsView: View {
                         Spacer()
                     }
 
-                    //Maybe never implemented
+                    // Maybe never implemented
                     // NavigationLink(destination: Text("Coming soon")) {
                     //     SettingsListLabel(
                     //         title: NSLocalizedString("settings__adv__address_type", comment: ""),

--- a/Bitkit/Views/Settings/Advanced/CloseConnectionConfirmation.swift
+++ b/Bitkit/Views/Settings/Advanced/CloseConnectionConfirmation.swift
@@ -72,10 +72,10 @@ struct CloseConnectionConfirmation: View {
             if failedChannels.isEmpty {
                 // Success - dismiss this view and show success toast
                 DispatchQueue.main.async {
-                    self.dismiss()
+                    dismiss()
 
                     // Show success toast
-                    self.app.toast(
+                    app.toast(
                         type: .success,
                         title: NSLocalizedString("lightning__close_success_title", comment: ""),
                         description: NSLocalizedString("lightning__close_success_msg", comment: "")

--- a/Bitkit/Views/Settings/Advanced/CoinSelectionSettingsView.swift
+++ b/Bitkit/Views/Settings/Advanced/CoinSelectionSettingsView.swift
@@ -1,10 +1,3 @@
-//
-//  CoinSelectionSettingsView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2025/06/27.
-//
-
 import LDKNode
 import SwiftUI
 
@@ -30,11 +23,11 @@ extension CoinSelectionAlgorithm {
             return NSLocalizedString("settings__adv__cs_first_in_first_out", comment: "")
         case .singleRandomDraw:
             return "Single Random Draw" // TODO: add missing localized text
-        // Commented out unsupported algorithms
-        // case .smallestFirst:
-        //     return NSLocalizedString("settings__adv__cs_max", comment: "")
-        // case .consolidate:
-        //     return NSLocalizedString("settings__adv__cs_consolidate", comment: "")
+            // Commented out unsupported algorithms
+            // case .smallestFirst:
+            //     return NSLocalizedString("settings__adv__cs_max", comment: "")
+            // case .consolidate:
+            //     return NSLocalizedString("settings__adv__cs_consolidate", comment: "")
         }
     }
 
@@ -48,11 +41,11 @@ extension CoinSelectionAlgorithm {
             return NSLocalizedString("settings__adv__cs_first_in_first_out_description", comment: "")
         case .singleRandomDraw:
             return "Random selection for privacy" // TODO: add missing localized text
-        // Commented out unsupported algorithms
-        // case .smallestFirst:
-        //     return NSLocalizedString("settings__adv__cs_max_description", comment: "")
-        // case .consolidate:
-        //     return NSLocalizedString("settings__adv__cs_consolidate_description", comment: "")
+            // Commented out unsupported algorithms
+            // case .smallestFirst:
+            //     return NSLocalizedString("settings__adv__cs_max_description", comment: "")
+            // case .consolidate:
+            //     return NSLocalizedString("settings__adv__cs_consolidate_description", comment: "")
         }
     }
 

--- a/Bitkit/Views/Settings/Advanced/LightningConnectionDetailView.swift
+++ b/Bitkit/Views/Settings/Advanced/LightningConnectionDetailView.swift
@@ -71,10 +71,12 @@ struct LightningConnectionDetailView: View {
                             Divider().padding(.horizontal, 16)
                             DetailRow(
                                 label: NSLocalizedString("lightning__transaction", comment: ""),
-                                value: truncateString(order.payment.onchain.address, length: 16))
+                                value: truncateString(order.payment.onchain.address, length: 16)
+                            )
                             Divider().padding(.horizontal, 16)
                             DetailRow(
-                                label: NSLocalizedString("lightning__order_fee", comment: ""), value: "₿ \(formatNumber(order.feeSat))", isLast: true)
+                                label: NSLocalizedString("lightning__order_fee", comment: ""), value: "₿ \(formatNumber(order.feeSat))", isLast: true
+                            )
                         }
                     }
                 }
@@ -90,19 +92,23 @@ struct LightningConnectionDetailView: View {
                     VStack(spacing: 0) {
                         DetailRow(
                             label: NSLocalizedString("lightning__receiving_label", comment: ""),
-                            value: "₿ \(formatNumber(channel.inboundCapacityMsat / 1000))", isFirst: true)
+                            value: "₿ \(formatNumber(channel.inboundCapacityMsat / 1000))", isFirst: true
+                        )
                         Divider().padding(.horizontal, 16)
                         DetailRow(
                             label: NSLocalizedString("lightning__spending_label", comment: ""),
-                            value: "₿ \(formatNumber(channel.outboundCapacityMsat / 1000))")
+                            value: "₿ \(formatNumber(channel.outboundCapacityMsat / 1000))"
+                        )
                         Divider().padding(.horizontal, 16)
                         DetailRow(
                             label: NSLocalizedString("lightning__reserve_balance", comment: ""),
-                            value: "₿ \(formatNumber(channel.unspendablePunishmentReserve ?? 0))")
+                            value: "₿ \(formatNumber(channel.unspendablePunishmentReserve ?? 0))"
+                        )
                         Divider().padding(.horizontal, 16)
                         DetailRow(
                             label: NSLocalizedString("lightning__total_size", comment: ""), value: "₿ \(formatNumber(channel.channelValueSats))",
-                            isLast: true)
+                            isLast: true
+                        )
                     }
                 }
 
@@ -136,16 +142,19 @@ struct LightningConnectionDetailView: View {
                             DetailRow(
                                 label: NSLocalizedString("lightning__opened_on", comment: ""),
                                 value: formattedDate,
-                                isFirst: true)
+                                isFirst: true
+                            )
                             Divider().padding(.horizontal, 16)
                             DetailRow(
                                 label: NSLocalizedString("lightning__channel_node_id", comment: ""),
-                                value: truncateString(channel.counterpartyNodeId.description, length: 16), isLast: true)
+                                value: truncateString(channel.counterpartyNodeId.description, length: 16), isLast: true
+                            )
                         } else {
                             DetailRow(
                                 label: NSLocalizedString("lightning__channel_node_id", comment: ""),
                                 value: truncateString(channel.counterpartyNodeId.description, length: 16),
-                                isFirst: true, isLast: true)
+                                isFirst: true, isLast: true
+                            )
                         }
                     }
                 }
@@ -264,7 +273,7 @@ struct LightningConnectionDetailView: View {
     }
 
     private func isValidDate(_ dateString: String?) -> Bool {
-        guard let dateString = dateString, !dateString.isEmpty else { return false }
+        guard let dateString, !dateString.isEmpty else { return false }
         return formatDate(dateString) != nil
     }
 

--- a/Bitkit/Views/Settings/Advanced/LightningConnectionsView.swift
+++ b/Bitkit/Views/Settings/Advanced/LightningConnectionsView.swift
@@ -38,7 +38,6 @@ struct LightningConnectionsView: View {
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
-
                 }
                 .padding(.top, 24)
                 .padding(.bottom, 16)
@@ -251,7 +250,7 @@ struct LightningConnectionsView: View {
 
     private var openChannels: [ChannelDetails] {
         guard let channels = wallet.channels else { return [] }
-        return channels.filter { $0.isChannelReady }
+        return channels.filter(\.isChannelReady)
     }
 
     private var closedConnections: [IBtOrder] {
@@ -296,8 +295,8 @@ struct LightningConnectionsView: View {
             let shortChannelIdString = String(shortChannelId)
             for order in orders {
                 if let orderChannel = order.channel,
-                    let orderShortChannelId = orderChannel.shortChannelId,
-                    orderShortChannelId == shortChannelIdString
+                   let orderShortChannelId = orderChannel.shortChannelId,
+                   orderShortChannelId == shortChannelIdString
                 {
                     return order
                 }
@@ -308,7 +307,7 @@ struct LightningConnectionsView: View {
         if let fundingTxo = channel.fundingTxo {
             for order in orders {
                 if let orderChannel = order.channel,
-                    orderChannel.fundingTx.id == fundingTxo.txid
+                   orderChannel.fundingTx.id == fundingTxo.txid
                 {
                     return order
                 }
@@ -319,7 +318,7 @@ struct LightningConnectionsView: View {
         let counterpartyNodeIdString = channel.counterpartyNodeId.description
         for order in orders {
             if let orderChannel = order.channel,
-                orderChannel.clientNodePubkey == counterpartyNodeIdString || orderChannel.lspNodePubkey == counterpartyNodeIdString
+               orderChannel.clientNodePubkey == counterpartyNodeIdString || orderChannel.lspNodePubkey == counterpartyNodeIdString
             {
                 return order
             }

--- a/Bitkit/Views/Settings/AppStatusView.swift
+++ b/Bitkit/Views/Settings/AppStatusView.swift
@@ -10,7 +10,7 @@ struct AppStatusView: View {
             NavigationLink(value: Route.node) {
                 lightningNodeStatusView
             }
-            lightningConnectionStatusView //TODO: navigate to channel list view
+            lightningConnectionStatusView // TODO: navigate to channel list view
         }
         .navigationTitle(NSLocalizedString("settings__status__title", comment: ""))
         .navigationBarTitleDisplayMode(.inline)
@@ -27,8 +27,8 @@ struct AppStatusView: View {
         let iconColor: Color = isConnected ? .greenAccent : .redAccent
         let status =
             isConnected
-            ? NSLocalizedString("settings__status__internet__ready", comment: "Connected")
-            : NSLocalizedString("settings__status__internet__error", comment: "Disconnected")
+                ? NSLocalizedString("settings__status__internet__ready", comment: "Connected")
+                : NSLocalizedString("settings__status__internet__error", comment: "Disconnected")
         let statusColor: Color = isConnected ? .greenAccent : .redAccent
 
         return StatusItemView(
@@ -54,8 +54,8 @@ struct AppStatusView: View {
 
     private var lightningConnectionStatusView: some View {
         let hasChannels = (wallet.channelCount > 0)
-        let hasUsableChannels = wallet.channels?.contains(where: { $0.isUsable }) ?? false
-        let hasReadyChannels = wallet.channels?.contains(where: { $0.isChannelReady }) ?? false
+        let hasUsableChannels = wallet.channels?.contains(where: \.isUsable) ?? false
+        let hasReadyChannels = wallet.channels?.contains(where: \.isChannelReady) ?? false
 
         let connectionColor: Color = {
             if !hasChannels {

--- a/Bitkit/Views/Settings/Backup/BackupSettings.swift
+++ b/Bitkit/Views/Settings/Backup/BackupSettings.swift
@@ -30,10 +30,10 @@ private struct StatusItemView: View {
         case .running:
             // return "Running"
             return "Dummy Status"
-        case .required(let timestamp):
+        case let .required(timestamp):
             // return "Required"
             return "Dummy Status"
-        case .synced(let timestamp):
+        case let .synced(timestamp):
             // return "Synced"
             return "Dummy Status"
         }

--- a/Bitkit/Views/Settings/DevSettingsView.swift
+++ b/Bitkit/Views/Settings/DevSettingsView.swift
@@ -69,7 +69,7 @@ struct DevSettingsView: View {
                             )
 
                             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                                let window = windowScene.windows.first
+                               let window = windowScene.windows.first
                             {
                                 window.rootViewController?.present(activityViewController, animated: true)
                             }

--- a/Bitkit/Views/Settings/General/DefaultUnitSettingsView.swift
+++ b/Bitkit/Views/Settings/General/DefaultUnitSettingsView.swift
@@ -64,7 +64,7 @@ struct DefaultUnitSettingsView: View {
 
 // Helper for conditional modifiers
 extension View {
-    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+    @ViewBuilder func `if`(_ condition: Bool, transform: (Self) -> some View) -> some View {
         if condition {
             transform(self)
         } else {

--- a/Bitkit/Views/Settings/LogView.swift
+++ b/Bitkit/Views/Settings/LogView.swift
@@ -1,10 +1,3 @@
-//
-//  LogView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/16.
-//
-
 import SwiftUI
 import UIKit
 
@@ -30,12 +23,12 @@ struct LogView: View {
         .navigationTitle("Log Files")
         .navigationBarItems(
             trailing:
-                Button(action: {
-                    showingDeleteConfirmation = true
-                }) {
-                    Image(systemName: "trash")
-                }
-                .disabled(logFiles.isEmpty)
+            Button(action: {
+                showingDeleteConfirmation = true
+            }) {
+                Image(systemName: "trash")
+            }
+            .disabled(logFiles.isEmpty)
         )
         .alert("Delete All Logs", isPresented: $showingDeleteConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -61,33 +54,33 @@ struct LogView: View {
         ) {
             let logFiles =
                 logURLs
-                .filter { $0.pathExtension == "log" }
-                .map { url -> LogFile in
-                    let fileName = url.lastPathComponent
-                    let components = fileName.components(separatedBy: "_")
+                    .filter { $0.pathExtension == "log" }
+                    .map { url -> LogFile in
+                        let fileName = url.lastPathComponent
+                        let components = fileName.components(separatedBy: "_")
 
-                    // First component is the service name (e.g., "bitkit" or "ldk")
-                    let serviceName = components.first?.capitalized ?? "Unknown"
+                        // First component is the service name (e.g., "bitkit" or "ldk")
+                        let serviceName = components.first?.capitalized ?? "Unknown"
 
-                    // Format the date from the timestamp component (should be near the end)
-                    let timestamp = components.count >= 3 ? components[components.count - 2] : ""
+                        // Format the date from the timestamp component (should be near the end)
+                        let timestamp = components.count >= 3 ? components[components.count - 2] : ""
 
-                    // Create a display name showing service and date
-                    let displayName = "\(serviceName) Log: \(timestamp)"
+                        // Create a display name showing service and date
+                        let displayName = "\(serviceName) Log: \(timestamp)"
 
-                    return LogFile(displayName: displayName, url: url)
-                }
-                .sorted { (lhs, rhs) -> Bool in
-                    // Try to get creation dates, fall back to modification dates if needed
-                    let lhsResourceValues = try? lhs.url.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
-                    let rhsResourceValues = try? rhs.url.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
+                        return LogFile(displayName: displayName, url: url)
+                    }
+                    .sorted { lhs, rhs -> Bool in
+                        // Try to get creation dates, fall back to modification dates if needed
+                        let lhsResourceValues = try? lhs.url.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
+                        let rhsResourceValues = try? rhs.url.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
 
-                    let lhsDate = lhsResourceValues?.creationDate ?? lhsResourceValues?.contentModificationDate ?? Date.distantPast
-                    let rhsDate = rhsResourceValues?.creationDate ?? rhsResourceValues?.contentModificationDate ?? Date.distantPast
+                        let lhsDate = lhsResourceValues?.creationDate ?? lhsResourceValues?.contentModificationDate ?? Date.distantPast
+                        let rhsDate = rhsResourceValues?.creationDate ?? rhsResourceValues?.contentModificationDate ?? Date.distantPast
 
-                    // Sort descending (newest first)
-                    return lhsDate > rhsDate
-                }
+                        // Sort descending (newest first)
+                        return lhsDate > rhsDate
+                    }
 
             files.append(contentsOf: logFiles)
         }
@@ -139,9 +132,9 @@ struct LogContentView: View {
         .navigationTitle(logFile.displayName)
         .navigationBarItems(
             trailing:
-                Button(action: { showShareSheet = true }) {
-                    Image(systemName: "square.and.arrow.up")
-                }
+            Button(action: { showShareSheet = true }) {
+                Image(systemName: "square.and.arrow.up")
+            }
         )
         .sheet(isPresented: $showShareSheet) {
             ShareSheet(activityItems: [prepareFileForSharing(logFile.url)])

--- a/Bitkit/Views/Settings/Security/DisablePinView.swift
+++ b/Bitkit/Views/Settings/Security/DisablePinView.swift
@@ -1,10 +1,3 @@
-//
-//  DisablePinView.swift
-//  Bitkit
-//
-//  Created by Assistant on 2024/12/19.
-//
-
 import SwiftUI
 
 struct DisablePinView: View {

--- a/Bitkit/Views/Settings/Security/PinChangeView.swift
+++ b/Bitkit/Views/Settings/Security/PinChangeView.swift
@@ -179,7 +179,6 @@ struct PinChangeView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-
             if step == .success {
                 successScreen
             } else {

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityBiometrics.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityBiometrics.swift
@@ -105,7 +105,7 @@ struct SecurityBiometrics: View {
     }
 
     private func handleBiometricError(_ error: Error?) {
-        guard let error = error else { return }
+        guard let error else { return }
 
         let nsError = error as NSError
 

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityPin.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityPin.swift
@@ -53,7 +53,7 @@ struct SecurityPin: View {
     }
 
     private func handlePinComplete(_ pin: String) {
-        if let pinToCheck = pinToCheck {
+        if let pinToCheck {
             // This is the confirmation step
             if pin == pinToCheck {
                 // PINs match, save via SettingsViewModel and check biometric enrollment
@@ -78,7 +78,7 @@ struct SecurityPin: View {
             }
         } else {
             // This is the initial PIN entry, set pinToCheck and reset input for confirmation
-            self.pinToCheck = pin
+            pinToCheck = pin
             pinInput = ""
             errorMessage = ""
         }

--- a/Bitkit/Views/Settings/SecurityPrivacySettingsView.swift
+++ b/Bitkit/Views/Settings/SecurityPrivacySettingsView.swift
@@ -122,7 +122,8 @@ struct SecurityPrivacySettingsView: View {
                     SettingsListLabel(
                         title: localizedString(
                             "settings__security__use_bio", comment: "",
-                            variables: ["biometryTypeName": biometryTypeName]),
+                            variables: ["biometryTypeName": biometryTypeName]
+                        ),
                         toggle: Binding(
                             get: { settings.useBiometrics },
                             set: { newValue in
@@ -250,7 +251,7 @@ struct SecurityPrivacySettingsView: View {
     }
 
     private func handleBiometricError(_ error: Error?) {
-        guard let error = error else { return }
+        guard let error else { return }
 
         let nsError = error as NSError
 

--- a/Bitkit/Views/Settings/Support/ReportIssue.swift
+++ b/Bitkit/Views/Settings/Support/ReportIssue.swift
@@ -70,7 +70,7 @@ struct ReportIssue: View {
 
             // Check response
             if let httpResponse = response as? HTTPURLResponse,
-                (200 ... 299).contains(httpResponse.statusCode)
+               (200 ... 299).contains(httpResponse.statusCode)
             {
                 // Success - reset form and show success screen
                 email = ""

--- a/Bitkit/Views/Settings/TransactionSpeed/CustomSpeedView.swift
+++ b/Bitkit/Views/Settings/TransactionSpeed/CustomSpeedView.swift
@@ -36,15 +36,17 @@ struct CustomSpeedView: View {
                                 "feeSats": String(totalFee),
                                 "fiatSymbol": fiatAmount.symbol,
                                 "fiatFormatted": fiatAmount.formatted,
-                            ])
+                            ]
+                        )
                     )
                 } else {
                     BodyMText(
                         localizedString(
                             "settings__general__speed_fee_total",
                             variables: [
-                                "feeSats": String(totalFee)
-                            ])
+                                "feeSats": String(totalFee),
+                            ]
+                        )
                     )
                 }
             }
@@ -72,7 +74,7 @@ struct CustomSpeedView: View {
         .bottomSafeAreaPadding()
         .onAppear {
             // Initialize from current setting if it's custom
-            if case .custom(let currentRate) = settings.defaultTransactionSpeed {
+            if case let .custom(currentRate) = settings.defaultTransactionSpeed {
                 feeRate = currentRate
             }
         }
@@ -90,11 +92,10 @@ struct CustomSpeedView: View {
             }
         } else {
             // Handle leading zero
-            let newString: String
-            if current == "0" {
-                newString = key
+            let newString: String = if current == "0" {
+                key
             } else {
-                newString = current + key
+                current + key
             }
 
             // Limit to 3 digits (max 999 sat/vB)

--- a/Bitkit/Views/Settings/TransactionSpeed/TransactionSpeedSettingsView.swift
+++ b/Bitkit/Views/Settings/TransactionSpeed/TransactionSpeedSettingsView.swift
@@ -8,7 +8,7 @@ struct TransactionSpeedSettingsRow: View {
 
     var iconColor: Color {
         switch speed {
-        case .custom(_):
+        case .custom:
             return .textSecondary
         default:
             return .brandAccent

--- a/Bitkit/Views/Sheets/LnurlAuth/LnurlAuthSheet.swift
+++ b/Bitkit/Views/Sheets/LnurlAuth/LnurlAuthSheet.swift
@@ -101,7 +101,7 @@ struct LnurlAuthSheet: View {
 
     private var extractedDomain: String {
         guard let url = URL(string: config.authData.uri),
-            let host = url.host
+              let host = url.host
         else {
             return "Unknown Domain"
         }

--- a/Bitkit/Views/Sheets/Sheet.swift
+++ b/Bitkit/Views/Sheets/Sheet.swift
@@ -7,8 +7,8 @@ enum SheetSize {
         let screenHeight = UIScreen.screenHeight
         let safeAreaInsets =
             UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .first?.windows.first?.safeAreaInsets ?? .zero
+                .compactMap { $0 as? UIWindowScene }
+                .first?.windows.first?.safeAreaInsets ?? .zero
         let headerHeight: CGFloat = 46
         let balanceHeight: CGFloat = 70
         let spacing: CGFloat = 32
@@ -72,7 +72,7 @@ struct SheetHeader: View {
             SubtitleText(title)
                 .frame(maxWidth: .infinity, alignment: .center)
 
-            if let action = action {
+            if let action {
                 action
             } else {
                 Spacer()
@@ -97,7 +97,7 @@ struct Sheet<Content: View>: View {
     let content: () -> Content
 
     init(id: SheetID, data: (any SheetItem)? = nil, @ViewBuilder content: @escaping () -> Content) {
-        self.configuration = SheetConfiguration(id: id, data: data)
+        configuration = SheetConfiguration(id: id, data: data)
         self.content = content
     }
 

--- a/Bitkit/Views/Shop/ShopDiscover.swift
+++ b/Bitkit/Views/Shop/ShopDiscover.swift
@@ -137,6 +137,7 @@ struct ShopDiscover: View {
 }
 
 // MARK: - Shop Discover Card Component
+
 struct ShopDiscoverCard: View {
     let title: String
     let description: String
@@ -187,6 +188,7 @@ struct ShopDiscoverCard: View {
 }
 
 // MARK: - Shop Category Row Component
+
 struct ShopCategoryRow: View {
     let title: String
     let iconName: String

--- a/Bitkit/Views/Shop/ShopMain.swift
+++ b/Bitkit/Views/Shop/ShopMain.swift
@@ -38,12 +38,12 @@ struct ShopMain: View {
     private func handleMessage(_ message: String) {
         // Parse the message as a JSON-encoded string
         guard let messageData = message.data(using: .utf8),
-            let jsonString = try? JSONSerialization.jsonObject(with: messageData, options: .allowFragments) as? String,
-            let innerData = jsonString.data(using: .utf8),
-            let json = try? JSONSerialization.jsonObject(with: innerData) as? [String: Any],
-            let event = json["event"] as? String,
-            event == "payment_intent",
-            let paymentUri = json["paymentUri"] as? String
+              let jsonString = try? JSONSerialization.jsonObject(with: messageData, options: .allowFragments) as? String,
+              let innerData = jsonString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: innerData) as? [String: Any],
+              let event = json["event"] as? String,
+              event == "payment_intent",
+              let paymentUri = json["paymentUri"] as? String
         else {
             return
         }
@@ -117,10 +117,10 @@ struct WebView: UIViewRepresentable {
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             // Inject JavaScript to capture postMessage events
             let script = """
-                    window.addEventListener('message', function(event) {
-                        window.webkit.messageHandlers.messageHandler.postMessage(JSON.stringify(event.data));
-                    });
-                """
+                window.addEventListener('message', function(event) {
+                    window.webkit.messageHandlers.messageHandler.postMessage(JSON.stringify(event.data));
+                });
+            """
             webView.evaluateJavaScript(script)
         }
     }

--- a/Bitkit/Views/Transfer/FundManualSetupView.swift
+++ b/Bitkit/Views/Transfer/FundManualSetupView.swift
@@ -134,7 +134,7 @@ struct FundManualSetupView: View {
             )
         }
         .onAppear {
-            if let initialNodeUri = initialNodeUri {
+            if let initialNodeUri {
                 parseNodeUri(initialNodeUri)
             }
         }

--- a/Bitkit/Views/Transfer/FundManualSuccessView.swift
+++ b/Bitkit/Views/Transfer/FundManualSuccessView.swift
@@ -18,7 +18,8 @@ struct FundManualSuccessView: View {
 
                 BodyMText(
                     NSLocalizedString("lightning__external_success__text", comment: ""),
-                    textColor: .textSecondary, accentColor: .white, accentFont: Fonts.bold)
+                    textColor: .textSecondary, accentColor: .white, accentFont: Fonts.bold
+                )
 
                 Spacer()
 

--- a/Bitkit/Views/Transfer/LnurlChannel.swift
+++ b/Bitkit/Views/Transfer/LnurlChannel.swift
@@ -14,7 +14,7 @@ struct LnurlChannel: View {
 
     // Parse the node URI to extract node, host, and port
     private var parsedUri: LnPeer {
-        guard let channelInfo = channelInfo else {
+        guard let channelInfo else {
             return LnPeer(nodeId: "", host: "", port: 0)
         }
 
@@ -164,11 +164,11 @@ struct LnurlChannel: View {
 
             await MainActor.run {
                 self.channelInfo = channelInfo
-                self.isLoadingChannelInfo = false
+                isLoadingChannelInfo = false
             }
         } catch {
             await MainActor.run {
-                self.isLoadingChannelInfo = false
+                isLoadingChannelInfo = false
             }
         }
     }

--- a/Bitkit/Views/Transfer/SavingsAdvancedView.swift
+++ b/Bitkit/Views/Transfer/SavingsAdvancedView.swift
@@ -13,11 +13,11 @@ struct SavingsAdvancedView: View {
 
         return
             channels
-            .filter { transfer.selectedChannelIds.contains($0.channelId) }
-            .reduce(0) { total, channel in
-                let balance = channel.outboundCapacityMsat / 1000 + (channel.unspendablePunishmentReserve ?? 0)
-                return total + balance
-            }
+                .filter { transfer.selectedChannelIds.contains($0.channelId) }
+                .reduce(0) { total, channel in
+                    let balance = channel.outboundCapacityMsat / 1000 + (channel.unspendablePunishmentReserve ?? 0)
+                    return total + balance
+                }
     }
 
     var body: some View {
@@ -57,7 +57,7 @@ struct SavingsAdvancedView: View {
         .bottomSafeAreaPadding()
         .task {
             if transfer.selectedChannelIds.isEmpty, let channels = wallet.channels {
-                transfer.selectedChannelIds = channels.map { $0.channelId }
+                transfer.selectedChannelIds = channels.map(\.channelId)
             }
         }
     }

--- a/Bitkit/Views/Transfer/SavingsConfirmView.swift
+++ b/Bitkit/Views/Transfer/SavingsConfirmView.swift
@@ -1,10 +1,3 @@
-//
-//  SavingsConfirmView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/13.
-//
-
 import LDKNode
 import SwiftUI
 
@@ -19,7 +12,7 @@ struct SavingsConfirmView: View {
 
     private var hasMultipleChannels: Bool {
         guard let channels = wallet.channels else { return false }
-        return channels.filter { $0.isChannelReady }.count > 1
+        return channels.filter(\.isChannelReady).count > 1
     }
 
     private var hasSelectedChannels: Bool {
@@ -28,7 +21,7 @@ struct SavingsConfirmView: View {
 
     private var channels: [ChannelDetails] {
         guard let channels = wallet.channels else { return [] }
-        let usableChannels = channels.filter { $0.isChannelReady }
+        let usableChannels = channels.filter(\.isChannelReady)
 
         if transfer.selectedChannelIds.isEmpty {
             return usableChannels
@@ -118,7 +111,8 @@ struct SavingsConfirmView: View {
                 {
                     let vm = TransferViewModel()
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }

--- a/Bitkit/Views/Transfer/SavingsProgressView.swift
+++ b/Bitkit/Views/Transfer/SavingsProgressView.swift
@@ -1,10 +1,3 @@
-//
-//  SavingsProgressView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2025/03/21.
-//
-
 import SwiftUI
 
 enum SavingsProgressState {

--- a/Bitkit/Views/Transfer/SettingUpView.swift
+++ b/Bitkit/Views/Transfer/SettingUpView.swift
@@ -198,7 +198,8 @@ struct SettingUpView: View {
                     vm.onOrderCreated(order: IBtOrder.mock(state2: .created))
                     vm.lightningSetupStep = 0
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }
@@ -213,7 +214,8 @@ struct SettingUpView: View {
                     vm.onOrderCreated(order: IBtOrder.mock(state2: .paid))
                     vm.lightningSetupStep = 1
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }
@@ -228,7 +230,8 @@ struct SettingUpView: View {
                     vm.onOrderCreated(order: IBtOrder.mock(state2: .executed))
                     vm.lightningSetupStep = 2
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }
@@ -243,7 +246,8 @@ struct SettingUpView: View {
                     vm.onOrderCreated(order: IBtOrder.mock(state2: .executed, channel: .mock()))
                     vm.lightningSetupStep = 4
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }

--- a/Bitkit/Views/Transfer/SpendingAdvancedView.swift
+++ b/Bitkit/Views/Transfer/SpendingAdvancedView.swift
@@ -1,10 +1,3 @@
-//
-//  SpendingAdvancedView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/12.
-//
-
 import BitkitCore
 import SwiftUI
 
@@ -54,7 +47,7 @@ struct SpendingAdvancedView: View {
                 HStack(spacing: 4) {
                     CaptionMText(localizedString("lightning__spending_advanced__fee"))
 
-                    if let feeEstimate = feeEstimate {
+                    if let feeEstimate {
                         MoneyText(sats: Int(feeEstimate), size: .bodySSB, symbol: true)
                     } else {
                         CaptionMText("—")

--- a/Bitkit/Views/Transfer/SpendingAmount.swift
+++ b/Bitkit/Views/Transfer/SpendingAmount.swift
@@ -89,7 +89,8 @@ struct SpendingAmount: View {
                     vm.selectedCurrency = "USD"
                     vm.primaryDisplay = .fiat
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }
@@ -107,7 +108,8 @@ struct SpendingAmount: View {
                     vm.selectedCurrency = "EUR"
                     vm.primaryDisplay = .fiat
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }
@@ -125,7 +127,8 @@ struct SpendingAmount: View {
                     vm.primaryDisplay = .bitcoin
                     vm.displayUnit = .modern
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }
@@ -143,7 +146,8 @@ struct SpendingAmount: View {
                     vm.primaryDisplay = .bitcoin
                     vm.displayUnit = .classic
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }

--- a/Bitkit/Views/Transfer/SpendingConfirm.swift
+++ b/Bitkit/Views/Transfer/SpendingConfirm.swift
@@ -137,7 +137,8 @@ private struct SpendingDetailRow: View {
                     let vm = TransferViewModel()
                     vm.onOrderCreated(order: IBtOrder.mock())
                     return vm
-                }())
+                }()
+            )
     }
     .preferredColorScheme(.dark)
 }

--- a/Bitkit/Views/Transfer/TransferLearnMoreView.swift
+++ b/Bitkit/Views/Transfer/TransferLearnMoreView.swift
@@ -1,10 +1,3 @@
-//
-//  TransferLearnMoreView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/12.
-//
-
 import BitkitCore
 import SwiftUI
 

--- a/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
@@ -9,17 +9,17 @@ struct ActivityExplorerView: View {
     @EnvironmentObject var currency: CurrencyViewModel
 
     private var onchain: OnchainActivity? {
-        guard case .onchain(let activity) = item else { return nil }
+        guard case let .onchain(activity) = item else { return nil }
         return activity
     }
 
     private var lightning: LightningActivity? {
-        guard case .lightning(let activity) = item else { return nil }
+        guard case let .lightning(activity) = item else { return nil }
         return activity
     }
 
     private var paymentHash: String? {
-        guard case .lightning(let activity) = item else { return nil }
+        guard case let .lightning(activity) = item else { return nil }
         return activity.id
     }
 
@@ -35,9 +35,9 @@ struct ActivityExplorerView: View {
     @ViewBuilder
     private var amountView: some View {
         switch item {
-        case .lightning(let activity):
+        case let .lightning(activity):
             MoneyStack(sats: Int(activity.value), prefix: activity.txType == .sent ? "-" : "+", showSymbol: false)
-        case .onchain(let activity):
+        case let .onchain(activity):
             MoneyStack(sats: Int(activity.value), prefix: activity.txType == .sent ? "-" : "+", showSymbol: false)
         }
     }
@@ -82,7 +82,7 @@ struct ActivityExplorerView: View {
             .padding(.vertical)
             .padding(.bottom, 16)
 
-            if let onchain = onchain {
+            if let onchain {
                 InfoSection(
                     title: localizedString("wallet__activity_tx_id"),
                     content: onchain.txId,
@@ -107,7 +107,7 @@ struct ActivityExplorerView: View {
 
                 Divider()
                     .padding(.bottom, 16)
-            } else if let lightning = lightning {
+            } else if let lightning {
                 if let preimage = lightning.preimage {
                     InfoSection(
                         title: localizedString("wallet__activity_preimage"),
@@ -115,7 +115,7 @@ struct ActivityExplorerView: View {
                     )
                 }
 
-                if let paymentHash = paymentHash {
+                if let paymentHash {
                     InfoSection(
                         title: localizedString("wallet__activity_payment_hash"),
                         content: paymentHash,
@@ -132,8 +132,8 @@ struct ActivityExplorerView: View {
 
             if onchain != nil {
                 CustomButton(title: localizedString("common__open_block_explorer"), shouldExpand: true) {
-                    if let onchain = onchain,
-                        let url = getBlockExplorerUrl(txId: onchain.txId)
+                    if let onchain,
+                       let url = getBlockExplorerUrl(txId: onchain.txId)
                     {
                         UIApplication.shared.open(url)
                     }
@@ -157,10 +157,10 @@ struct ActivityExplorer_Previews: PreviewProvider {
                         id: "test-lightning-1",
                         txType: .received,
                         status: .succeeded,
-                        value: 50_000,
+                        value: 50000,
                         fee: 1,
                         invoice:
-                            "lnbc500n1p3hk3hgpp5ygx8cnfds9x49rp2mwxhcqpvdp4xys5pcxg95tyc2mrqz8dskvvsdq5g9kxy7fqd9h8vmmfvdjscqzpgxqyz5vqsp5usyc4l9c2y2funvqp0gsq3u7yws2h0pjkm984dlv6rvhtevk4ms9qyyssqzpvy9gyzjc0xsmp9gk4w2rlp3ezs5f3k2cxqzfmjh8mcst8zps4stu8qf0egyn7vgx8k9dvrbr7znlkc9s67x8j88t0y4mu5m7c4kcpj8wcr3",
+                        "lnbc500n1p3hk3hgpp5ygx8cnfds9x49rp2mwxhcqpvdp4xys5pcxg95tyc2mrqz8dskvvsdq5g9kxy7fqd9h8vmmfvdjscqzpgxqyz5vqsp5usyc4l9c2y2funvqp0gsq3u7yws2h0pjkm984dlv6rvhtevk4ms9qyyssqzpvy9gyzjc0xsmp9gk4w2rlp3ezs5f3k2cxqzfmjh8mcst8zps4stu8qf0egyn7vgx8k9dvrbr7znlkc9s67x8j88t0y4mu5m7c4kcpj8wcr3",
                         message: "Test payment",
                         timestamp: UInt64(Date().timeIntervalSince1970),
                         preimage: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",

--- a/Bitkit/Views/Wallets/Activity/ActivityIcon.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityIcon.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import BitkitCore
+import SwiftUI
 
 struct ActivityIcon: View {
     let isLightning: Bool
@@ -11,16 +11,16 @@ struct ActivityIcon: View {
     init(activity: Activity, size: CGFloat = 32) {
         self.size = size
         switch activity {
-        case .lightning(let ln):
-            self.isLightning = true
-            self.status = ln.status
-            self.confirmed = nil
-            self.txType = ln.txType
-        case .onchain(let onchain):
-            self.isLightning = false
-            self.status = nil
-            self.confirmed = onchain.confirmed
-            self.txType = onchain.txType
+        case let .lightning(ln):
+            isLightning = true
+            status = ln.status
+            confirmed = nil
+            txType = ln.txType
+        case let .onchain(onchain):
+            isLightning = false
+            status = nil
+            confirmed = onchain.confirmed
+            txType = onchain.txType
         }
     }
 

--- a/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
@@ -1,10 +1,3 @@
-//
-//  ActivityItemView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/18.
-//
-
 import BitkitCore
 import LDKNode
 import SwiftUI
@@ -24,9 +17,9 @@ struct ActivityItemView: View {
 
     private var isSent: Bool {
         switch viewModel.activity {
-        case .lightning(let activity):
+        case let .lightning(activity):
             return activity.txType == .sent
-        case .onchain(let activity):
+        case let .onchain(activity):
             return activity.txType == .sent
         }
     }
@@ -44,7 +37,7 @@ struct ActivityItemView: View {
         switch viewModel.activity {
         case .lightning:
             return false
-        case .onchain(let activity):
+        case let .onchain(activity):
             return activity.isTransfer
         }
     }
@@ -55,9 +48,9 @@ struct ActivityItemView: View {
 
     private var activity: (timestamp: UInt64, fee: UInt64?, value: UInt64) {
         switch viewModel.activity {
-        case .lightning(let activity):
+        case let .lightning(activity):
             return (activity.timestamp, activity.fee, activity.value)
-        case .onchain(let activity):
+        case let .onchain(activity):
             return (activity.timestamp, activity.fee, activity.value)
         }
     }
@@ -87,7 +80,7 @@ struct ActivityItemView: View {
         case .lightning:
             // Lightning transactions can never be boosted
             return true
-        case .onchain(let activity):
+        case let .onchain(activity):
             // Disable boost for onchain if transaction is confirmed or already boosted
             return activity.confirmed == true || activity.isBoosted
         }
@@ -136,9 +129,9 @@ struct ActivityItemView: View {
     @ViewBuilder
     private var amountView: some View {
         switch viewModel.activity {
-        case .lightning(let activity):
+        case let .lightning(activity):
             MoneyStack(sats: Int(activity.value), prefix: amountPrefix, showSymbol: false)
-        case .onchain(let activity):
+        case let .onchain(activity):
             MoneyStack(sats: Int(activity.value), prefix: amountPrefix, showSymbol: false)
         }
     }
@@ -157,7 +150,7 @@ struct ActivityItemView: View {
 
             HStack(spacing: 4) {
                 switch viewModel.activity {
-                case .lightning(let activity):
+                case let .lightning(activity):
                     switch activity.status {
                     case .pending:
                         Image("hourglass-simple")
@@ -175,7 +168,7 @@ struct ActivityItemView: View {
                             .frame(width: 16, height: 16)
                         BodySSBText(localizedString("wallet__activity_failed"), textColor: .purpleAccent)
                     }
-                case .onchain(let activity):
+                case let .onchain(activity):
                     if activity.confirmed == true {
                         Image("check-circle")
                             .foregroundColor(.greenAccent)
@@ -185,7 +178,11 @@ struct ActivityItemView: View {
                         Image("hourglass-simple")
                             .foregroundColor(.yellowAccent)
                             .frame(width: 16, height: 16)
-                        BodySSBText(localizedString("wallet__activity_confirms_in_boosted", variables: ["feeRateDescription": localizedString("fee__fast__shortDescription")]), textColor: .yellowAccent)
+                        BodySSBText(
+                            localizedString("wallet__activity_confirms_in_boosted",
+                                            variables: ["feeRateDescription": localizedString("fee__fast__shortDescription")]),
+                            textColor: .yellowAccent
+                        )
                     } else {
                         Image("hourglass-simple")
                             .foregroundColor(.brandAccent)
@@ -298,7 +295,8 @@ struct ActivityItemView: View {
                                 Task {
                                     await viewModel.removeTag(tag)
                                 }
-                            })
+                            }
+                        )
                     }
                 }
                 .padding(.bottom, 16)
@@ -310,7 +308,7 @@ struct ActivityItemView: View {
 
     @ViewBuilder
     private var note: some View {
-        if case .lightning(let activity) = viewModel.activity {
+        if case let .lightning(activity) = viewModel.activity {
             if !activity.message.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
                     CaptionText(localizedString("wallet__activity_invoice_note"))
@@ -339,7 +337,8 @@ struct ActivityItemView: View {
                     title: localizedString("wallet__activity_assign"), size: .small,
                     icon: Image("user-plus")
                         .foregroundColor(accentColor),
-                    shouldExpand: true)
+                    shouldExpand: true
+                )
 
                 CustomButton(
                     title: localizedString("wallet__activity_tag"), size: .small,
@@ -347,12 +346,11 @@ struct ActivityItemView: View {
                         .foregroundColor(accentColor),
                     shouldExpand: true
                 ) {
-                    let activityId: String
-                    switch viewModel.activity {
-                    case .lightning(let activity):
-                        activityId = activity.id
-                    case .onchain(let activity):
-                        activityId = activity.id
+                    let activityId: String = switch viewModel.activity {
+                    case let .lightning(activity):
+                        activity.id
+                    case let .onchain(activity):
+                        activity.id
                     }
                     sheets.showSheet(.addTag, data: AddTagConfig(activityId: activityId))
                 }
@@ -368,7 +366,7 @@ struct ActivityItemView: View {
                     shouldExpand: true
                 ) {
                     // Only show boost sheet for onchain activities
-                    if case .onchain(let onchainActivity) = viewModel.activity {
+                    if case let .onchain(onchainActivity) = viewModel.activity {
                         sheets.showSheet(.boost, data: BoostConfig(onchainActivity: onchainActivity))
                     }
                 }
@@ -430,13 +428,14 @@ struct ActivityItemView_Previews: PreviewProvider {
                         value: 50000,
                         fee: 1,
                         invoice:
-                            "lnbcrt30u1p5ppdlupp5rs2w7htserff3zcwaz3ds205y8zzj4ax82qx6f4zj0f0lxzs7nasdqqcqzzsxqy9gcqsp59h735hvajjauzewf5dsemldwgra9mrfff3eha0mwqx2n7tp4wlmq9p4gqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqysgqymzf4jnknunl6kxx2977xdy3g53m4wz9y8cds40v6ex89tct8tv8gzw40ddem70gfyr9nlfgadtzr6rk5cxuxknjx2j4ef998q8ga3sqhqlcux",
+                        "lnbcrt30u1p5ppdlupp5rs2w7htserff3zcwaz3ds205y8zzj4ax82qx6f4zj0f0lxzs7nasdqqcqzzsxqy9gcqsp59h735hvajjauzewf5dsemldwgra9mrfff3eha0mwqx2n7tp4wlmq9p4gqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqysgqymzf4jnknunl6kxx2977xdy3g53m4wz9y8cds40v6ex89tct8tv8gzw40ddem70gfyr9nlfgadtzr6rk5cxuxknjx2j4ef998q8ga3sqhqlcux",
                         message: "Splitting the lunch bill. Thanks for suggesting that amazing restaurant!",
                         timestamp: UInt64(Date().timeIntervalSince1970),
                         preimage: nil,
                         createdAt: nil,
                         updatedAt: nil
-                    ))
+                    )
+                )
             )
             .environmentObject(CurrencyViewModel())
             .previewDisplayName("Lightning Payment")
@@ -448,7 +447,7 @@ struct ActivityItemView_Previews: PreviewProvider {
                         id: "test-onchain-1",
                         txType: .received,
                         txId: "abc123",
-                        value: 100000,
+                        value: 100_000,
                         fee: 500,
                         feeRate: 8,
                         address: "bc1...",
@@ -462,7 +461,8 @@ struct ActivityItemView_Previews: PreviewProvider {
                         transferTxId: nil,
                         createdAt: nil,
                         updatedAt: nil
-                    ))
+                    )
+                )
             )
             .environmentObject(CurrencyViewModel())
             .previewDisplayName("Onchain Payment")

--- a/Bitkit/Views/Wallets/Activity/ActivityLatest.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityLatest.swift
@@ -1,10 +1,3 @@
-//
-//  ActivityLatest.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/12/20.
-//
-
 import SwiftUI
 
 struct ActivityLatest: View {
@@ -32,14 +25,15 @@ struct ActivityLatest: View {
                         }
                     }
 
-                    if items.count == 0 {
+                    if items.isEmpty {
                         Button(
                             action: {
                                 sheets.showSheet(.receive)
                             },
                             label: {
                                 EmptyActivityRow()
-                            })
+                            }
+                        )
                     } else {
                         CustomButton(title: localizedString("wallet__activity_show_all"), variant: .tertiary) {
                             navigation.navigate(.activityList)

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -1,12 +1,5 @@
-//
-//  ActivityRow.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/18.
-//
-
-import SwiftUI
 import BitkitCore
+import SwiftUI
 
 private struct TransactionStatusText: View {
     let txType: PaymentType
@@ -17,14 +10,14 @@ private struct TransactionStatusText: View {
     init(txType: PaymentType, activity: Activity) {
         self.txType = txType
         switch activity {
-        case .lightning(let ln):
-            self.isLightning = true
-            self.status = ln.status
-            self.confirmed = nil
-        case .onchain(let onchain):
-            self.isLightning = false
-            self.status = nil
-            self.confirmed = onchain.confirmed
+        case let .lightning(ln):
+            isLightning = true
+            status = ln.status
+            confirmed = nil
+        case let .onchain(onchain):
+            isLightning = false
+            status = nil
+            confirmed = onchain.confirmed
         }
     }
 
@@ -78,12 +71,11 @@ struct ActivityRow: View {
     @EnvironmentObject var currency: CurrencyViewModel
 
     private var formattedTime: String {
-        let timestamp: TimeInterval
-        switch item {
-        case .lightning(let activity):
-            timestamp = TimeInterval(activity.timestamp)
-        case .onchain(let activity):
-            timestamp = TimeInterval(activity.timestamp)
+        let timestamp = switch item {
+        case let .lightning(activity):
+            TimeInterval(activity.timestamp)
+        case let .onchain(activity):
+            TimeInterval(activity.timestamp)
         }
 
         return DateFormatterHelpers.formatActivityTime(UInt64(timestamp))
@@ -91,9 +83,9 @@ struct ActivityRow: View {
 
     private var amountPrefix: String {
         switch item {
-        case .lightning(let activity):
+        case let .lightning(activity):
             return activity.txType == .sent ? "-" : "+"
-        case .onchain(let activity):
+        case let .onchain(activity):
             return activity.txType == .sent ? "-" : "+"
         }
     }
@@ -101,9 +93,9 @@ struct ActivityRow: View {
     @ViewBuilder
     private var amountView: some View {
         switch item {
-        case .lightning(let activity):
+        case let .lightning(activity):
             MoneyCell(sats: Int(activity.value), prefix: amountPrefix)
-        case .onchain(let activity):
+        case let .onchain(activity):
             MoneyCell(sats: Int(activity.value), prefix: amountPrefix)
         }
     }
@@ -114,21 +106,21 @@ struct ActivityRow: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 switch item {
-                case .lightning(let activity):
+                case let .lightning(activity):
                     TransactionStatusText(txType: activity.txType, activity: item)
-                case .onchain(let activity):
+                case let .onchain(activity):
                     TransactionStatusText(txType: activity.txType, activity: item)
                 }
 
                 // Show message if available, otherwise show time
                 switch item {
-                case .lightning(let activity):
+                case let .lightning(activity):
                     if !activity.message.isEmpty {
                         CaptionBText(activity.message)
                     } else {
                         CaptionBText(formattedTime)
                     }
-                case .onchain(_):
+                case .onchain:
                     CaptionBText(formattedTime)
                 }
             }

--- a/Bitkit/Views/Wallets/Activity/AllActivityView.swift
+++ b/Bitkit/Views/Wallets/Activity/AllActivityView.swift
@@ -1,10 +1,3 @@
-//
-//  AllActivityView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/18.
-//
-
 import SwiftUI
 
 struct AllActivityView: View {
@@ -74,7 +67,7 @@ struct AllActivityView: View {
                                     if horizontalAmount < -50 {
                                         // Swipe left - move to next tab
                                         if let currentIndex = ActivityTab.allCases.firstIndex(of: selectedTab),
-                                            currentIndex < ActivityTab.allCases.count - 1
+                                           currentIndex < ActivityTab.allCases.count - 1
                                         {
                                             withAnimation(.easeInOut(duration: 0.2)) {
                                                 selectedTab = ActivityTab.allCases[currentIndex + 1]
@@ -83,7 +76,7 @@ struct AllActivityView: View {
                                     } else if horizontalAmount > 50 {
                                         // Swipe right - move to previous tab
                                         if let currentIndex = ActivityTab.allCases.firstIndex(of: selectedTab),
-                                            currentIndex > 0
+                                           currentIndex > 0
                                         {
                                             withAnimation(.easeInOut(duration: 0.2)) {
                                                 selectedTab = ActivityTab.allCases[currentIndex - 1]

--- a/Bitkit/Views/Wallets/HomeView.swift
+++ b/Bitkit/Views/Wallets/HomeView.swift
@@ -1,10 +1,3 @@
-//
-//  HomeView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/07/31.
-//
-
 import SwiftUI
 
 struct HomeView: View {

--- a/Bitkit/Views/Wallets/LnurlWithdraw/LnurlWithdrawSheet.swift
+++ b/Bitkit/Views/Wallets/LnurlWithdraw/LnurlWithdrawSheet.swift
@@ -10,7 +10,7 @@ struct LnurlWithdrawConfig {
     let initialRoute: LnurlWithdrawRoute
 
     init(view: LnurlWithdrawRoute = .amount) {
-        self.initialRoute = view
+        initialRoute = view
     }
 }
 
@@ -46,7 +46,7 @@ struct LnurlWithdrawSheet: View {
             LnurlWithdrawAmount(navigationPath: $navigationPath)
         case .confirm:
             LnurlWithdrawConfirm(navigationPath: $navigationPath)
-        case .failure(let amount):
+        case let .failure(amount):
             LnurlWithdrawFailure(navigationPath: $navigationPath, amount: amount)
         }
     }

--- a/Bitkit/Views/Wallets/Receive/QrArea.swift
+++ b/Bitkit/Views/Wallets/Receive/QrArea.swift
@@ -79,9 +79,9 @@ struct QrArea: View {
 
         if let outputImage = filter.outputImage {
             // Generate padded QR image for sharing
-            let fixedSize: Int = 400
+            let fixedSize = 400
             let padding: CGFloat = 16
-            let qrSize: CGFloat = CGFloat(fixedSize) - (padding * 2)
+            let qrSize = CGFloat(fixedSize) - (padding * 2)
 
             // Scale the QR code to fit exactly in the available space
             let scale = qrSize / outputImage.extent.width

--- a/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
@@ -13,19 +13,18 @@ struct ReceiveQr: View {
     @State private var showDetails = false
 
     init(navigationPath: Binding<[ReceiveRoute]>, cjitInvoice: String? = nil, tab: ReceiveTab? = nil) {
-        self._navigationPath = navigationPath
+        _navigationPath = navigationPath
         self.cjitInvoice = cjitInvoice
         self.tab = tab
 
         // Default to unified tab if available, otherwise use provided tab or savings
-        let defaultTab: ReceiveTab
-        if tab != nil {
-            defaultTab = tab!
+        let defaultTab: ReceiveTab = if tab != nil {
+            tab!
         } else {
             // We'll set this in onAppear since we need access to wallet.channelCount
-            defaultTab = .savings
+            .savings
         }
-        self._selectedTab = State(initialValue: defaultTab)
+        _selectedTab = State(initialValue: defaultTab)
     }
 
     enum ReceiveTab: CaseIterable, CustomStringConvertible {
@@ -71,17 +70,17 @@ struct ReceiveQr: View {
                 SheetHeader(
                     title: localizedString("wallet__receive_bitcoin"),
                     action:
-                        AnyView(
-                            Button(action: {
-                                showDetails.toggle()
-                            }) {
-                                Image(showDetails ? "qr" : "note")
-                                    .resizable()
-                                    .scaledToFit()
-                                    .foregroundColor(.white50)
-                                    .frame(width: 24, height: 24)
-                            }
-                        )
+                    AnyView(
+                        Button(action: {
+                            showDetails.toggle()
+                        }) {
+                            Image(showDetails ? "qr" : "note")
+                                .resizable()
+                                .scaledToFit()
+                                .foregroundColor(.white50)
+                                .frame(width: 24, height: 24)
+                        }
+                    )
                 )
                 .padding(.horizontal, 16)
 
@@ -219,17 +218,19 @@ struct ReceiveQr: View {
                                 title: localizedString("wallet__receive_bitcoin_invoice"),
                                 address: wallet.onchainAddress,
                                 type: .onchain
-                            ))
+                            )
+                        )
                     }
                 case .spending:
                     // Spending: cjitInvoice or bolt11
-                    if let cjitInvoice = cjitInvoice {
+                    if let cjitInvoice {
                         pairs.append(
                             CopyAddressPair(
                                 title: localizedString("wallet__receive_lightning_invoice"),
                                 address: cjitInvoice,
                                 type: .lightning
-                            ))
+                            )
+                        )
                         break
                     }
 
@@ -239,7 +240,8 @@ struct ReceiveQr: View {
                                 title: localizedString("wallet__receive_lightning_invoice"),
                                 address: wallet.bolt11,
                                 type: .lightning
-                            ))
+                            )
+                        )
                     }
                 case .unified:
                     // Unified: both onchain and lightning
@@ -249,7 +251,8 @@ struct ReceiveQr: View {
                                 title: localizedString("wallet__receive_bitcoin_invoice"),
                                 address: wallet.onchainAddress,
                                 type: .onchain
-                            ))
+                            )
+                        )
                     }
 
                     if !wallet.bolt11.isEmpty {
@@ -258,7 +261,8 @@ struct ReceiveQr: View {
                                 title: localizedString("wallet__receive_lightning_invoice"),
                                 address: wallet.bolt11,
                                 type: .lightning
-                            ))
+                            )
+                        )
                     }
                 }
 
@@ -359,7 +363,7 @@ struct ReceiveQr: View {
     /// - Returns: BIP21 URI with lightning parameter removed
     private func stripLightningFromBip21(_ bip21: String) -> String {
         guard let url = URL(string: bip21),
-            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         else {
             return bip21
         }

--- a/Bitkit/Views/Wallets/Receive/ReceiveSheet.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveSheet.swift
@@ -14,7 +14,7 @@ struct ReceiveConfig {
     let initialRoute: ReceiveRoute
 
     init(view: ReceiveRoute = .qr(cjitInvoice: nil, tab: nil)) {
-        self.initialRoute = view
+        initialRoute = view
     }
 }
 
@@ -54,7 +54,7 @@ struct ReceiveSheet: View {
     @ViewBuilder
     private func viewForRoute(_ route: ReceiveRoute) -> some View {
         switch route {
-        case .qr(let cjitInvoice, let tab):
+        case let .qr(cjitInvoice, tab):
             ReceiveQr(navigationPath: $navigationPath, cjitInvoice: cjitInvoice, tab: tab)
         case .edit:
             ReceiveEdit(navigationPath: $navigationPath)
@@ -62,9 +62,9 @@ struct ReceiveSheet: View {
             ReceiveTag(navigationPath: $navigationPath)
         case .cjitAmount:
             ReceiveCjitAmount(navigationPath: $navigationPath)
-        case .cjitLearnMore(let entry, let receiveAmountSats):
+        case let .cjitLearnMore(entry, receiveAmountSats):
             ReceiveCjitLearnMore(entry: entry, receiveAmountSats: receiveAmountSats)
-        case .cjitConfirm(let entry, let receiveAmountSats):
+        case let .cjitConfirm(entry, receiveAmountSats):
             ReceiveCjitConfirmation(navigationPath: $navigationPath, entry: entry, receiveAmountSats: receiveAmountSats)
         }
     }

--- a/Bitkit/Views/Wallets/SavingsWalletView.swift
+++ b/Bitkit/Views/Wallets/SavingsWalletView.swift
@@ -1,10 +1,3 @@
-//
-//  SavingsWalletView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/11.
-//
-
 import SwiftUI
 
 struct SavingsWalletView: View {
@@ -75,7 +68,7 @@ struct SavingsWalletView: View {
 
     var transferButton: some View {
         CustomButton(
-            title: "Transfer To Spending", //TODO: add missing translation
+            title: "Transfer To Spending", // TODO: add missing translation
             variant: .secondary,
             icon: Image("arrow-up-down")
                 .resizable()

--- a/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
+++ b/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
@@ -105,11 +105,10 @@ struct LnurlPayConfirm: View {
             ) {
                 // Check if we need to show warning for amounts over $100 USD
                 if settings.warnWhenSendingOver100 {
-                    let sats: UInt64
-                    if let invoice = app.scannedLightningInvoice {
-                        sats = wallet.sendAmountSats ?? invoice.amountSatoshis
+                    let sats: UInt64 = if let invoice = app.scannedLightningInvoice {
+                        wallet.sendAmountSats ?? invoice.amountSatoshis
                     } else {
-                        sats = 0
+                        0
                     }
 
                     // Convert to USD to check if over $100
@@ -231,7 +230,7 @@ struct LnurlPayConfirm: View {
                         continuation.resume(returning: true)
                     } else {
                         if let error = authenticationError {
-                            self.handleBiometricError(error)
+                            handleBiometricError(error)
                         }
                         continuation.resume(returning: false)
                     }
@@ -241,7 +240,7 @@ struct LnurlPayConfirm: View {
     }
 
     private func handleBiometricError(_ error: Error?) {
-        guard let error = error else { return }
+        guard let error else { return }
 
         let nsError = error as NSError
 
@@ -295,7 +294,8 @@ struct LnurlPayConfirm: View {
                         onFail: { reason in
                             Logger.error("LNURL payment failed: \(reason)")
                             continuation.resume(
-                                throwing: NSError(domain: "Lightning", code: -1, userInfo: [NSLocalizedDescriptionKey: reason]))
+                                throwing: NSError(domain: "Lightning", code: -1, userInfo: [NSLocalizedDescriptionKey: reason])
+                            )
                             navigationPath.append(.failure)
                         }
                     )

--- a/Bitkit/Views/Wallets/Send/SendAmountView.swift
+++ b/Bitkit/Views/Wallets/Send/SendAmountView.swift
@@ -1,10 +1,3 @@
-//
-//  SendAmount.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/11.
-//
-
 import SwiftUI
 
 struct SendAmountView: View {
@@ -55,7 +48,7 @@ struct SendAmountView: View {
                         color: app.selectedWalletToPayFrom == .lightning ? .purpleAccent : .brandAccent,
                         variant: .secondary
                     ) {
-                        //Allow switching to savings if we have an onchain invoice
+                        // Allow switching to savings if we have an onchain invoice
                         if app.selectedWalletToPayFrom == .lightning && app.scannedOnchainInvoice != nil {
                             app.selectedWalletToPayFrom = .onchain
                         } else if app.selectedWalletToPayFrom == .onchain && app.scannedLightningInvoice != nil {
@@ -85,11 +78,12 @@ struct SendAmountView: View {
                     if satsAmount > 0 {
                         wallet.sendAmountSats = satsAmount
 
-                        //Lightning tx
+                        // Lightning tx
                         if app.selectedWalletToPayFrom == .lightning {
                             if UInt64(wallet.totalLightningSats) < satsAmount {
                                 app.toast(
-                                    type: .error, title: "Insufficient Funds", description: "You do not have enough funds in the selected wallet.")
+                                    type: .error, title: "Insufficient Funds", description: "You do not have enough funds in the selected wallet."
+                                )
                                 return
                             }
 
@@ -97,7 +91,7 @@ struct SendAmountView: View {
                             return
                         }
 
-                        //Onchain tx
+                        // Onchain tx
                         try await wallet.setFeeRate(speed: settings.defaultTransactionSpeed)
                         if settings.coinSelectionMethod == .manual {
                             try await wallet.loadAvailableUtxos()
@@ -109,18 +103,20 @@ struct SendAmountView: View {
 
                             if wallet.availableUtxos.reduce(0) { $0 + $1.valueSats } < satsAmount {
                                 app.toast(
-                                    type: .error, title: "Insufficient Funds", description: "You do not have enough funds in the selected wallet.")
+                                    type: .error, title: "Insufficient Funds", description: "You do not have enough funds in the selected wallet."
+                                )
                                 return
                             }
 
-                            navigationPath.append(.utxoSelection) //User needs to select utxos
+                            navigationPath.append(.utxoSelection) // User needs to select utxos
                         } else {
                             try await wallet.setUtxoSelection(coinSelectionAlgorythm: settings.coinSelectionAlgorithm)
 
                             let totalSelectedSats = wallet.selectedUtxo?.reduce(0) { $0 + $1.valueSats } ?? 0
                             if totalSelectedSats < satsAmount {
                                 app.toast(
-                                    type: .error, title: "Insufficient Funds", description: "You do not have enough funds in the selected wallet.")
+                                    type: .error, title: "Insufficient Funds", description: "You do not have enough funds in the selected wallet."
+                                )
                                 return
                             }
 

--- a/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
+++ b/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
@@ -1,10 +1,3 @@
-//
-//  SendConfirmationView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/11/19.
-//
-
 import BitkitCore
 import LocalAuthentication
 import SwiftUI
@@ -67,13 +60,12 @@ struct SendConfirmationView: View {
             ) {
                 // Check if we need to show warning for amounts over $100 USD
                 if settings.warnWhenSendingOver100 {
-                    let sats: UInt64
-                    if app.selectedWalletToPayFrom == .lightning, let invoice = app.scannedLightningInvoice {
-                        sats = wallet.sendAmountSats ?? invoice.amountSatoshis
+                    let sats: UInt64 = if app.selectedWalletToPayFrom == .lightning, let invoice = app.scannedLightningInvoice {
+                        wallet.sendAmountSats ?? invoice.amountSatoshis
                     } else if app.selectedWalletToPayFrom == .onchain, let invoice = app.scannedOnchainInvoice {
-                        sats = wallet.sendAmountSats ?? invoice.amountSatoshis
+                        wallet.sendAmountSats ?? invoice.amountSatoshis
                     } else {
-                        sats = 0
+                        0
                     }
 
                     // Convert to USD to check if over $100
@@ -197,7 +189,7 @@ struct SendConfirmationView: View {
                         continuation.resume(returning: true)
                     } else {
                         if let error = authenticationError {
-                            self.handleBiometricError(error)
+                            handleBiometricError(error)
                         }
                         continuation.resume(returning: false)
                     }
@@ -207,7 +199,7 @@ struct SendConfirmationView: View {
     }
 
     private func handleBiometricError(_ error: Error?) {
-        guard let error = error else { return }
+        guard let error else { return }
 
         let nsError = error as NSError
 
@@ -235,7 +227,8 @@ struct SendConfirmationView: View {
     private func performPayment() async throws {
         do {
             if app.selectedWalletToPayFrom == .lightning, let bolt11 = app.scannedLightningBolt11Invoice {
-                // A LN payment can throw an error right away, be successful right away, or take a while to complete/fail because it's retrying different paths.
+                // A LN payment can throw an error right away, be successful right away, or take a while to complete/fail because it's retrying
+                // different paths.
                 // So we need to handle all these cases here.
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                     Task {
@@ -252,7 +245,8 @@ struct SendConfirmationView: View {
                                     Logger.error("Lightning payment failed: \(reason)")
                                     app.toast(type: .error, title: "Payment failed", description: reason)
                                     continuation.resume(
-                                        throwing: NSError(domain: "Lightning", code: -1, userInfo: [NSLocalizedDescriptionKey: reason]))
+                                        throwing: NSError(domain: "Lightning", code: -1, userInfo: [NSLocalizedDescriptionKey: reason])
+                                    )
                                 }
                             )
                             Logger.info("Lightning send initiated with payment hash: \(paymentHash)")
@@ -272,7 +266,8 @@ struct SendConfirmationView: View {
                 navigationPath.append(.success)
             } else {
                 throw NSError(
-                    domain: "Payment", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid payment method or missing invoice data"])
+                    domain: "Payment", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid payment method or missing invoice data"]
+                )
             }
         } catch {
             app.toast(error)
@@ -364,7 +359,8 @@ struct SendConfirmationView: View {
                                 let vm = CurrencyViewModel()
                                 vm.primaryDisplay = .bitcoin
                                 return vm
-                            }())
+                            }()
+                        )
                 }
                 .presentationDetents([.height(UIScreen.screenHeight - 120)])
             }

--- a/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
+++ b/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
@@ -1,10 +1,3 @@
-//
-//  SendEnterManually.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/11.
-//
-
 import SwiftUI
 
 struct SendEnterManuallyView: View {

--- a/Bitkit/Views/Wallets/Send/SendOptionsView.swift
+++ b/Bitkit/Views/Wallets/Send/SendOptionsView.swift
@@ -1,15 +1,8 @@
-//
-//  SendOptionsView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/08/23.
-//
-
 import SwiftUI
 
 struct SendOptionCard: View {
     var title: String
-    var action: (() -> Void)
+    var action: () -> Void
     var iconName: String
     var testID: String
 
@@ -112,7 +105,8 @@ struct SendOptionsView: View {
             app.toast(
                 type: .warning,
                 title: localizedString("wallet__send_clipboard_empty_title"),
-                description: localizedString("wallet__send_clipboard_empty_text"))
+                description: localizedString("wallet__send_clipboard_empty_text")
+            )
             return
         }
 

--- a/Bitkit/Views/Wallets/Send/SendQuickpay.swift
+++ b/Bitkit/Views/Wallets/Send/SendQuickpay.swift
@@ -99,11 +99,13 @@ struct SendQuickpay: View {
 
         guard let bolt11 = bolt11Invoice else {
             throw NSError(
-                domain: "Payment", code: -1, userInfo: [NSLocalizedDescriptionKey: "No Lightning invoice found"])
+                domain: "Payment", code: -1, userInfo: [NSLocalizedDescriptionKey: "No Lightning invoice found"]
+            )
         }
 
         do {
-            // A LN payment can throw an error right away, be successful right away, or take a while to complete/fail because it's retrying different paths.
+            // A LN payment can throw an error right away, be successful right away, or take a while to complete/fail because it's retrying different
+            // paths.
             // So we need to handle all these cases here.
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 Task {
@@ -119,7 +121,8 @@ struct SendQuickpay: View {
                             onFail: { reason in
                                 Logger.error("Quickpay payment failed: \(reason)")
                                 continuation.resume(
-                                    throwing: NSError(domain: "Lightning", code: -1, userInfo: [NSLocalizedDescriptionKey: reason]))
+                                    throwing: NSError(domain: "Lightning", code: -1, userInfo: [NSLocalizedDescriptionKey: reason])
+                                )
                                 navigationPath.append(.failure)
                             }
                         )

--- a/Bitkit/Views/Wallets/Send/SendSheet.swift
+++ b/Bitkit/Views/Wallets/Send/SendSheet.swift
@@ -18,7 +18,7 @@ struct SendConfig {
     let initialRoute: SendRoute
 
     init(view: SendRoute = .options) {
-        self.initialRoute = view
+        initialRoute = view
     }
 }
 

--- a/Bitkit/Views/Wallets/Send/SendUtxoSelectionView.swift
+++ b/Bitkit/Views/Wallets/Send/SendUtxoSelectionView.swift
@@ -28,7 +28,7 @@ struct SendUtxoSelectionView: View {
 
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    ForEach(Array(wallet.availableUtxos.enumerated()), id: \.element.outpoint.txid) { index, utxo in
+                    ForEach(Array(wallet.availableUtxos.enumerated()), id: \.element.outpoint.txid) { _, utxo in
                         UtxoRowView(
                             utxo: utxo,
                             tags: utxoTags[utxo.outpoint.txid] ?? [],
@@ -93,7 +93,7 @@ struct SendUtxoSelectionView: View {
         // Create a map of txId to activity for efficient lookup
         let activityMap = Dictionary(
             onchainActivities.compactMap { activity in
-                if case .onchain(let onchainActivity) = activity {
+                if case let .onchain(onchainActivity) = activity {
                     return (onchainActivity.txId, onchainActivity)
                 }
                 return nil

--- a/Bitkit/Views/Wallets/Sheets/BoostSheet.swift
+++ b/Bitkit/Views/Wallets/Sheets/BoostSheet.swift
@@ -77,7 +77,7 @@ struct BoostSheet: View {
 
     private var fiatFeeString: String {
         guard estimatedFeeSats > 0,
-            let converted = currency.convert(sats: estimatedFeeSats)
+              let converted = currency.convert(sats: estimatedFeeSats)
         else {
             return ""
         }
@@ -182,7 +182,7 @@ struct BoostSheet: View {
                             }) {
                                 HStack(spacing: 8) {
                                     VStack(alignment: .trailing, spacing: 2) {
-                                        if let feeRate = feeRate {
+                                        if let feeRate {
                                             BodySSBText("₿ \(estimatedFeeSats)")
                                         } else if fetchingFees {
                                             ProgressView()
@@ -235,7 +235,8 @@ struct BoostSheet: View {
             Logger.info("Starting fee rate fetch for boost", context: "BoostSheet.fetchFeeRate")
             Logger.debug(
                 "Transaction details - ID: \(onchainActivity.txId), Type: \(onchainActivity.txType), IsIncoming: \(isIncoming)",
-                context: "BoostSheet.fetchFeeRate")
+                context: "BoostSheet.fetchFeeRate"
+            )
 
             do {
                 // Wait for wallet to be ready before fetching fees
@@ -273,10 +274,12 @@ struct BoostSheet: View {
 
                         Logger.info(
                             "CPFP fee rate calculated: \(calculatedFeeRate) sat/vbyte (base: \(baseFeeRate), multiplier: 1.5x, minimum: 20)",
-                            context: "BoostSheet.fetchFeeRate")
+                            context: "BoostSheet.fetchFeeRate"
+                        )
                         Logger.debug(
                             "Estimated fee cost: \(estimatedFeeSats) sats (\(calculatedFeeRate) sat/vbyte × \(estimatedTxSize) vbytes)",
-                            context: "BoostSheet.fetchFeeRate")
+                            context: "BoostSheet.fetchFeeRate"
+                        )
 
                         fetchingFees = false
                     }
@@ -299,10 +302,12 @@ struct BoostSheet: View {
 
                         Logger.info(
                             "RBF fee rate set: \(validatedFeeRate) sat/vbyte (selected: \(selectedFeeRate ?? 0), original: \(originalFeeRate), min RBF: \(minRbfFeeRate))",
-                            context: "BoostSheet.fetchFeeRate")
+                            context: "BoostSheet.fetchFeeRate"
+                        )
                         Logger.debug(
                             "Estimated fee cost: \(estimatedFeeSats) sats (\(validatedFeeRate) sat/vbyte × \(estimatedTxSize) vbytes)",
-                            context: "BoostSheet.fetchFeeRate")
+                            context: "BoostSheet.fetchFeeRate"
+                        )
 
                         fetchingFees = false
                     }
@@ -313,7 +318,8 @@ struct BoostSheet: View {
             } catch {
                 Logger.error("Failed to fetch fee rate for boost: \(error)", context: "BoostSheet.fetchFeeRate")
                 Logger.debug(
-                    "Error details - Type: \(type(of: error)), Description: \(error.localizedDescription)", context: "BoostSheet.fetchFeeRate")
+                    "Error details - Type: \(type(of: error)), Description: \(error.localizedDescription)", context: "BoostSheet.fetchFeeRate"
+                )
 
                 await MainActor.run {
                     fetchingFees = false
@@ -331,7 +337,8 @@ struct BoostSheet: View {
         Logger.info("Starting boost transaction", context: "BoostSheet.performBoost")
         Logger.debug(
             "Transaction details - ID: \(onchainActivity.txId), Type: \(onchainActivity.txType), IsIncoming: \(isIncoming)",
-            context: "BoostSheet.performBoost")
+            context: "BoostSheet.performBoost"
+        )
 
         let feeRateToUse = currentFeeRate
         guard feeRateToUse > 0 else {
@@ -357,7 +364,8 @@ struct BoostSheet: View {
 
         Logger.info("Using fee rate: \(feeRateToUse) sat/vbyte for boost", context: "BoostSheet.performBoost")
         Logger.debug(
-            "Estimated transaction size: \(estimatedTxSize) vbytes, Estimated fee: \(estimatedFeeSats) sats", context: "BoostSheet.performBoost")
+            "Estimated transaction size: \(estimatedTxSize) vbytes, Estimated fee: \(estimatedFeeSats) sats", context: "BoostSheet.performBoost"
+        )
 
         do {
             // Perform the boost operation via CoreService
@@ -391,10 +399,12 @@ struct BoostSheet: View {
         } catch {
             Logger.error("Failed to boost transaction: \(error)", context: "BoostSheet.performBoost")
             Logger.debug(
-                "Boost error details - Type: \(type(of: error)), Description: \(error.localizedDescription)", context: "BoostSheet.performBoost")
+                "Boost error details - Type: \(type(of: error)), Description: \(error.localizedDescription)", context: "BoostSheet.performBoost"
+            )
             Logger.debug(
                 "Failed boost parameters - TxID: \(onchainActivity.txId), FeeRate: \(feeRateToUse) sat/vbyte, IsIncoming: \(isIncoming)",
-                context: "BoostSheet.performBoost")
+                context: "BoostSheet.performBoost"
+            )
 
             app.toast(
                 type: .error,
@@ -418,7 +428,7 @@ struct BoostSheet: View {
                             id: "test-onchain-1",
                             txType: .sent,
                             txId: "abc123",
-                            value: 100000,
+                            value: 100_000,
                             fee: 500,
                             feeRate: 8,
                             address: "bc1...",

--- a/Bitkit/Views/Wallets/SpendingWalletView.swift
+++ b/Bitkit/Views/Wallets/SpendingWalletView.swift
@@ -1,10 +1,3 @@
-//
-//  SpendingWalletView.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/10/11.
-//
-
 import SwiftUI
 
 struct SpendingWalletView: View {
@@ -75,7 +68,7 @@ struct SpendingWalletView: View {
 
     var transferButton: some View {
         CustomButton(
-            title: "Transfer To Savings", //TODO: add missing translation
+            title: "Transfer To Savings", // TODO: add missing translation
             variant: .secondary,
             icon: Image("arrow-up-down")
                 .resizable()

--- a/Bitkit/Views/Widgets/WidgetEditModels.swift
+++ b/Bitkit/Views/Widgets/WidgetEditModels.swift
@@ -26,8 +26,8 @@ struct WidgetEditItem {
     init(key: String, type: WidgetItemType, title: String, value: String? = nil, isChecked: Bool) {
         self.key = key
         self.type = type
-        self.titleView = AnyView(BodySSBText(title, textColor: .textSecondary))
-        self.valueView = value.map { AnyView(BodySSBText($0)) }
+        titleView = AnyView(BodySSBText(title, textColor: .textSecondary))
+        valueView = value.map { AnyView(BodySSBText($0)) }
         self.isChecked = isChecked
     }
 
@@ -35,7 +35,7 @@ struct WidgetEditItem {
     init(key: String, type: WidgetItemType, title: String, valueView: AnyView? = nil, isChecked: Bool) {
         self.key = key
         self.type = type
-        self.titleView = AnyView(BodySSBText(title, textColor: .textSecondary))
+        titleView = AnyView(BodySSBText(title, textColor: .textSecondary))
         self.valueView = valueView
         self.isChecked = isChecked
     }
@@ -43,8 +43,7 @@ struct WidgetEditItem {
 
 // MARK: - Widget Edit Item Factory
 
-struct WidgetEditItemFactory {
-
+enum WidgetEditItemFactory {
     @MainActor
     static func getBlocksItems(
         blocksViewModel: BlocksViewModel,
@@ -60,7 +59,8 @@ struct WidgetEditItemFactory {
                     title: "Block",
                     value: data.height,
                     isChecked: blocksOptions.height
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -69,7 +69,8 @@ struct WidgetEditItemFactory {
                     title: "Time",
                     value: data.time,
                     isChecked: blocksOptions.time
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -78,7 +79,8 @@ struct WidgetEditItemFactory {
                     title: "Date",
                     value: data.date,
                     isChecked: blocksOptions.date
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -87,7 +89,8 @@ struct WidgetEditItemFactory {
                     title: "Transactions",
                     value: data.transactionCount,
                     isChecked: blocksOptions.transactionCount
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -96,7 +99,8 @@ struct WidgetEditItemFactory {
                     title: "Size",
                     value: data.size,
                     isChecked: blocksOptions.size
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -105,7 +109,8 @@ struct WidgetEditItemFactory {
                     title: "Weight",
                     value: data.weight,
                     isChecked: blocksOptions.weight
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -114,7 +119,8 @@ struct WidgetEditItemFactory {
                     title: "Difficulty",
                     value: data.difficulty,
                     isChecked: blocksOptions.difficulty
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -123,7 +129,8 @@ struct WidgetEditItemFactory {
                     title: "Hash",
                     value: data.hash,
                     isChecked: blocksOptions.hash
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -132,7 +139,8 @@ struct WidgetEditItemFactory {
                     title: "Merkle Root",
                     value: data.merkleRoot,
                     isChecked: blocksOptions.merkleRoot
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -141,7 +149,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__widget__source"),
                     valueView: AnyView(BodySSBText("mempool.space", textColor: .textSecondary)),
                     isChecked: blocksOptions.showSource
-                ))
+                )
+            )
         } else {
             // Fallback when no data is available
             items.append(
@@ -151,7 +160,8 @@ struct WidgetEditItemFactory {
                     title: "Block",
                     value: "870,123",
                     isChecked: blocksOptions.height
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -160,7 +170,8 @@ struct WidgetEditItemFactory {
                     title: "Time",
                     value: "2:45:30 PM",
                     isChecked: blocksOptions.time
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -169,7 +180,8 @@ struct WidgetEditItemFactory {
                     title: "Date",
                     value: "Dec 15, 2024",
                     isChecked: blocksOptions.date
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -178,7 +190,8 @@ struct WidgetEditItemFactory {
                     title: "Transactions",
                     value: "3,456",
                     isChecked: blocksOptions.transactionCount
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -187,7 +200,8 @@ struct WidgetEditItemFactory {
                     title: "Size",
                     value: "1,234 KB",
                     isChecked: blocksOptions.size
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -196,7 +210,8 @@ struct WidgetEditItemFactory {
                     title: "Weight",
                     value: "3.45 MWU",
                     isChecked: blocksOptions.weight
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -205,7 +220,8 @@ struct WidgetEditItemFactory {
                     title: "Difficulty",
                     value: "102.45 T",
                     isChecked: blocksOptions.difficulty
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -214,7 +230,8 @@ struct WidgetEditItemFactory {
                     title: "Hash",
                     value: "00000000000000000002a7c4c1e48d76c5a37902165a270156b7a8d72728a054",
                     isChecked: blocksOptions.hash
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -223,7 +240,8 @@ struct WidgetEditItemFactory {
                     title: "Merkle Root",
                     value: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
                     isChecked: blocksOptions.merkleRoot
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -232,7 +250,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__widget__source"),
                     valueView: AnyView(BodySSBText("mempool.space", textColor: .textSecondary)),
                     isChecked: blocksOptions.showSource
-                ))
+                )
+            )
         }
 
         return items
@@ -248,7 +267,8 @@ struct WidgetEditItemFactory {
                 type: .staticItem,
                 titleView: AnyView(TitleText(factsViewModel.fact)),
                 isChecked: true
-            ))
+            )
+        )
 
         items.append(
             WidgetEditItem(
@@ -257,7 +277,8 @@ struct WidgetEditItemFactory {
                 title: localizedString("widgets__widget__source"),
                 valueView: AnyView(BodySSBText("mempool.space", textColor: .textSecondary)),
                 isChecked: factsOptions.showSource
-            ))
+            )
+        )
 
         return items
     }
@@ -277,7 +298,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(BodyMText(data.timeAgo, textColor: .textPrimary)),
                     valueView: nil,
                     isChecked: newsOptions.showDate
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -286,7 +308,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(TitleText(data.title)),
                     valueView: nil,
                     isChecked: true // Static items are always shown
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -295,7 +318,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__widget__source"),
                     valueView: AnyView(BodySSBText(data.publisher, textColor: .textSecondary)),
                     isChecked: newsOptions.showSource
-                ))
+                )
+            )
         } else {
             // Fallback when no data is available
             items.append(
@@ -305,7 +329,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(BodyMText("13 hours ago", textColor: .textPrimary)),
                     valueView: nil,
                     isChecked: newsOptions.showDate
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -314,7 +339,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(TitleText("Exodus Launches XO Pay, An In-App Bitcoin And Crypto Purchase Solution")),
                     valueView: nil,
                     isChecked: true // Static items are always shown
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -323,7 +349,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__widget__source"),
                     valueView: AnyView(BodySSBText("Bitcoin Magazine", textColor: .textSecondary)),
                     isChecked: newsOptions.showSource
-                ))
+                )
+            )
         }
 
         return items
@@ -350,7 +377,8 @@ struct WidgetEditItemFactory {
                     title: pair,
                     value: livePrice,
                     isChecked: priceOptions.selectedPairs.contains(pair)
-                ))
+                )
+            )
         }
 
         // Period selection (radio group) with charts
@@ -374,7 +402,8 @@ struct WidgetEditItemFactory {
                     ),
                     valueView: nil,
                     isChecked: priceOptions.selectedPeriod == period
-                ))
+                )
+            )
         }
 
         items.append(
@@ -384,7 +413,8 @@ struct WidgetEditItemFactory {
                 title: localizedString("widgets__widget__source"),
                 valueView: AnyView(BodySSBText("Bitfinex.com", textColor: .textSecondary)),
                 isChecked: priceOptions.showSource
-            ))
+            )
+        )
 
         return items
     }
@@ -404,7 +434,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(TitleText(data.condition.title)),
                     valueView: AnyView(Text(data.condition.icon).font(.system(size: 30))),
                     isChecked: weatherOptions.showStatus
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -413,7 +444,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(BodyMText(data.condition.description, textColor: .textPrimary)),
                     valueView: nil,
                     isChecked: weatherOptions.showText
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -422,7 +454,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__weather__current_fee"),
                     value: data.currentFee,
                     isChecked: weatherOptions.showMedian
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -431,7 +464,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__weather__next_block"),
                     value: "\(data.nextBlockFee) ₿/vByte",
                     isChecked: weatherOptions.showNextBlockFee
-                ))
+                )
+            )
         } else {
             // Fallback when no data is available
             items.append(
@@ -441,7 +475,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(TitleText("Good")),
                     valueView: AnyView(Text("☀️").font(.system(size: 30))),
                     isChecked: weatherOptions.showStatus
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -450,7 +485,8 @@ struct WidgetEditItemFactory {
                     titleView: AnyView(BodyMText("Fees are low and transactions are fast", textColor: .textPrimary)),
                     valueView: nil,
                     isChecked: weatherOptions.showText
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -459,7 +495,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__weather__current_fee"),
                     value: "$0.50",
                     isChecked: weatherOptions.showMedian
-                ))
+                )
+            )
 
             items.append(
                 WidgetEditItem(
@@ -468,7 +505,8 @@ struct WidgetEditItemFactory {
                     title: localizedString("widgets__weather__next_block"),
                     value: "15 ₿/vByte",
                     isChecked: weatherOptions.showNextBlockFee
-                ))
+                )
+            )
         }
 
         return items

--- a/Bitkit/Views/Widgets/WidgetEditView.swift
+++ b/Bitkit/Views/Widgets/WidgetEditView.swift
@@ -30,7 +30,7 @@ struct WidgetEditView: View {
     }
 
     private func getItems() -> [WidgetEditItem] {
-        guard let editLogic = editLogic else { return [] }
+        guard let editLogic else { return [] }
         return WidgetEditItemFactory.getItems(
             for: id,
             blocksViewModel: blocksViewModel,

--- a/BitkitTests/ActivityListTest.swift
+++ b/BitkitTests/ActivityListTest.swift
@@ -1,12 +1,5 @@
-//
-//  ActivityListTest.swift
-//  BitkitTests
-//
-//  Created by Jason van den Berg on 2024/12/17.
-//
-
-import XCTest
 import BitkitCore
+import XCTest
 
 @testable import Bitkit
 
@@ -52,7 +45,8 @@ final class ActivityTests: XCTestCase {
                 preimage: nil,
                 createdAt: nil,
                 updatedAt: nil
-            ))
+            )
+        )
 
         // Insert the activity
         try await service.insert(lightningActivity)
@@ -97,7 +91,8 @@ final class ActivityTests: XCTestCase {
                 transferTxId: nil,
                 createdAt: nil,
                 updatedAt: nil
-            ))
+            )
+        )
 
         // Insert the activity
         try await service.insert(onchainActivity)
@@ -133,7 +128,8 @@ final class ActivityTests: XCTestCase {
                 preimage: nil,
                 createdAt: nil,
                 updatedAt: nil
-            ))
+            )
+        )
 
         try await service.insert(activity)
 
@@ -169,7 +165,8 @@ final class ActivityTests: XCTestCase {
                     preimage: nil,
                     createdAt: nil,
                     updatedAt: nil
-                )),
+                )
+            ),
             Activity.lightning(
                 LightningActivity(
                     id: "test-tag-filter-2",
@@ -183,7 +180,8 @@ final class ActivityTests: XCTestCase {
                     preimage: nil,
                     createdAt: nil,
                     updatedAt: nil
-                )),
+                )
+            ),
         ]
 
         // Insert activities and add tags
@@ -223,7 +221,8 @@ final class ActivityTests: XCTestCase {
                     preimage: nil,
                     createdAt: nil,
                     updatedAt: nil
-                )),
+                )
+            ),
             Activity.onchain(
                 OnchainActivity(
                     id: "test-unique-tags-2",
@@ -243,7 +242,8 @@ final class ActivityTests: XCTestCase {
                     transferTxId: nil,
                     createdAt: nil,
                     updatedAt: nil
-                )),
+                )
+            ),
         ]
 
         // Insert activities and add different combinations of tags
@@ -296,7 +296,8 @@ final class ActivityTests: XCTestCase {
                 preimage: nil,
                 createdAt: nil,
                 updatedAt: nil
-            ))
+            )
+        )
 
         try await service.insert(initialActivity)
 
@@ -314,7 +315,8 @@ final class ActivityTests: XCTestCase {
                 preimage: "preimage123",
                 createdAt: nil,
                 updatedAt: nil
-            ))
+            )
+        )
 
         // Update the activity
         try await service.update(id: "test-update-1", activity: updatedActivity)
@@ -349,7 +351,8 @@ final class ActivityTests: XCTestCase {
                 preimage: nil,
                 createdAt: nil,
                 updatedAt: nil
-            ))
+            )
+        )
 
         try await service.insert(activity)
 
@@ -384,7 +387,8 @@ final class ActivityTests: XCTestCase {
                     preimage: nil,
                     createdAt: nil,
                     updatedAt: nil
-                )),
+                )
+            ),
             Activity.onchain(
                 OnchainActivity(
                     id: "test-limit-2",
@@ -404,7 +408,8 @@ final class ActivityTests: XCTestCase {
                     transferTxId: nil,
                     createdAt: nil,
                     updatedAt: nil
-                )),
+                )
+            ),
             Activity.lightning(
                 LightningActivity(
                     id: "test-limit-3",
@@ -418,7 +423,8 @@ final class ActivityTests: XCTestCase {
                     preimage: nil,
                     createdAt: nil,
                     updatedAt: nil
-                )),
+                )
+            ),
         ]
 
         // Insert all activities

--- a/BitkitTests/BlocktankTests.swift
+++ b/BitkitTests/BlocktankTests.swift
@@ -1,12 +1,5 @@
-//
-//  BlocktankTests.swift
-//  BitkitTests
-//
-//  Created by Jason van den Berg on 2024/08/28.
-//
-
-import XCTest
 import BitkitCore
+import XCTest
 
 @testable import Bitkit
 
@@ -59,10 +52,10 @@ final class BlocktankTests: XCTestCase {
 
     func testCreateCjitOrder() async throws {
         // Test creating a CJIT order
-        let channelSizeSat: UInt64 = 100_000  // 100k sats
-        let invoiceSat: UInt64 = 10_000  // 10k sats for the invoice
+        let channelSizeSat: UInt64 = 100_000 // 100k sats
+        let invoiceSat: UInt64 = 10000 // 10k sats for the invoice
         let invoiceDescription = "Test CJIT order"
-        let nodeId = "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"  // Example node ID
+        let nodeId = "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad" // Example node ID
         let channelExpiryWeeks: UInt32 = 6
         let options = CreateCjitOptions(source: "bitkit", discountCode: nil)
 

--- a/BitkitTests/ChannelPurchaseFlow.swift
+++ b/BitkitTests/ChannelPurchaseFlow.swift
@@ -1,10 +1,3 @@
-//
-//  PaymentFlow.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2025/04/15.
-//
-
 import BitkitCore
 import XCTest
 
@@ -120,7 +113,7 @@ final class PaymentFlowTests: XCTestCase {
         try await blocktank.regtestMineBlocks(1)
         Logger.test("Blocks mined successfully", context: "PaymentFlowTests")
 
-        //Sleep 10 seconds to ensure the blocks are mined
+        // Sleep 10 seconds to ensure the blocks are mined
         Logger.test("Waiting 10 seconds for blocks to be processed", context: "PaymentFlowTests")
         try await Task.sleep(nanoseconds: 10_000_000_000)
         Logger.test("Wait completed", context: "PaymentFlowTests")
@@ -180,7 +173,7 @@ final class PaymentFlowTests: XCTestCase {
         XCTAssertFalse(paymentTxId.isEmpty, "Payment transaction ID should not be empty")
         Logger.test("Payment sent with transaction ID: \(paymentTxId)", context: "PaymentFlowTests")
 
-        //Mine 1 block to confirm the payment transaction
+        // Mine 1 block to confirm the payment transaction
         try await Task.sleep(nanoseconds: 500_000_000)
         try await blocktank.regtestMineBlocks(1)
         Logger.test("Block mined successfully", context: "PaymentFlowTests")
@@ -241,7 +234,7 @@ final class PaymentFlowTests: XCTestCase {
         XCTAssertGreaterThan(channels?.count ?? 0, 0, "Should have at least one channel")
 
         // Check if we have at least one usable channel
-        let usableChannels = channels?.filter { $0.isUsable } ?? []
+        let usableChannels = channels?.filter(\.isUsable) ?? []
         XCTAssertGreaterThan(usableChannels.count, 0, "Should have at least one usable channel")
 
         if let firstUsableChannel = usableChannels.first {
@@ -255,13 +248,14 @@ final class PaymentFlowTests: XCTestCase {
         } else if let firstChannel = channels?.first {
             Logger.test(
                 "Channel exists but is not yet usable. State: isChannelReady=\(firstChannel.isChannelReady), isUsable=\(firstChannel.isUsable)",
-                context: "PaymentFlowTests")
+                context: "PaymentFlowTests"
+            )
             Logger.test("Channel capacity: \(firstChannel.channelValueSats) sats", context: "PaymentFlowTests")
             Logger.test("Channel counterparty: \(firstChannel.counterpartyNodeId)", context: "PaymentFlowTests")
             XCTFail("Channel exists but is not usable yet")
         }
 
-        //TODO: actually try route some payments
+        // TODO: actually try route some payments
 
         // Clean up by removing the test wallet
         Logger.test("Stopping lightning node", context: "PaymentFlowTests")

--- a/BitkitTests/CryptoTests.swift
+++ b/BitkitTests/CryptoTests.swift
@@ -1,10 +1,3 @@
-//
-//  CryptoTests.swift
-//  BitkitTests
-//
-//  Created by Jason van den Berg on 2024/09/13.
-//
-
 import XCTest
 
 final class CryptoTests: XCTestCase {
@@ -22,7 +15,8 @@ final class CryptoTests: XCTestCase {
         let derivationName = "encryption"
 
         let sharedSecret2 = try Crypto.generateSharedSecret(
-            privateKey: keyPair3.privateKey, nodePubkey: Data(keyPair4.publicKey).hex, derivationName: derivationName)
+            privateKey: keyPair3.privateKey, nodePubkey: Data(keyPair4.publicKey).hex, derivationName: derivationName
+        )
         XCTAssertEqual(sharedSecret2.count, 32)
         XCTAssertNotEqual(sharedSecret1, sharedSecret2)
 
@@ -38,9 +32,11 @@ final class CryptoTests: XCTestCase {
 
         // Generate shared secrets
         let aliceSharedSecret = try Crypto.generateSharedSecret(
-            privateKey: aliceKeyPair.privateKey, nodePubkey: Data(bobKeyPair.publicKey).hex, derivationName: "random123")
+            privateKey: aliceKeyPair.privateKey, nodePubkey: Data(bobKeyPair.publicKey).hex, derivationName: "random123"
+        )
         let bobSharedSecret = try Crypto.generateSharedSecret(
-            privateKey: bobKeyPair.privateKey, nodePubkey: Data(aliceKeyPair.publicKey).hex, derivationName: "random123")
+            privateKey: bobKeyPair.privateKey, nodePubkey: Data(aliceKeyPair.publicKey).hex, derivationName: "random123"
+        )
 
         // Ensure shared secrets are the same
         XCTAssertEqual(aliceSharedSecret, bobSharedSecret)
@@ -84,7 +80,8 @@ final class CryptoTests: XCTestCase {
         XCTAssertEqual("028ce542975d6d7b2307c92e527d507b03ffb3d897eb2e0830d29f40d5efd80ee3", sharedSecret.hex)
 
         let sharedSecret2 = try Crypto.generateSharedSecret(
-            privateKey: clientPrivateKey.hexaData, nodePubkey: serverPublicKey, derivationName: derivationName)
+            privateKey: clientPrivateKey.hexaData, nodePubkey: serverPublicKey, derivationName: derivationName
+        )
         XCTAssertEqual("3a9d552cb16dfae40feae644254c4ca46cab82e570de5662aacc4018e33b609b", sharedSecret2.hex)
 
         let encryptedPayload = Crypto.EncryptedPayload(cipher: ciphertext, iv: iv.hexaData, tag: tag.hexaData)

--- a/BitkitTests/KeychainTests.swift
+++ b/BitkitTests/KeychainTests.swift
@@ -1,10 +1,3 @@
-//
-//  Keychain.swift
-//  BitkitTests
-//
-//  Created by Jason van den Berg on 2024/07/29.
-//
-
 import XCTest
 
 final class KeychainTests: XCTestCase {
@@ -18,8 +11,8 @@ final class KeychainTests: XCTestCase {
 
     func testKeychain() throws {
         let testMnemonic =
-            "test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999)) test\(Int.random(in: 0...99999))"
-        let testPassphrase = "testpasshrase\(Int.random(in: 0...99999))"
+            "test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999)) test\(Int.random(in: 0 ... 99999))"
+        let testPassphrase = "testpasshrase\(Int.random(in: 0 ... 99999))"
 
         // Write
         try Keychain.saveString(key: .bip39Mnemonic(index: 0), str: testMnemonic)

--- a/BitkitTests/LdkMigration.swift
+++ b/BitkitTests/LdkMigration.swift
@@ -1,10 +1,3 @@
-//
-//  LdkMigration.swift
-//  BitkitTests
-//
-//  Created by Jason van den Berg on 2024/07/23.
-//
-
 import XCTest
 
 final class LdkMigrationTests: XCTestCase {
@@ -33,7 +26,8 @@ final class LdkMigrationTests: XCTestCase {
         //            return
         //        }
         //
-        //        guard let channelFile = Bundle(for: type(of: self)).url(forResource: "adb1de43b448b04b3fdde638155929cd2163d2c53d36bb40b517d7acc44d1630", withExtension: "bin") else {
+        //        guard let channelFile = Bundle(for: type(of: self)).url(forResource:
+        //        "adb1de43b448b04b3fdde638155929cd2163d2c53d36bb40b517d7acc44d1630", withExtension: "bin") else {
         //            XCTFail("Missing file: adb1de43b448b04b3fdde638155929cd2163d2c53d36bb40b517d7acc44d1630.bin")
         //            return
         //        }

--- a/BitkitTests/StateLockerTests.swift
+++ b/BitkitTests/StateLockerTests.swift
@@ -1,10 +1,3 @@
-//
-//  StateLockerTests.swift
-//  Bitkit
-//
-//  Created by Jason van den Berg on 2024/09/19.
-//
-
 import XCTest
 
 final class StateLockerTests: XCTestCase {
@@ -50,12 +43,12 @@ final class StateLockerTests: XCTestCase {
 
     func testLockExpiry() {
         // Inject a past date for quick testing
-        let pastDate = Date().addingTimeInterval(-3600)  // 1 hour ago
+        let pastDate = Date().addingTimeInterval(-3600) // 1 hour ago
         StateLocker.injectTestDate(pastDate)
 
         XCTAssertNoThrow(try StateLocker.lock(.lightning, wait: 1))
 
-        StateLocker.injectTestDate(Date())  // Reset to current date
+        StateLocker.injectTestDate(Date()) // Reset to current date
         XCTAssertFalse(StateLocker.isLocked(.lightning))
     }
 
@@ -97,7 +90,7 @@ final class StateLockerTests: XCTestCase {
     }
 
     func testLockExpiryInDifferentEnvironments() {
-        let pastDate = Date().addingTimeInterval(-3600)  // 1 hour ago
+        let pastDate = Date().addingTimeInterval(-3600) // 1 hour ago
 
         // Set past date and lock in foreground app environment
         StateLocker.injectTestDate(pastDate)
@@ -106,7 +99,7 @@ final class StateLockerTests: XCTestCase {
 
         // Check lock status in push notification extension environment
         StateLocker.injectTestEnvironment(.pushNotificationExtension)
-        StateLocker.injectTestDate(Date())  // Reset to current date
+        StateLocker.injectTestDate(Date()) // Reset to current date
         XCTAssertFalse(StateLocker.isLocked(.lightning))
 
         // Attempt to lock in push notification extension environment
@@ -128,11 +121,11 @@ final class StateLockerTests: XCTestCase {
 
     func testLockSameEnvironment() {
         StateLocker.injectTestEnvironment(.foregroundApp)
-        
+
         // First lock
         XCTAssertNoThrow(try StateLocker.lock(.lightning, wait: 1))
         XCTAssertTrue(StateLocker.isLocked(.lightning))
-        
+
         // Second lock attempt in same environment should succeed
         XCTAssertNoThrow(try StateLocker.lock(.lightning, wait: 1))
         XCTAssertTrue(StateLocker.isLocked(.lightning))

--- a/BitkitTests/TxBumpingTests.swift
+++ b/BitkitTests/TxBumpingTests.swift
@@ -1,10 +1,3 @@
-//
-//  TxBumpingTests.swift
-//  BitkitTests
-//
-//  Created by Jason van den Berg on 2025/06/12.
-//
-
 import BitkitCore
 import LDKNode
 import XCTest
@@ -100,7 +93,7 @@ final class TxBumpingTests: XCTestCase {
 
         // Send a transaction with a low fee rate
         let destinationAddress = "bcrt1q59y53uy2h02dlqn76n824ns3maupd3mx4lfm0y"
-        let sendAmount: UInt64 = 10_000 // Send 10,000 sats
+        let sendAmount: UInt64 = 10000 // Send 10,000 sats
         let lowFeeRate: UInt32 = 1 // 1 sat/vbyte (very low)
 
         Logger.test("Sending \(sendAmount) sats to \(destinationAddress) with low fee rate of \(lowFeeRate) sat/vbyte", context: "TxBumpingTests")
@@ -215,7 +208,8 @@ final class TxBumpingTests: XCTestCase {
         // This demonstrates using CPFP to quickly move received funds
         let highFeeRate: UInt32 = 20 // 20 sat/vbyte (very high for fast confirmation)
         Logger.test(
-            "Using CPFP to quickly spend from incoming transaction \(stuckIncomingTxId) with \(highFeeRate) sat/vbyte", context: "TxBumpingTests")
+            "Using CPFP to quickly spend from incoming transaction \(stuckIncomingTxId) with \(highFeeRate) sat/vbyte", context: "TxBumpingTests"
+        )
 
         // Generate a destination address for the CPFP transaction (where we'll send the funds)
         Logger.test("Generating destination address for CPFP child transaction", context: "TxBumpingTests")

--- a/BitkitTests/UtxoSelectionTests.swift
+++ b/BitkitTests/UtxoSelectionTests.swift
@@ -1,13 +1,6 @@
-//
-//  UtxoSelectionTests.swift
-//  BitkitTests
-//
-//  Created by Jason van den Berg on 2025/06/12.
-//
-
 import BitkitCore
-import XCTest
 import LDKNode
+import XCTest
 
 @testable import Bitkit
 
@@ -69,14 +62,15 @@ final class UtxoSelectionTests: XCTestCase {
         Logger.test("Deposit address: \(depositAddress)", context: "UtxoSelectionTests")
 
         // Define different deposit amounts for 5 transactions
-        let depositAmounts: [UInt64] = [15_000, 25_000, 35_000, 45_000, 50_000] // Different amounts in sats
+        let depositAmounts: [UInt64] = [15000, 25000, 35000, 45000, 50000] // Different amounts in sats
         var totalExpectedAmount: UInt64 = 0
         var transactionIds: [String] = []
 
         // Fund the wallet with multiple transactions
         for (index, depositAmount) in depositAmounts.enumerated() {
             Logger.test(
-                "Depositing \(depositAmount) sats to wallet (transaction \(index + 1)/\(depositAmounts.count))", context: "UtxoSelectionTests")
+                "Depositing \(depositAmount) sats to wallet (transaction \(index + 1)/\(depositAmounts.count))", context: "UtxoSelectionTests"
+            )
             let txId = try await blocktank.regtestDepositFunds(address: depositAddress, amountSat: depositAmount)
             XCTAssertFalse(txId.isEmpty, "Transaction ID should not be empty")
             transactionIds.append(txId)
@@ -136,7 +130,8 @@ final class UtxoSelectionTests: XCTestCase {
 
         // Ensure all deposit amounts were matched
         XCTAssertTrue(
-            remainingDepositAmounts.isEmpty, "Not all deposit amounts were matched. Remaining unmatched amounts: \(remainingDepositAmounts)")
+            remainingDepositAmounts.isEmpty, "Not all deposit amounts were matched. Remaining unmatched amounts: \(remainingDepositAmounts)"
+        )
         Logger.test("✓ All spendable outputs successfully matched with deposit amounts", context: "UtxoSelectionTests")
 
         // Test a transaction spending specific utxos
@@ -150,13 +145,14 @@ final class UtxoSelectionTests: XCTestCase {
         Logger.test("Selected \(utxosToSpend.count) UTXOs to spend:", context: "UtxoSelectionTests")
         for (index, utxo) in utxosToSpend.enumerated() {
             Logger.test(
-                "  UTXO \(index + 1): \(utxo.outpoint.txid):\(utxo.outpoint.vout) - \(utxo.valueSats) sats", context: "UtxoSelectionTests")
+                "  UTXO \(index + 1): \(utxo.outpoint.txid):\(utxo.outpoint.vout) - \(utxo.valueSats) sats", context: "UtxoSelectionTests"
+            )
         }
         Logger.test("Total amount from selected UTXOs: \(totalSelectedAmount) sats", context: "UtxoSelectionTests")
 
         // Send transaction spending only the selected UTXOs
         let destinationAddress = "bcrt1q59y53uy2h02dlqn76n824ns3maupd3mx4lfm0y"
-        let sendAmount: UInt64 = 10_000 // Send 10,000 sats
+        let sendAmount: UInt64 = 10000 // Send 10,000 sats
         let feeRate: UInt32 = 1 // 1 sat/vbyte
 
         Logger.test("Sending \(sendAmount) sats to \(destinationAddress) using specific UTXOs", context: "UtxoSelectionTests")
@@ -213,7 +209,8 @@ final class UtxoSelectionTests: XCTestCase {
         Logger.test("Lightning node stopped successfully", context: "UtxoSelectionTests")
         Logger.test(
             "UTXO selection test completed successfully with \(depositAmounts.count) transactions totaling \(totalExpectedAmount) sats",
-            context: "UtxoSelectionTests")
+            context: "UtxoSelectionTests"
+        )
     }
 
     func testUtxoSelectionAlgorithms() async throws {
@@ -239,14 +236,15 @@ final class UtxoSelectionTests: XCTestCase {
         Logger.test("Deposit address: \(depositAddress)", context: "UtxoSelectionTests")
 
         // Define different deposit amounts for testing coin selection algorithms
-        let depositAmounts: [UInt64] = [5_000, 10_000, 20_000, 30_000, 50_000] // Different amounts in sats
+        let depositAmounts: [UInt64] = [5000, 10000, 20000, 30000, 50000] // Different amounts in sats
         var totalExpectedAmount: UInt64 = 0
 
         // Fund the wallet with multiple transactions
         for (index, depositAmount) in depositAmounts.enumerated() {
             Logger.test(
                 "Depositing \(depositAmount) sats to wallet (transaction \(index + 1)/\(depositAmounts.count))",
-                context: "UtxoSelectionTests")
+                context: "UtxoSelectionTests"
+            )
             let txId = try await blocktank.regtestDepositFunds(address: depositAddress, amountSat: depositAmount)
             XCTAssertFalse(txId.isEmpty, "Transaction ID should not be empty")
             totalExpectedAmount += depositAmount
@@ -277,7 +275,7 @@ final class UtxoSelectionTests: XCTestCase {
         XCTAssertEqual(allUtxos.count, depositAmounts.count, "Number of UTXOs should match number of deposits")
 
         // Test parameters
-        let targetAmountSats: UInt64 = 25_000 // Target amount for selection
+        let targetAmountSats: UInt64 = 25000 // Target amount for selection
         let feeRate: UInt32 = 1 // 1 sat/vbyte
 
         // Test each coin selection algorithm
@@ -298,16 +296,19 @@ final class UtxoSelectionTests: XCTestCase {
             let selectedAmount = selectedUtxos.reduce(0) { $0 + $1.valueSats }
             Logger.test(
                 "Algorithm \(algorithm) selected \(selectedUtxos.count) UTXOs with total amount: \(selectedAmount) sats",
-                context: "UtxoSelectionTests")
+                context: "UtxoSelectionTests"
+            )
 
             // Verify that the selected amount is sufficient for the target amount
             XCTAssertGreaterThanOrEqual(
-                selectedAmount, targetAmountSats, "Selected amount should be at least the target amount for algorithm \(algorithm)")
+                selectedAmount, targetAmountSats, "Selected amount should be at least the target amount for algorithm \(algorithm)"
+            )
 
             // Log details of selected UTXOs
             for (index, utxo) in selectedUtxos.enumerated() {
                 Logger.test(
-                    "  UTXO \(index + 1): \(utxo.outpoint.txid):\(utxo.outpoint.vout) - \(utxo.valueSats) sats", context: "UtxoSelectionTests")
+                    "  UTXO \(index + 1): \(utxo.outpoint.txid):\(utxo.outpoint.vout) - \(utxo.valueSats) sats", context: "UtxoSelectionTests"
+                )
             }
 
             Logger.test("✓ Algorithm \(algorithm) successfully selected UTXOs", context: "UtxoSelectionTests")
@@ -317,7 +318,7 @@ final class UtxoSelectionTests: XCTestCase {
         Logger.test("Testing algorithm-specific behaviors with different target amounts", context: "UtxoSelectionTests")
 
         // Test with small amount (should prefer smaller UTXOs)
-        let smallTargetAmount: UInt64 = 7_000
+        let smallTargetAmount: UInt64 = 7000
         let smallAmountUtxos = try await lightning.selectUtxosWithAlgorithm(
             targetAmountSats: smallTargetAmount,
             satsPerVbyte: feeRate,
@@ -327,7 +328,7 @@ final class UtxoSelectionTests: XCTestCase {
         Logger.test("Largest first for \(smallTargetAmount) sats selected \(smallAmountUtxos.count) UTXOs", context: "UtxoSelectionTests")
 
         // Test with large amount (might need multiple UTXOs)
-        let largeTargetAmount: UInt64 = 80_000
+        let largeTargetAmount: UInt64 = 80000
         let largeAmountUtxos = try await lightning.selectUtxosWithAlgorithm(
             targetAmountSats: largeTargetAmount,
             satsPerVbyte: feeRate,
@@ -343,14 +344,15 @@ final class UtxoSelectionTests: XCTestCase {
         Logger.test("Testing coin selection with subset of UTXOs", context: "UtxoSelectionTests")
         let subsetUtxos = Array(allUtxos.prefix(3)) // Use only first 3 UTXOs
         let subsetSelectedUtxos = try await lightning.selectUtxosWithAlgorithm(
-            targetAmountSats: 15_000,
+            targetAmountSats: 15000,
             satsPerVbyte: feeRate,
             coinSelectionAlgorythm: .branchAndBound,
             utxos: subsetUtxos
         )
         Logger.test(
             "Branch and bound with subset selected \(subsetSelectedUtxos.count) UTXOs from \(subsetUtxos.count) available",
-            context: "UtxoSelectionTests")
+            context: "UtxoSelectionTests"
+        )
 
         // Clean up by stopping the lightning node
         Logger.test("Stopping lightning node", context: "UtxoSelectionTests")

--- a/BitkitUITests/BitkitUITests.swift
+++ b/BitkitUITests/BitkitUITests.swift
@@ -1,10 +1,3 @@
-//
-//  BitkitUITests.swift
-//  BitkitUITests
-//
-//  Created by Jason van den Berg on 2024/06/27.
-//
-
 import XCTest
 
 final class BitkitUITests: XCTestCase {
@@ -14,7 +7,8 @@ final class BitkitUITests: XCTestCase {
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp
+        // method is a good place to do this.
     }
 
     override func tearDownWithError() throws {

--- a/BitkitUITests/BitkitUITestsLaunchTests.swift
+++ b/BitkitUITests/BitkitUITestsLaunchTests.swift
@@ -1,10 +1,3 @@
-//
-//  BitkitUITestsLaunchTests.swift
-//  BitkitUITests
-//
-//  Created by Jason van den Berg on 2024/06/27.
-//
-
 import XCTest
 
 final class BitkitUITestsLaunchTests: XCTestCase {

--- a/README.md
+++ b/README.md
@@ -29,17 +29,33 @@ node scripts/validate-translations.js
 
 ## Development
 
-### Git Hooks
+### Formatting
 
-This project uses pre-commit hooks to ensure code quality. To set up the hooks, run:
+This project uses [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) for code formatting. Configuration is in `.swiftformat`.
 
+**Install SwiftFormat:**
 ```bash
-chmod +x scripts/setup-hooks.sh
-./scripts/setup-hooks.sh
+brew install swiftformat
 ```
 
-This will install the pre-commit hook that runs various checks before each commit, including:
-- Running swift-format on staged Swift files
+**IDE Extensions:**
+- [VSCode extension](https://open-vsx.org/extension/vknabel/vscode-swiftformat)
+- [Xcode extension](https://github.com/nicklockwood/SwiftFormat#xcode-source-editor-extension)
+
+**Format code:**
+```bash
+swiftformat .
+```
+
+### Git Hooks
+
+The project includes git hooks to automatically check code formatting before commits.
+
+**Set up git hooks:**
+1. Install [git-format-staged](https://github.com/hallettj/git-format-staged): `npm install -g git-format-staged`
+2. Run: `./scripts/setup-hooks.sh`
+
+This installs a pre-commit hook that lints Swift files with SwiftFormat.
 
 ### Xcode Previews
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-# Force color output for better readability
-export FORCE_COLOR=1
-
-echo "🔍 Checking staged files for lint issues..."
+echo "🔍 Checking staged Swift files for formatting issues..."
 
 # Get list of staged .swift files
-FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$')
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$')
 
 # Exit early if no Swift files are staged
-if [ -z "$FILES" ]; then
+if [ -z "$STAGED_FILES" ]; then
     echo "✨ No Swift files staged for commit."
     exit 0
 fi
@@ -17,63 +14,48 @@ fi
 # Initialize error flag
 HAS_ERRORS=0
 
-for FILE in $FILES; do
+# Create a temporary directory for staged content
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Copy .swiftformat config to temp directory
+cp .swiftformat "$TEMP_DIR/"
+
+for FILE in $STAGED_FILES; do
     if [ ! -f "$FILE" ]; then
         continue
     fi
-
-    # Store original file path for output
-    ORIGINAL_FILE="$FILE"
     
-    # Extract project name from the original file path
-    PROJECT_NAME=$(echo "$ORIGINAL_FILE" | cut -d'/' -f1)
-
-    # Create a temporary directory with the same structure as the file
-    TEMP_DIR=$(mktemp -d)
+    # Create directory structure in temp
     mkdir -p "$TEMP_DIR/$(dirname "$FILE")"
     
-    # Copy the swift-format configuration
-    cp .swift-format "$TEMP_DIR/"
+    # Get staged content of the file
+    git show :"$FILE" > "$TEMP_DIR/$FILE" 2>/dev/null || {
+        echo "⚠️  Could not get staged content for $FILE, skipping..."
+        continue
+    }
     
-    # Get the base file (either from HEAD or empty for new files)
-    if git show HEAD:"$FILE" > /dev/null 2>&1; then
-        git show HEAD:"$FILE" > "$TEMP_DIR/$FILE"
-    else
-        touch "$TEMP_DIR/$FILE"
-    fi
-    
-    # Apply staged changes silently
-    git diff --cached "$FILE" | patch -s -N "$TEMP_DIR/$FILE"
-    
-    # Run swift-format lint and capture output while preserving colors
+    # Run swiftformat --lint on the staged content
     cd "$TEMP_DIR"
-    LINT_OUTPUT=$(script -q /dev/null swift-format lint "$FILE" 2>&1)
-    
-    # Remove the ^D character that script adds
-    LINT_OUTPUT=$(echo "$LINT_OUTPUT" | tr -d '\r')
-    
-    # Strip ANSI color codes for error checking
-    STRIPPED_OUTPUT=$(echo "$LINT_OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
-    
-    # Check if there are actual lint errors (lines containing ": warning: [" or ": error: [")
-    if echo "$STRIPPED_OUTPUT" | grep -q ": \(warning\|error\): \["; then
-        # Replace both the temporary file path and /private prefix with the original file path
-        echo "$LINT_OUTPUT" | sed "s|$TEMP_DIR/$FILE|$ORIGINAL_FILE|g" | sed "s|/private$PROJECT_NAME/|$PROJECT_NAME/|g"
-        echo "❌ Linting issues found in $ORIGINAL_FILE"
-        HAS_ERRORS=1
-    fi
+    LINT_OUTPUT=$(swiftformat --lint "$FILE" 2>&1)
+    LINT_EXIT_CODE=$?
     cd - > /dev/null
     
-    # Clean up temporary directory
-    rm -rf "$TEMP_DIR"
+    # Check if linting failed
+    if [ $LINT_EXIT_CODE -ne 0 ]; then
+        # Replace temp path with original path in output
+        echo "$LINT_OUTPUT" | sed "s|$TEMP_DIR/||g"
+        echo "❌ Formatting issues found in $FILE"
+        HAS_ERRORS=1
+    fi
 done
 
-# Exit with error if any staged changes failed linting
+# Exit with error if any files failed linting
 if [ $HAS_ERRORS -eq 1 ]; then
     echo ""
-    echo "🚫 Commit blocked: Linting issues found."
-    echo "Please fix the linting issues and try committing again."
+    echo "🚫 Commit blocked: Formatting issues found in staged files."
+    echo "Run 'swiftformat .' to fix formatting issues, then commit again."
     exit 1
 fi
 
-echo "✨ All staged changes passed linting."
+echo "✨ All staged changes passed formatting checks."


### PR DESCRIPTION
### Description

We use [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) for formatting and linting. This PR updates the `.swiftformat` config and ensures that IDE plugins and the `pre-commit` git hook also use SwiftFormat instead of apple's [swift-format](https://github.com/swiftlang/swift-format). Configuration is mostly default except for a few rules that make the code easier to read for devs not familiar with Swift's very concise syntax (implicit return, and-chaining etc.).

- add `.swiftformat` config file to align IDE plugin config with `swiftformat`
- format all files
- update `pre-commit` git hook to use `swiftformat`
- add "Formatting" section to README.md
