### PR TITLE
refactor: localized string

### DIFF
--- a/Bitkit/Components/Activity/ActivityList.swift
+++ b/Bitkit/Components/Activity/ActivityList.swift
@@ -43,7 +43,7 @@ struct ActivityList: View {
                 }
             }
         } else {
-            BodyMText(localizedString("wallet__activity_no"))
+            BodyMText(t("wallet__activity_no"))
                 .padding()
         }
     }

--- a/Bitkit/Components/CopyAddressCard.swift
+++ b/Bitkit/Components/CopyAddressCard.swift
@@ -31,7 +31,7 @@ struct CopyAddressCard: View {
 
                         HStack(spacing: 8) {
                             CustomButton(
-                                title: localizedString("common__copy"),
+                                title: t("common__copy"),
                                 size: .small,
                                 icon: Image("copy").foregroundColor(pair.type == .lightning ? .purpleAccent : .brandAccent),
                                 shouldExpand: true
@@ -41,7 +41,7 @@ struct CopyAddressCard: View {
 
                             ShareLink(item: URL(string: pair.address)!) {
                                 CustomButton(
-                                    title: localizedString("common__share"),
+                                    title: t("common__share"),
                                     size: .small,
                                     icon: Image("share").foregroundColor(pair.type == .lightning ? .purpleAccent : .brandAccent),
                                     shouldExpand: true
@@ -56,7 +56,7 @@ struct CopyAddressCard: View {
                             Spacer()
                                 .frame(height: 60) // Position below address text
 
-                            Tooltip(text: localizedString("wallet__receive_copied"))
+                            Tooltip(text: t("wallet__receive_copied"))
                                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
                         }
                         .frame(maxWidth: .infinity, alignment: .center)

--- a/Bitkit/Components/DrawerView.swift
+++ b/Bitkit/Components/DrawerView.swift
@@ -28,14 +28,14 @@ enum DrawerMenuItem: Int, CaseIterable, Identifiable, Hashable {
 
     var label: String {
         switch self {
-        case .wallet: return localizedString("wallet__drawer__wallet")
-        case .activity: return localizedString("wallet__drawer__activity")
-        case .contacts: return localizedString("wallet__drawer__contacts")
-        case .profile: return localizedString("wallet__drawer__profile")
-        case .widgets: return localizedString("wallet__drawer__widgets")
-        case .shop: return localizedString("wallet__drawer__shop")
-        case .settings: return localizedString("wallet__drawer__settings")
-        case .appStatus: return localizedString("settings__status__title")
+        case .wallet: return t("wallet__drawer__wallet")
+        case .activity: return t("wallet__drawer__activity")
+        case .contacts: return t("wallet__drawer__contacts")
+        case .profile: return t("wallet__drawer__profile")
+        case .widgets: return t("wallet__drawer__widgets")
+        case .shop: return t("wallet__drawer__shop")
+        case .settings: return t("wallet__drawer__settings")
+        case .appStatus: return t("settings__status__title")
         }
     }
 

--- a/Bitkit/Components/EmptyStateView.swift
+++ b/Bitkit/Components/EmptyStateView.swift
@@ -36,7 +36,7 @@ struct EmptyStateView: View {
 
             HStack(alignment: .bottom, spacing: 0) {
                 DisplayText(
-                    NSLocalizedString(type.localizationKey, comment: ""),
+                    t(type.localizationKey),
                     accentColor: type.accentColor
                 )
                 .frame(width: 224)

--- a/Bitkit/Components/Home/Suggestions.swift
+++ b/Bitkit/Components/Home/Suggestions.swift
@@ -25,80 +25,80 @@ enum SuggestionAction: Hashable {
 let cards: [SuggestionCardData] = [
     SuggestionCardData(
         id: "backupSeedPhrase",
-        title: localizedString("cards__backupSeedPhrase__title"),
-        description: localizedString("cards__backupSeedPhrase__description"),
+        title: t("cards__backupSeedPhrase__title"),
+        description: t("cards__backupSeedPhrase__description"),
         imageName: "safe",
         color: .blue24,
         action: .backup
     ),
     SuggestionCardData(
         id: "transferToSpending",
-        title: localizedString("cards__lightning__title"),
-        description: localizedString("cards__lightning__description"),
+        title: t("cards__lightning__title"),
+        description: t("cards__lightning__description"),
         imageName: "lightning",
         color: .purple24,
         action: .transferToSpending
     ),
     SuggestionCardData(
         id: "pin",
-        title: localizedString("cards__pin__title"),
-        description: localizedString("cards__pin__description"),
+        title: t("cards__pin__title"),
+        description: t("cards__pin__description"),
         imageName: "shield-figure",
         color: .green24,
         action: .secure
     ),
     SuggestionCardData(
         id: "buyBitcoin",
-        title: localizedString("cards__buyBitcoin__title"),
-        description: localizedString("cards__buyBitcoin__description"),
+        title: t("cards__buyBitcoin__title"),
+        description: t("cards__buyBitcoin__description"),
         imageName: "b-emboss",
         color: .brand24,
         action: .buyBitcoin
     ),
     SuggestionCardData(
         id: "support",
-        title: localizedString("cards__support__title"),
-        description: localizedString("cards__support__description"),
+        title: t("cards__support__title"),
+        description: t("cards__support__description"),
         imageName: "lightbulb",
         color: .yellow24,
         action: .support
     ),
     SuggestionCardData(
         id: "invite",
-        title: localizedString("cards__invite__title"),
-        description: localizedString("cards__invite__description"),
+        title: t("cards__invite__title"),
+        description: t("cards__invite__description"),
         imageName: "group",
         color: .blue24,
         action: .invite
     ),
     SuggestionCardData(
         id: "quickpay",
-        title: localizedString("cards__quickpay__title"),
-        description: localizedString("cards__quickpay__description"),
+        title: t("cards__quickpay__title"),
+        description: t("cards__quickpay__description"),
         imageName: "fast-forward",
         color: .green24,
         action: .quickpay
     ),
     SuggestionCardData(
         id: "notifications",
-        title: localizedString("cards__notifications__title"),
-        description: localizedString("cards__notifications__description"),
+        title: t("cards__notifications__title"),
+        description: t("cards__notifications__description"),
         imageName: "bell-figure",
         color: .purple24,
         action: .notifications
     ),
     SuggestionCardData(
         id: "shop",
-        title: localizedString("cards__shop__title"),
-        description: localizedString("cards__shop__description"),
+        title: t("cards__shop__title"),
+        description: t("cards__shop__description"),
         imageName: "bag",
         color: .yellow24,
         action: .shop
     ),
     SuggestionCardData(
         id: "profile",
-        title: localizedString("cards__slashtagsProfile__title"),
-        description: localizedString("cards__slashtagsProfile__description"),
+        title: t("cards__slashtagsProfile__title"),
+        description: t("cards__slashtagsProfile__description"),
         imageName: "crown",
         color: .brand24,
         action: .profile
@@ -149,7 +149,7 @@ struct Suggestions: View {
             EmptyView()
         } else {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionMText(localizedString("cards__suggestions"))
+                CaptionMText(t("cards__suggestions"))
                     .padding(.horizontal)
                     .padding(.bottom, 16)
 
@@ -175,7 +175,7 @@ struct Suggestions: View {
             .padding(.top, 32)
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: [
-                    localizedString(
+                    t(
                         "settings__about__shareText",
                         variables: [
                             "appStoreUrl": Env.appStoreUrl,

--- a/Bitkit/Components/Home/Widgets.swift
+++ b/Bitkit/Components/Home/Widgets.swift
@@ -22,7 +22,7 @@ struct Widgets: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                CaptionMText(localizedString("widgets__widgets"))
+                CaptionMText(t("widgets__widgets"))
 
                 Spacer()
 
@@ -56,7 +56,7 @@ struct Widgets: View {
             }
 
             CustomButton(
-                title: localizedString("widgets__add"), variant: .tertiary, size: .large, icon: Image("plus")
+                title: t("widgets__add"), variant: .tertiary, size: .large, icon: Image("plus")
             ) {
                 if app.hasSeenWidgetsIntro {
                     navigation.navigate(.widgetsList)

--- a/Bitkit/Components/LightningChannel.swift
+++ b/Bitkit/Components/LightningChannel.swift
@@ -86,11 +86,11 @@ struct LightningChannel: View {
         VStack(spacing: 8) {
             if showLabels {
                 HStack {
-                    CaptionMText(NSLocalizedString("lightning__spending_label", comment: ""))
+                    CaptionMText(t("lightning__spending_label"))
 
                     Spacer()
 
-                    CaptionMText(NSLocalizedString("lightning__receiving_label", comment: ""))
+                    CaptionMText(t("lightning__receiving_label"))
                 }
             }
 

--- a/Bitkit/Components/SeedInputAccessory.swift
+++ b/Bitkit/Components/SeedInputAccessory.swift
@@ -14,7 +14,7 @@ struct SeedInputAccessory: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            CaptionText(localizedString("onboarding__restore_suggestions"))
+            CaptionText(t("onboarding__restore_suggestions"))
                 .padding(.horizontal, 32)
                 .padding(.vertical, 12)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Bitkit/Components/TabBar.swift
+++ b/Bitkit/Components/TabBar.swift
@@ -46,7 +46,7 @@ struct TabBar: View {
                                     .aspectRatio(contentMode: .fit)
                                     .frame(height: 16)
                                     .rotationEffect(.degrees(180))
-                                BodySSBText(localizedString("wallet__send"))
+                                BodySSBText(t("wallet__send"))
                             }
                             .foregroundColor(.white)
                         }
@@ -64,7 +64,7 @@ struct TabBar: View {
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
                                     .frame(height: 16)
-                                BodySSBText(localizedString("wallet__receive"))
+                                BodySSBText(t("wallet__receive"))
                             }
                             .foregroundColor(.white)
                         }

--- a/Bitkit/Components/Widgets/BaseWidget.swift
+++ b/Bitkit/Components/Widgets/BaseWidget.swift
@@ -45,7 +45,7 @@ enum WidgetContentBuilder {
     static func sourceRow(source: String) -> some View {
         HStack(spacing: 0) {
             HStack {
-                CaptionBText(localizedString("widgets__widget__source"))
+                CaptionBText(t("widgets__widget__source"))
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -193,20 +193,20 @@ struct BaseWidget<Content: View>: View {
         .background(Color.white10)
         .cornerRadius(16)
         .alert(
-            localizedString("widgets__delete__title"),
+            t("widgets__delete__title"),
             isPresented: $showDeleteDialog,
             actions: {
-                Button(localizedString("common__cancel"), role: .cancel) {
+                Button(t("common__cancel"), role: .cancel) {
                     showDeleteDialog = false
                 }
 
-                Button(localizedString("common__delete_yes"), role: .destructive) {
+                Button(t("common__delete_yes"), role: .destructive) {
                     widgets.deleteWidget(type)
                     showDeleteDialog = false
                 }
             },
             message: {
-                Text(localizedString("widgets__delete__description", variables: ["name": metadata.name]))
+                Text(t("widgets__delete__description", variables: ["name": metadata.name]))
             }
         )
     }

--- a/Bitkit/Components/Widgets/BlocksWidget.swift
+++ b/Bitkit/Components/Widgets/BlocksWidget.swift
@@ -62,7 +62,7 @@ struct BlocksWidget: View {
                 if viewModel.isLoading {
                     WidgetContentBuilder.loadingView()
                 } else if viewModel.error != nil {
-                    WidgetContentBuilder.errorView(localizedString("widgets__blocks__error"))
+                    WidgetContentBuilder.errorView(t("widgets__blocks__error"))
                 } else if let data = viewModel.blockData {
                     VStack(spacing: 0) {
                         // Display block data rows based on options

--- a/Bitkit/Components/Widgets/NewsWidget.swift
+++ b/Bitkit/Components/Widgets/NewsWidget.swift
@@ -42,7 +42,7 @@ struct NewsWidget: View {
                 if viewModel.isLoading {
                     WidgetContentBuilder.loadingView()
                 } else if viewModel.error != nil {
-                    WidgetContentBuilder.errorView(localizedString("widgets__news__error"))
+                    WidgetContentBuilder.errorView(t("widgets__news__error"))
                 } else if let data = viewModel.widgetData {
                     if options.showDate {
                         BodyMText(data.timeAgo, textColor: .textPrimary)

--- a/Bitkit/Components/Widgets/PriceWidget.swift
+++ b/Bitkit/Components/Widgets/PriceWidget.swift
@@ -43,7 +43,7 @@ struct PriceWidget: View {
                 if viewModel.isLoading && filteredPriceData.isEmpty {
                     WidgetContentBuilder.loadingView()
                 } else if viewModel.error != nil {
-                    WidgetContentBuilder.errorView(localizedString("widgets__price__error"))
+                    WidgetContentBuilder.errorView(t("widgets__price__error"))
                 } else {
                     ForEach(filteredPriceData, id: \.name) { priceData in
                         PriceRow(data: priceData)

--- a/Bitkit/Components/Widgets/WeatherWidget.swift
+++ b/Bitkit/Components/Widgets/WeatherWidget.swift
@@ -17,22 +17,22 @@ enum FeeCondition: String, Codable {
     var title: String {
         switch self {
         case .good:
-            return localizedString("widgets__weather__condition__good__title")
+            return t("widgets__weather__condition__good__title")
         case .average:
-            return localizedString("widgets__weather__condition__average__title")
+            return t("widgets__weather__condition__average__title")
         case .poor:
-            return localizedString("widgets__weather__condition__poor__title")
+            return t("widgets__weather__condition__poor__title")
         }
     }
 
     var description: String {
         switch self {
         case .good:
-            return localizedString("widgets__weather__condition__good__description")
+            return t("widgets__weather__condition__good__description")
         case .average:
-            return localizedString("widgets__weather__condition__average__description")
+            return t("widgets__weather__condition__average__description")
         case .poor:
-            return localizedString("widgets__weather__condition__poor__description")
+            return t("widgets__weather__condition__poor__description")
         }
     }
 
@@ -93,7 +93,7 @@ struct WeatherWidget: View {
                 if viewModel.isLoading {
                     WidgetContentBuilder.loadingView()
                 } else if viewModel.error != nil {
-                    WidgetContentBuilder.errorView(localizedString("widgets__weather__error"))
+                    WidgetContentBuilder.errorView(t("widgets__weather__error"))
                 } else if let data = viewModel.weatherData {
                     VStack(spacing: 16) {
                         // Status condition with icon
@@ -121,7 +121,7 @@ struct WeatherWidget: View {
                                 if options.showMedian {
                                     HStack(spacing: 0) {
                                         HStack {
-                                            BodySSBText(localizedString("widgets__weather__current_fee"), textColor: .textSecondary)
+                                            BodySSBText(t("widgets__weather__current_fee"), textColor: .textSecondary)
                                                 .lineLimit(1)
                                         }
                                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -138,7 +138,7 @@ struct WeatherWidget: View {
                                 if options.showNextBlockFee {
                                     HStack(spacing: 0) {
                                         HStack {
-                                            BodySSBText(localizedString("widgets__weather__next_block"), textColor: .textSecondary)
+                                            BodySSBText(t("widgets__weather__next_block"), textColor: .textSecondary)
                                                 .lineLimit(1)
                                         }
                                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Bitkit/Components/Widgets/WidgetListItem.swift
+++ b/Bitkit/Components/Widgets/WidgetListItem.swift
@@ -8,11 +8,11 @@ struct WidgetListItem: View {
 
     // Widget data computed from the ID
     private var widget: (name: String, description: String, icon: String) {
-        let name = localizedString("widgets__\(id.rawValue)__name")
+        let name = t("widgets__\(id.rawValue)__name")
 
         // Get fiat symbol from currency conversion
         let fiatSymbol = currency.symbol
-        let description = localizedString("widgets__\(id.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
+        let description = t("widgets__\(id.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
         let icon = "\(id.rawValue)-widget"
 
         return (name: name, description: description, icon: icon)

--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -158,8 +158,8 @@ struct MainNavView: View {
                     Logger.error(error, context: "Failed to handle deeplink")
                     app.toast(
                         type: .error,
-                        title: localizedString("other__qr_error_header"),
-                        description: localizedString("other__qr_error_text")
+                        title: t("other__qr_error_header"),
+                        description: t("other__qr_error_text")
                     )
                 }
             }
@@ -392,8 +392,8 @@ struct MainNavView: View {
                 Logger.error(error, context: "Failed to read data from clipboard")
                 app.toast(
                     type: .error,
-                    title: localizedString("other__qr_error_header"),
-                    description: localizedString("other__qr_error_text")
+                    title: t("other__qr_error_header"),
+                    description: t("other__qr_error_text")
                 )
             }
         }

--- a/Bitkit/Models/TransactionSpeed.swift
+++ b/Bitkit/Models/TransactionSpeed.swift
@@ -39,7 +39,7 @@ public enum TransactionSpeed: Equatable, RawRepresentable {
     public var customSetSpeed: String? {
         switch self {
         case let .custom(satsPerVByte):
-            return "\(satsPerVByte) \(NSLocalizedString("common__sat_vbyte_compact", comment: ""))"
+            return "\(satsPerVByte) \(t("common__sat_vbyte_compact"))"
         default:
             return nil
         }
@@ -48,52 +48,52 @@ public enum TransactionSpeed: Equatable, RawRepresentable {
     public var displayTitle: String {
         switch self {
         case .fast:
-            return NSLocalizedString("fee__fast__title", comment: "")
+            return t("fee__fast__title")
         case .medium:
-            return NSLocalizedString("fee__normal__title", comment: "")
+            return t("fee__normal__title")
         case .slow:
-            return NSLocalizedString("fee__slow__title", comment: "")
+            return t("fee__slow__title")
         case .custom:
-            return NSLocalizedString("fee__custom__title", comment: "")
+            return t("fee__custom__title")
         }
     }
 
     public var displayLabel: String {
         switch self {
         case .fast:
-            return NSLocalizedString("settings__fee__fast__label", comment: "")
+            return t("settings__fee__fast__label")
         case .medium:
-            return NSLocalizedString("settings__fee__normal__label", comment: "")
+            return t("settings__fee__normal__label")
         case .slow:
-            return NSLocalizedString("settings__fee__slow__label", comment: "")
+            return t("settings__fee__slow__label")
         case .custom:
-            return NSLocalizedString("settings__fee__custom__label", comment: "")
+            return t("settings__fee__custom__label")
         }
     }
 
     public var displayValue: String {
         switch self {
         case .fast:
-            return NSLocalizedString("settings__fee__fast__value", comment: "")
+            return t("settings__fee__fast__value")
         case .medium:
-            return NSLocalizedString("settings__fee__normal__value", comment: "")
+            return t("settings__fee__normal__value")
         case .slow:
-            return NSLocalizedString("settings__fee__slow__value", comment: "")
+            return t("settings__fee__slow__value")
         case .custom:
-            return NSLocalizedString("settings__fee__custom__value", comment: "")
+            return t("settings__fee__custom__value")
         }
     }
 
     public var displayDescription: String {
         switch self {
         case .fast:
-            return NSLocalizedString("settings__fee__fast__description", comment: "")
+            return t("settings__fee__fast__description")
         case .medium:
-            return NSLocalizedString("settings__fee__normal__description", comment: "")
+            return t("settings__fee__normal__description")
         case .slow:
-            return NSLocalizedString("settings__fee__slow__description", comment: "")
+            return t("settings__fee__slow__description")
         case .custom:
-            return NSLocalizedString("settings__fee__custom__description", comment: "")
+            return t("settings__fee__custom__description")
         }
     }
 

--- a/Bitkit/Models/WalletType.swift
+++ b/Bitkit/Models/WalletType.swift
@@ -7,9 +7,9 @@ enum WalletType {
     var title: String {
         switch self {
         case .onchain:
-            return NSLocalizedString("lightning__savings", comment: "").uppercased()
+            return t("lightning__savings").uppercased()
         case .lightning:
-            return NSLocalizedString("lightning__spending", comment: "").uppercased()
+            return t("lightning__spending").uppercased()
         }
     }
 

--- a/Bitkit/Styles/TextStyle.swift
+++ b/Bitkit/Styles/TextStyle.swift
@@ -618,10 +618,10 @@ private struct FlexibleTextView: View {
 #Preview {
     ScrollView {
         HStack {
-            DisplayText(NSLocalizedString("onboarding__empty_wallet", comment: ""))
+            DisplayText(t("onboarding__empty_wallet"))
                 .background(Color.red.opacity(0.1))
 
-            DisplayText(NSLocalizedString("onboarding__welcome_title", comment: ""))
+            DisplayText(t("onboarding__welcome_title"))
                 .background(Color.blue.opacity(0.1))
         }
         .padding(.bottom, 20)
@@ -635,7 +635,7 @@ private struct FlexibleTextView: View {
         }
         .padding(.bottom, 20)
 
-        DisplayText(NSLocalizedString("onboarding__slide0_header", comment: ""))
+        DisplayText(t("onboarding__slide0_header"))
             .background(Color.orange.opacity(0.1))
             .padding(.bottom, 20)
 

--- a/Bitkit/Utilities/AppReset.swift
+++ b/Bitkit/Utilities/AppReset.swift
@@ -26,8 +26,8 @@ enum AppReset {
         // 4) Show toast
         app.toast(
             type: toastType,
-            title: localizedString("security__wiped_title"),
-            description: localizedString("security__wiped_message")
+            title: t("security__wiped_title"),
+            description: t("security__wiped_message")
         )
     }
 }

--- a/Bitkit/Utilities/DateFormatterHelpers.swift
+++ b/Bitkit/Utilities/DateFormatterHelpers.swift
@@ -136,10 +136,10 @@ enum DateFormatterHelpers {
 
         if date >= beginningOfWeek {
             // This week - return localized "This week"
-            return localizedString("wallet__activity_group_week", comment: "Activity group header for current week")
+            return t("wallet__activity_group_week", comment: "Activity group header for current week")
         } else if date >= beginningOfMonth {
             // This month - return localized "This month"
-            return localizedString("wallet__activity_group_month", comment: "Activity group header for current month")
+            return t("wallet__activity_group_month", comment: "Activity group header for current month")
         } else if date >= beginningOfYear {
             // This year - use month and year
             let monthYearFormatter = DateFormatter()

--- a/Bitkit/Utilities/LocalizeHelpers.swift
+++ b/Bitkit/Utilities/LocalizeHelpers.swift
@@ -59,7 +59,8 @@ enum LocalizationHelper {
 
 // MARK: - Public API
 
-func localizedString(_ key: String, comment: String = "", variables: [String: String] = [:]) -> String {
+// The main function for getting a localized string
+func t(_ key: String, comment: String = "", variables: [String: String] = [:]) -> String {
     var localizedString = LocalizationHelper.getString(for: key, comment: comment)
 
     // Replace variables
@@ -70,6 +71,7 @@ func localizedString(_ key: String, comment: String = "", variables: [String: St
     return localizedString
 }
 
+// Get a random line from a localized string
 func localizedRandom(_ key: String, comment: String = "") -> String {
     let localizedString = LocalizationHelper.getString(for: key, comment: comment)
     let components = localizedString.components(separatedBy: "\n")

--- a/Bitkit/ViewModels/AppViewModel.swift
+++ b/Bitkit/ViewModels/AppViewModel.swift
@@ -273,8 +273,8 @@ extension AppViewModel {
         if lightningBalance < data.minSendable {
             toast(
                 type: .warning,
-                title: localizedString("other__lnurl_pay_error"),
-                description: localizedString("other__lnurl_pay_error_no_capacity")
+                title: t("other__lnurl_pay_error"),
+                description: t("other__lnurl_pay_error_no_capacity")
             )
             return
         }
@@ -294,8 +294,8 @@ extension AppViewModel {
         if (data.minWithdrawable ?? 1000) > data.maxWithdrawable {
             toast(
                 type: .warning,
-                title: localizedString("other__lnurl_withdr_error"),
-                description: localizedString("other__lnurl_withdr_error_minmax")
+                title: t("other__lnurl_withdr_error"),
+                description: t("other__lnurl_withdr_error_minmax")
             )
             return
         }
@@ -305,8 +305,8 @@ extension AppViewModel {
         if lightningBalance < (data.minWithdrawable ?? 1000) / 1000 {
             toast(
                 type: .warning,
-                title: localizedString("other__lnurl_withdr_error"),
-                description: localizedString("other__lnurl_withdr_error_no_capacity")
+                title: t("other__lnurl_withdr_error"),
+                description: t("other__lnurl_withdr_error_no_capacity")
             )
             return
         }

--- a/Bitkit/ViewModels/WidgetsViewModel.swift
+++ b/Bitkit/ViewModels/WidgetsViewModel.swift
@@ -38,8 +38,8 @@ struct WidgetMetadata {
     let icon: String
 
     init(type: WidgetType, fiatSymbol: String = "$") {
-        name = localizedString("widgets__\(type.rawValue)__name")
-        description = localizedString("widgets__\(type.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
+        name = t("widgets__\(type.rawValue)__name")
+        description = t("widgets__\(type.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
         icon = "\(type.rawValue)-widget"
     }
 }

--- a/Bitkit/Views/Backup/BackupConfirmMnemonic.swift
+++ b/Bitkit/Views/Backup/BackupConfirmMnemonic.swift
@@ -11,10 +11,10 @@ struct BackupConfirmMnemonic: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("security__mnemonic_confirm"), showBackButton: true)
+            SheetHeader(title: t("security__mnemonic_confirm"), showBackButton: true)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__mnemonic_confirm_tap"))
+                BodyMText(t("security__mnemonic_confirm_tap"))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.bottom, 16)
 
@@ -62,7 +62,7 @@ struct BackupConfirmMnemonic: View {
 
                 HStack(alignment: .center, spacing: 16) {
                     CustomButton(
-                        title: localizedString("common__continue"),
+                        title: t("common__continue"),
                         isDisabled: selectedWords != mnemonic,
                     ) {
                         if let passphrase, !passphrase.isEmpty {

--- a/Bitkit/Views/Backup/BackupConfirmPassphrase.swift
+++ b/Bitkit/Views/Backup/BackupConfirmPassphrase.swift
@@ -9,14 +9,14 @@ struct BackupConfirmPassphrase: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("security__pass_confirm"), showBackButton: true)
+            SheetHeader(title: t("security__pass_confirm"), showBackButton: true)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__pass_confirm_text"))
+                BodyMText(t("security__pass_confirm_text"))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.bottom, 32)
 
-                TextField(localizedString("security__pass").capitalized, text: $enteredText)
+                TextField(t("security__pass").capitalized, text: $enteredText)
                     .focused($isTextFieldFocused)
                     .autocapitalization(.none)
                     .autocorrectionDisabled(true)
@@ -27,7 +27,7 @@ struct BackupConfirmPassphrase: View {
 
                 HStack(alignment: .center, spacing: 16) {
                     CustomButton(
-                        title: localizedString("common__continue"),
+                        title: t("common__continue"),
                         isDisabled: enteredText != passphrase,
                     ) {
                         navigationPath.append(.reminder)

--- a/Bitkit/Views/Backup/BackupDevices.swift
+++ b/Bitkit/Views/Backup/BackupDevices.swift
@@ -5,10 +5,10 @@ struct BackupDevices: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("security__mnemonic_multiple_header"), showBackButton: true)
+            SheetHeader(title: t("security__mnemonic_multiple_header"), showBackButton: true)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__mnemonic_multiple_text"))
+                BodyMText(t("security__mnemonic_multiple_text"))
 
                 Spacer()
 
@@ -21,7 +21,7 @@ struct BackupDevices: View {
                 Spacer()
 
                 CustomButton(
-                    title: localizedString("common__ok"),
+                    title: t("common__ok"),
                 ) {
                     navigationPath.append(.metadata)
                 }

--- a/Bitkit/Views/Backup/BackupIntro.swift
+++ b/Bitkit/Views/Backup/BackupIntro.swift
@@ -7,16 +7,16 @@ struct BackupIntroView: View {
     @Binding var navigationPath: [BackupRoute]
 
     var body: some View {
-        let text = wallet.totalBalanceSats > 0 ? localizedString("security__backup_funds") : localizedString("security__backup_funds_no")
+        let text = wallet.totalBalanceSats > 0 ? t("security__backup_funds") : t("security__backup_funds_no")
 
         VStack(alignment: .leading, spacing: 0) {
             SheetIntro(
-                navTitle: localizedString("security__backup_wallet"),
-                title: localizedString("security__backup_title"),
+                navTitle: t("security__backup_wallet"),
+                title: t("security__backup_title"),
                 description: text,
                 image: "safe",
-                continueText: localizedString("security__backup_button"),
-                cancelText: localizedString("common__later"),
+                continueText: t("security__backup_button"),
+                cancelText: t("common__later"),
                 accentColor: .blueAccent,
                 testID: "BackupIntroView",
                 onCancel: {

--- a/Bitkit/Views/Backup/BackupMetadata.swift
+++ b/Bitkit/Views/Backup/BackupMetadata.swift
@@ -5,10 +5,10 @@ struct BackupMetadata: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("security__mnemonic_data_header"), showBackButton: true)
+            SheetHeader(title: t("security__mnemonic_data_header"), showBackButton: true)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__mnemonic_data_text"))
+                BodyMText(t("security__mnemonic_data_text"))
 
                 Spacer()
 
@@ -21,10 +21,10 @@ struct BackupMetadata: View {
                 Spacer()
 
                 // TODO: Add actual last backup time
-                BodySText(localizedString("security__mnemonic_latest_backup", variables: ["time": "12/06/2025 12:00"]))
+                BodySText(t("security__mnemonic_latest_backup", variables: ["time": "12/06/2025 12:00"]))
                     .padding(.bottom, 16)
 
-                CustomButton(title: localizedString("common__ok")) {
+                CustomButton(title: t("common__ok")) {
                     sheets.hideSheet()
                 }
             }

--- a/Bitkit/Views/Backup/BackupMnemonic.swift
+++ b/Bitkit/Views/Backup/BackupMnemonic.swift
@@ -9,10 +9,10 @@ struct BackupMnemonicView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("security__mnemonic_your"))
+            SheetHeader(title: t("security__mnemonic_your"))
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__mnemonic_write", variables: ["length": "\(mnemonic.count)"]))
+                BodyMText(t("security__mnemonic_write", variables: ["length": "\(mnemonic.count)"]))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.bottom, 16)
 
@@ -43,7 +43,7 @@ struct BackupMnemonicView: View {
                         Button(action: {
                             showMnemonic = true
                         }) {
-                            BodySSBText(localizedString("security__mnemonic_reveal"))
+                            BodySSBText(t("security__mnemonic_reveal"))
                                 .frame(width: 154, height: 56)
                                 .background(Color.black50)
                                 .cornerRadius(64)
@@ -63,17 +63,17 @@ struct BackupMnemonicView: View {
                     if Env.isDebug || Env.isTestFlight {
                         let mnemonicString = mnemonic.joined(separator: " ")
                         UIPasteboard.general.string = mnemonicString
-                        app.toast(type: .success, title: localizedString("common__copied"), description: "Mnemonic copied to clipboard")
+                        app.toast(type: .success, title: t("common__copied"), description: "Mnemonic copied to clipboard")
                     }
                 }
 
-                BodySText(localizedString("security__mnemonic_never_share"), accentColor: .brandAccent)
+                BodySText(t("security__mnemonic_never_share"), accentColor: .brandAccent)
 
                 Spacer()
 
                 HStack(alignment: .center, spacing: 16) {
                     CustomButton(
-                        title: localizedString("common__continue"),
+                        title: t("common__continue"),
                         isDisabled: !showMnemonic,
                     ) {
                         let route =
@@ -104,8 +104,8 @@ struct BackupMnemonicView: View {
             } else {
                 app.toast(
                     type: .error,
-                    title: localizedString("security__mnemonic_error"),
-                    description: localizedString("security__mnemonic_error_description")
+                    title: t("security__mnemonic_error"),
+                    description: t("security__mnemonic_error_description")
                 )
             }
 
@@ -113,8 +113,8 @@ struct BackupMnemonicView: View {
         } catch {
             app.toast(
                 type: .error,
-                title: localizedString("security__mnemonic_error"),
-                description: localizedString("security__mnemonic_error_description")
+                title: t("security__mnemonic_error"),
+                description: t("security__mnemonic_error_description")
             )
         }
     }

--- a/Bitkit/Views/Backup/BackupPassphrase.swift
+++ b/Bitkit/Views/Backup/BackupPassphrase.swift
@@ -7,15 +7,15 @@ struct BackupPassphrase: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("security__pass_your"))
+            SheetHeader(title: t("security__pass_your"))
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__pass_text"))
+                BodyMText(t("security__pass_text"))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.bottom, 16)
 
                 VStack(alignment: .leading, spacing: 0) {
-                    BodyMSBText(localizedString("security__pass"), textColor: .textSecondary)
+                    BodyMSBText(t("security__pass"), textColor: .textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     BodyMSBText(passphrase)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -32,13 +32,13 @@ struct BackupPassphrase: View {
                 .privacySensitive()
                 .frame(maxWidth: .infinity)
 
-                BodySText(localizedString("security__pass_never_share"), accentColor: .brandAccent)
+                BodySText(t("security__pass_never_share"), accentColor: .brandAccent)
 
                 Spacer()
 
                 HStack(alignment: .center, spacing: 16) {
                     CustomButton(
-                        title: localizedString("common__continue"),
+                        title: t("common__continue"),
                     ) {
                         navigationPath.append(.confirmMnemonic(mnemonic: mnemonic, passphrase: passphrase))
                     }

--- a/Bitkit/Views/Backup/BackupReminder.swift
+++ b/Bitkit/Views/Backup/BackupReminder.swift
@@ -5,10 +5,10 @@ struct BackupReminder: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("security__mnemonic_keep_header"), showBackButton: true)
+            SheetHeader(title: t("security__mnemonic_keep_header"), showBackButton: true)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__mnemonic_keep_text"), accentColor: .textPrimary, accentFont: Fonts.bold)
+                BodyMText(t("security__mnemonic_keep_text"), accentColor: .textPrimary, accentFont: Fonts.bold)
 
                 Spacer()
 
@@ -21,7 +21,7 @@ struct BackupReminder: View {
                 Spacer()
 
                 CustomButton(
-                    title: localizedString("common__ok"),
+                    title: t("common__ok"),
                 ) {
                     navigationPath.append(.success)
                 }

--- a/Bitkit/Views/Backup/BackupSuccess.swift
+++ b/Bitkit/Views/Backup/BackupSuccess.swift
@@ -6,10 +6,10 @@ struct BackupSuccess: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("security__mnemonic_result_header"), showBackButton: true)
+            SheetHeader(title: t("security__mnemonic_result_header"), showBackButton: true)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__mnemonic_result_text"), accentColor: .textPrimary, accentFont: Fonts.bold)
+                BodyMText(t("security__mnemonic_result_text"), accentColor: .textPrimary, accentFont: Fonts.bold)
 
                 Spacer()
 
@@ -22,7 +22,7 @@ struct BackupSuccess: View {
                 Spacer()
 
                 CustomButton(
-                    title: localizedString("common__ok"),
+                    title: t("common__ok"),
                 ) {
                     app.backupVerified = true
                     navigationPath.append(.devices)

--- a/Bitkit/Views/BuyBitcoinView.swift
+++ b/Bitkit/Views/BuyBitcoinView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 struct BuyBitcoinView: View {
     var body: some View {
         OnboardingView(
-            title: localizedString("other__buy_header"),
-            description: localizedString("other__buy_text"),
+            title: t("other__buy_header"),
+            description: t("other__buy_text"),
             imageName: "bitcoin-emboss",
-            buttonText: localizedString("other__buy_button"),
+            buttonText: t("other__buy_button"),
             onButtonPress: {
                 // TODO: hide card .buyBitcoin
                 UIApplication.shared.open(URL(string: "https://bitcoin.org/en/exchanges")!)

--- a/Bitkit/Views/Contacts/ContactsIntroView.swift
+++ b/Bitkit/Views/Contacts/ContactsIntroView.swift
@@ -6,10 +6,10 @@ struct ContactsIntroView: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("slashtags__onboarding_header"),
-            description: localizedString("slashtags__onboarding_text"),
+            title: t("slashtags__onboarding_header"),
+            description: t("slashtags__onboarding_text"),
             imageName: "group",
-            buttonText: localizedString("slashtags__onboarding_button"),
+            buttonText: t("slashtags__onboarding_button"),
             onButtonPress: {
                 app.hasSeenContactsIntro = true
                 navigation.navigate(.contacts)
@@ -18,7 +18,7 @@ struct ContactsIntroView: View {
             testID: "ContactsIntro"
         )
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("slashtags__contacts"))
+        .navigationTitle(t("slashtags__contacts"))
         .backToWalletButton()
     }
 }

--- a/Bitkit/Views/Onboarding/CreateWalletView.swift
+++ b/Bitkit/Views/Onboarding/CreateWalletView.swift
@@ -16,10 +16,10 @@ struct CreateWalletView: View {
                     .frame(maxWidth: .infinity, alignment: .center)
 
                 VStack(spacing: 14) {
-                    DisplayText(NSLocalizedString("onboarding__slide4_header", comment: ""), accentColor: .brandAccent)
+                    DisplayText(t("onboarding__slide4_header"), accentColor: .brandAccent)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
-                    BodyMText(NSLocalizedString("onboarding__slide4_text", comment: ""), accentFont: Fonts.bold)
+                    BodyMText(t("onboarding__slide4_text"), accentFont: Fonts.bold)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .padding(.top, 48)
@@ -28,7 +28,7 @@ struct CreateWalletView: View {
 
             // Action buttons
             HStack(spacing: 16) {
-                CustomButton(title: NSLocalizedString("onboarding__new_wallet", comment: "")) {
+                CustomButton(title: t("onboarding__new_wallet")) {
                     do {
                         wallet.nodeLifecycleState = .initializing
                         app.showAllEmptyStates(true)
@@ -40,7 +40,7 @@ struct CreateWalletView: View {
                 }
 
                 CustomButton(
-                    title: NSLocalizedString("onboarding__restore", comment: ""),
+                    title: t("onboarding__restore"),
                     variant: .secondary,
                     destination: MultipleWalletsView()
                 )

--- a/Bitkit/Views/Onboarding/CreateWalletWithPassphraseView.swift
+++ b/Bitkit/Views/Onboarding/CreateWalletWithPassphraseView.swift
@@ -22,20 +22,20 @@ struct CreateWalletWithPassphraseView: View {
 
             OnboardingContent(
                 imageName: "padlock2",
-                title: NSLocalizedString("onboarding__passphrase_header", comment: ""),
-                text: NSLocalizedString("onboarding__passphrase_text", comment: ""),
+                title: t("onboarding__passphrase_header"),
+                text: t("onboarding__passphrase_text"),
                 accentColor: .brandAccent
             )
             .frame(maxHeight: .infinity)
 
             TextField(
-                NSLocalizedString("onboarding__passphrase", comment: ""),
+                t("onboarding__passphrase"),
                 text: $bip39Passphrase
             )
             .padding(.bottom, 28)
 
             CustomButton(
-                title: NSLocalizedString("onboarding__create_new_wallet", comment: ""),
+                title: t("onboarding__create_new_wallet"),
                 isDisabled: !isValidPassphrase
             ) {
                 do {

--- a/Bitkit/Views/Onboarding/InitializingWalletView.swift
+++ b/Bitkit/Views/Onboarding/InitializingWalletView.swift
@@ -160,7 +160,7 @@ struct InitializingWalletView: View {
                 VStack(spacing: 32) {
                     spinner
 
-                    DisplayText(localizedString("onboarding__loading_header"))
+                    DisplayText(t("onboarding__loading_header"))
                 }
                 .padding(.horizontal, 32)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Bitkit/Views/Onboarding/IntroView.swift
+++ b/Bitkit/Views/Onboarding/IntroView.swift
@@ -14,17 +14,17 @@ struct IntroView: View {
             Spacer()
 
             VStack(alignment: .leading, spacing: 0) {
-                DisplayText(NSLocalizedString("onboarding__welcome_title", comment: ""))
+                DisplayText(t("onboarding__welcome_title"))
 
-                BodyMText(NSLocalizedString("onboarding__welcome_text", comment: ""), textColor: .textSecondary, accentColor: .brandAccent)
+                BodyMText(t("onboarding__welcome_text"), textColor: .textSecondary, accentColor: .brandAccent)
                     .padding(.top, 14)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 16) {
-                CustomButton(title: NSLocalizedString("onboarding__get_started", comment: ""), destination: OnboardingSlider())
+                CustomButton(title: t("onboarding__get_started"), destination: OnboardingSlider())
                 CustomButton(
-                    title: NSLocalizedString("onboarding__skip_intro", comment: ""),
+                    title: t("onboarding__skip_intro"),
                     variant: .secondary,
                     destination: OnboardingSlider(currentTab: 4)
                 )

--- a/Bitkit/Views/Onboarding/MultipleWalletsView.swift
+++ b/Bitkit/Views/Onboarding/MultipleWalletsView.swift
@@ -5,12 +5,12 @@ struct MultipleWalletsView: View {
         VStack(spacing: 0) {
             OnboardingContent(
                 imageName: "phone",
-                title: NSLocalizedString("onboarding__multiple_header", comment: ""),
-                text: NSLocalizedString("onboarding__multiple_text", comment: ""),
+                title: t("onboarding__multiple_header"),
+                text: t("onboarding__multiple_text"),
                 accentColor: .yellow
             )
 
-            CustomButton(title: NSLocalizedString("common__understood", comment: ""), destination: RestoreWalletView())
+            CustomButton(title: t("common__understood"), destination: RestoreWalletView())
         }
         .padding(.horizontal, 32)
         .bottomSafeAreaPadding()

--- a/Bitkit/Views/Onboarding/OnboardingSlider.swift
+++ b/Bitkit/Views/Onboarding/OnboardingSlider.swift
@@ -13,7 +13,7 @@ struct OnboardingToolbar: View {
             }) {
                 HStack {
                     Spacer()
-                    BodyMSBText(NSLocalizedString("onboarding__advanced_setup", comment: ""), textColor: .secondary)
+                    BodyMSBText(t("onboarding__advanced_setup"), textColor: .secondary)
                 }
             }
             .opacity(currentTab == 4 ? 1 : 0)
@@ -23,7 +23,7 @@ struct OnboardingToolbar: View {
             } label: {
                 HStack {
                     Spacer()
-                    BodyMSBText(NSLocalizedString("onboarding__skip", comment: ""), textColor: .secondary)
+                    BodyMSBText(t("onboarding__skip"), textColor: .secondary)
                 }
             }
             .opacity(currentTab == 4 ? 0 : 1)
@@ -62,8 +62,8 @@ struct OnboardingSlider: View {
                     // Slide 0
                     OnboardingTab(
                         imageName: "keyring",
-                        title: NSLocalizedString("onboarding__slide0_header", comment: ""),
-                        text: NSLocalizedString("onboarding__slide0_text", comment: ""),
+                        title: t("onboarding__slide0_header"),
+                        text: t("onboarding__slide0_text"),
                         accentColor: .blueAccent
                     )
                     .tag(0)
@@ -71,9 +71,9 @@ struct OnboardingSlider: View {
                     // Slide 1
                     OnboardingTab(
                         imageName: "lightning",
-                        title: NSLocalizedString("onboarding__slide1_header", comment: ""),
-                        text: NSLocalizedString("onboarding__slide1_text", comment: ""),
-                        disclaimerText: app.isGeoBlocked == true ? NSLocalizedString("onboarding__slide1_note", comment: "") : nil,
+                        title: t("onboarding__slide1_header"),
+                        text: t("onboarding__slide1_text"),
+                        disclaimerText: app.isGeoBlocked == true ? t("onboarding__slide1_note") : nil,
                         accentColor: .purpleAccent
                     )
                     .tag(1)
@@ -81,8 +81,8 @@ struct OnboardingSlider: View {
                     // Slide 2
                     OnboardingTab(
                         imageName: "spark",
-                        title: NSLocalizedString("onboarding__slide2_header", comment: ""),
-                        text: NSLocalizedString("onboarding__slide2_text", comment: ""),
+                        title: t("onboarding__slide2_header"),
+                        text: t("onboarding__slide2_text"),
                         accentColor: .yellowAccent
                     )
                     .tag(2)
@@ -90,8 +90,8 @@ struct OnboardingSlider: View {
                     // Slide 3
                     OnboardingTab(
                         imageName: "shield-figure",
-                        title: NSLocalizedString("onboarding__slide3_header", comment: ""),
-                        text: NSLocalizedString("onboarding__slide3_text", comment: ""),
+                        title: t("onboarding__slide3_header"),
+                        text: t("onboarding__slide3_text"),
                         accentColor: .greenAccent
                     )
                     .tag(3)

--- a/Bitkit/Views/Onboarding/RestoreWalletView.swift
+++ b/Bitkit/Views/Onboarding/RestoreWalletView.swift
@@ -78,12 +78,12 @@ struct RestoreWalletView: View {
 
             let invalidWords = currentWords.filter { !BIP39.isValidWord($0) }
             if !invalidWords.isEmpty {
-                return (localizedString("onboarding__restore_red_explain"), .textSecondary)
+                return (t("onboarding__restore_red_explain"), .textSecondary)
             } else {
-                return (localizedString("onboarding__restore_inv_checksum"), .redAccent)
+                return (t("onboarding__restore_inv_checksum"), .redAccent)
             }
         case .invalidEntropy:
-            return (localizedString("onboarding__restore_inv_checksum"), .redAccent)
+            return (t("onboarding__restore_inv_checksum"), .redAccent)
         }
     }
 
@@ -122,11 +122,11 @@ struct RestoreWalletView: View {
 
     private var headerSection: some View {
         VStack(spacing: 0) {
-            DisplayText(localizedString("onboarding__restore_header"), accentColor: .blueAccent)
+            DisplayText(t("onboarding__restore_header"), accentColor: .blueAccent)
                 .padding(.top, 40)
                 .padding(.bottom, 14)
 
-            BodyMText(localizedString("onboarding__restore_phrase"))
+            BodyMText(t("onboarding__restore_phrase"))
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
@@ -173,13 +173,13 @@ struct RestoreWalletView: View {
         Group {
             if showingPassphrase {
                 VStack(spacing: 16) {
-                    TextField(localizedString("onboarding__restore_passphrase_placeholder"), text: $bip39Passphrase)
+                    TextField(t("onboarding__restore_passphrase_placeholder"), text: $bip39Passphrase)
                         .autocapitalization(.none)
                         .autocorrectionDisabled()
                         .focused($isPassphraseFocused)
                         .padding(.top, 4)
 
-                    BodySText(localizedString("onboarding__restore_passphrase_meaning"))
+                    BodySText(t("onboarding__restore_passphrase_meaning"))
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
@@ -200,7 +200,7 @@ struct RestoreWalletView: View {
         HStack(spacing: 16) {
             if !showingPassphrase {
                 CustomButton(
-                    title: localizedString("onboarding__advanced"),
+                    title: t("onboarding__advanced"),
                     variant: .secondary,
                     isDisabled: !isValidMnemonic
                 ) {
@@ -210,7 +210,7 @@ struct RestoreWalletView: View {
             }
 
             CustomButton(
-                title: showingPassphrase ? localizedString("onboarding__restore_wallet") : localizedString("onboarding__restore"),
+                title: showingPassphrase ? t("onboarding__restore_wallet") : t("onboarding__restore"),
                 isDisabled: !isValidMnemonic
             ) {
                 restoreWallet()

--- a/Bitkit/Views/Onboarding/TermsView.swift
+++ b/Bitkit/Views/Onboarding/TermsView.swift
@@ -29,8 +29,8 @@ private struct TermsFooter: View {
             VStack(alignment: .leading, spacing: 12) {
                 // Terms checkbox
                 CheckboxRow(
-                    title: NSLocalizedString("onboarding__tos_checkbox", comment: ""),
-                    subtitle: NSLocalizedString("onboarding__tos_checkbox_value", comment: ""),
+                    title: t("onboarding__tos_checkbox"),
+                    subtitle: t("onboarding__tos_checkbox_value"),
                     subtitleUrl: URL(string: Env.termsOfServiceUrl),
                     isChecked: $termsAccepted
                 )
@@ -39,8 +39,8 @@ private struct TermsFooter: View {
 
                 // Privacy checkbox
                 CheckboxRow(
-                    title: NSLocalizedString("onboarding__pp_checkbox", comment: ""),
-                    subtitle: NSLocalizedString("onboarding__pp_checkbox_value", comment: ""),
+                    title: t("onboarding__pp_checkbox"),
+                    subtitle: t("onboarding__pp_checkbox_value"),
                     subtitleUrl: URL(string: Env.privacyPolicyUrl),
                     isChecked: $privacyAccepted
                 )
@@ -49,7 +49,7 @@ private struct TermsFooter: View {
             }
 
             CustomButton(
-                title: NSLocalizedString("common__continue", comment: ""),
+                title: t("common__continue"),
                 isDisabled: !(termsAccepted && privacyAccepted),
                 destination: IntroView()
             )
@@ -67,7 +67,7 @@ struct TermsView: View {
         ZStack(alignment: .bottom) {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 16) {
-                    DisplayText(localizedString("onboarding__tos_header"))
+                    DisplayText(t("onboarding__tos_header"))
 
                     TosContent()
                         .font(Fonts.regular(size: 17))

--- a/Bitkit/Views/Onboarding/WalletRestoreError.swift
+++ b/Bitkit/Views/Onboarding/WalletRestoreError.swift
@@ -7,12 +7,12 @@ struct WalletRestoreError: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            DisplayText(localizedString("onboarding__restore_failed_header"), accentColor: .redAccent)
+            DisplayText(t("onboarding__restore_failed_header"), accentColor: .redAccent)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 40)
                 .padding(.bottom, 14)
 
-            BodyMText(localizedString("onboarding__restore_failed_text"))
+            BodyMText(t("onboarding__restore_failed_text"))
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()
@@ -27,7 +27,7 @@ struct WalletRestoreError: View {
 
             // TODO: implement retry logic and continue without backup
 
-            CustomButton(title: localizedString("common__try_again")) {
+            CustomButton(title: t("common__try_again")) {
                 Haptics.play(.light)
                 Task {
                     do {
@@ -41,7 +41,7 @@ struct WalletRestoreError: View {
                 }
             }
 
-            CustomButton(title: localizedString("onboarding__restore_no_backup_button"), variant: .secondary, size: .large) {
+            CustomButton(title: t("onboarding__restore_no_backup_button"), variant: .secondary, size: .large) {
                 Haptics.play(.light)
                 showDialog = true
             }
@@ -50,20 +50,20 @@ struct WalletRestoreError: View {
         .padding(.horizontal, 32)
         .bottomSafeAreaPadding()
         .alert(
-            localizedString("common__are_you_sure"),
+            t("common__are_you_sure"),
             isPresented: $showDialog,
             actions: {
-                Button(localizedString("common__dialog_cancel"), role: .cancel) {
+                Button(t("common__dialog_cancel"), role: .cancel) {
                     showDialog = false
                 }
 
-                Button(localizedString("common__yes_proceed"), role: .destructive) {
+                Button(t("common__yes_proceed"), role: .destructive) {
                     Haptics.play(.light)
                     showDialog = false
                 }
             },
             message: {
-                Text(localizedString("onboarding__restore_no_backup_warn"))
+                Text(t("onboarding__restore_no_backup_warn"))
             }
         )
     }

--- a/Bitkit/Views/Onboarding/WalletRestoreSuccess.swift
+++ b/Bitkit/Views/Onboarding/WalletRestoreSuccess.swift
@@ -5,12 +5,12 @@ struct WalletRestoreSuccess: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            DisplayText(localizedString("onboarding__restore_success_header"), accentColor: .greenAccent)
+            DisplayText(t("onboarding__restore_success_header"), accentColor: .greenAccent)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 40)
                 .padding(.bottom, 14)
 
-            BodyMText(localizedString("onboarding__restore_success_text"))
+            BodyMText(t("onboarding__restore_success_text"))
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()
@@ -23,7 +23,7 @@ struct WalletRestoreSuccess: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("onboarding__get_started")) {
+            CustomButton(title: t("onboarding__get_started")) {
                 Haptics.play(.light)
                 wallet.isRestoringWallet = false
             }

--- a/Bitkit/Views/Profile/ProfileIntro.swift
+++ b/Bitkit/Views/Profile/ProfileIntro.swift
@@ -6,10 +6,10 @@ struct ProfileIntroView: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("slashtags__onboarding_profile1_header"),
-            description: localizedString("slashtags__onboarding_profile1_text"),
+            title: t("slashtags__onboarding_profile1_header"),
+            description: t("slashtags__onboarding_profile1_text"),
             imageName: "crown",
-            buttonText: localizedString("common__continue"),
+            buttonText: t("common__continue"),
             onButtonPress: {
                 app.hasSeenProfileIntro = true
                 navigation.navigate(.profile)
@@ -18,7 +18,7 @@ struct ProfileIntroView: View {
             testID: "ProfileIntro"
         )
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("slashtags__profile"))
+        .navigationTitle(t("slashtags__profile"))
         .backToWalletButton()
     }
 }

--- a/Bitkit/Views/Scanner/ScannerView.swift
+++ b/Bitkit/Views/Scanner/ScannerView.swift
@@ -61,12 +61,12 @@ struct ScannerView: View {
 
             // UI Elements on top of camera
             VStack {
-                SheetHeader(title: localizedString("other__qr_scan"), showBackButton: showBackButton)
+                SheetHeader(title: t("other__qr_scan"), showBackButton: showBackButton)
 
                 Spacer()
 
                 CustomButton(
-                    title: localizedString("other__qr_paste"),
+                    title: t("other__qr_paste"),
                     icon: Image("clipboard")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -127,8 +127,8 @@ struct ScannerView: View {
                 Logger.error(error, context: "Failed to read data from QR")
                 app.toast(
                     type: .error,
-                    title: localizedString("other__qr_error_header"),
-                    description: localizedString("other__qr_error_text")
+                    title: t("other__qr_error_header"),
+                    description: t("other__qr_error_text")
                 )
             }
         }
@@ -138,8 +138,8 @@ struct ScannerView: View {
         guard let uri = UIPasteboard.general.string else {
             app.toast(
                 type: .warning,
-                title: localizedString("wallet__send_clipboard_empty_title"),
-                description: localizedString("wallet__send_clipboard_empty_text")
+                title: t("wallet__send_clipboard_empty_title"),
+                description: t("wallet__send_clipboard_empty_text")
             )
             return
         }

--- a/Bitkit/Views/Security/AuthCheck.swift
+++ b/Bitkit/Views/Security/AuthCheck.swift
@@ -17,11 +17,11 @@ struct AuthCheck: View {
     private var biometryTypeName: String {
         switch Env.biometryType {
         case .touchID:
-            return NSLocalizedString("security__bio_touch_id", comment: "")
+            return t("security__bio_touch_id")
         case .faceID:
-            return NSLocalizedString("security__bio_face_id", comment: "")
+            return t("security__bio_face_id")
         default:
-            return NSLocalizedString("security__bio_face_id", comment: "") // Default to Face ID
+            return t("security__bio_face_id") // Default to Face ID
         }
     }
 
@@ -77,12 +77,12 @@ struct AuthCheck: View {
 
         if remainingAttempts == 1 {
             // Last attempt warning
-            errorMessage = NSLocalizedString(
+            errorMessage = t(
                 "security__pin_last_attempt", comment: "Last attempt. Entering the wrong PIN again will reset your wallet."
             )
         } else {
             // Show remaining attempts
-            errorMessage = localizedString(
+            errorMessage = t(
                 "security__pin_attempts", comment: "%d attempts remaining. Forgot your PIN?", variables: ["attemptsRemaining": "\(remainingAttempts)"]
             )
         }
@@ -99,7 +99,7 @@ struct AuthCheck: View {
         }
 
         // Request biometric authentication
-        let reason = localizedString("security__bio_confirm", variables: ["biometricsName": biometryTypeName])
+        let reason = t("security__bio_confirm", variables: ["biometricsName": biometryTypeName])
 
         context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, authenticationError in
             DispatchQueue.main.async {
@@ -127,7 +127,7 @@ struct AuthCheck: View {
                 .frame(width: 279, height: 82)
                 .padding(.bottom, 47)
 
-            BodyMSBText(localizedString("security__pin_enter"))
+            BodyMSBText(t("security__pin_enter"))
 
             VStack(alignment: .center, spacing: 0) {
                 Spacer()
@@ -135,7 +135,7 @@ struct AuthCheck: View {
                 // Biometric button (if enabled and available, and failed once)
                 if settings.useBiometrics && isBiometricAvailable && biometricFailedOnce {
                     CustomButton(
-                        title: localizedString("security__pin_use_biometrics", variables: ["biometricsName": biometryTypeName]),
+                        title: t("security__pin_use_biometrics", variables: ["biometricsName": biometryTypeName]),
                         size: .small,
                         icon: Image(Env.biometryType == .touchID ? "touch-id" : "face-id")
                             .resizable()

--- a/Bitkit/Views/Security/PinCheckView.swift
+++ b/Bitkit/Views/Security/PinCheckView.swift
@@ -39,7 +39,7 @@ struct PinCheckView: View {
         if settings.hasExceededPinAttempts() {
             // Exceeded maximum attempts - this should be handled by the app level
             let remainingAttempts = settings.getRemainingPinAttempts()
-            errorMessage = NSLocalizedString(
+            errorMessage = t(
                 "security__pin_exceeded_attempts",
                 comment: "Too many incorrect attempts. Please try again later."
             )
@@ -50,13 +50,13 @@ struct PinCheckView: View {
 
         if remainingAttempts == 1 {
             // Last attempt warning
-            errorMessage = NSLocalizedString(
+            errorMessage = t(
                 "security__pin_last_attempt",
                 comment: "Last attempt. Entering the wrong PIN again will reset your wallet."
             )
         } else {
             // Show remaining attempts
-            errorMessage = localizedString(
+            errorMessage = t(
                 "security__pin_attempts",
                 comment: "%d attempts remaining. Forgot your PIN?",
                 variables: ["attemptsRemaining": "\(remainingAttempts)"]

--- a/Bitkit/Views/Settings/AboutView.swift
+++ b/Bitkit/Views/Settings/AboutView.swift
@@ -10,7 +10,7 @@ struct AboutView: View {
     }
 
     private var shareText: String {
-        return localizedString(
+        return t(
             "settings__about__shareText",
             variables: ["appStoreUrl": Env.appStoreUrl, "playStoreUrl": Env.playStoreUrl]
         )
@@ -18,28 +18,28 @@ struct AboutView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            BodyMText(localizedString("settings__about__text"))
+            BodyMText(t("settings__about__text"))
                 .padding(.vertical, 16)
 
             VStack(spacing: 0) {
                 Button(action: {
                     openURL(URL(string: Env.termsOfServiceUrl)!)
                 }) {
-                    SettingsListLabel(title: localizedString("settings__about__legal"))
+                    SettingsListLabel(title: t("settings__about__legal"))
                 }
 
                 ShareLink(
                     item: shareText,
                     message: Text(shareText)
                 ) {
-                    SettingsListLabel(title: localizedString("settings__about__share"))
+                    SettingsListLabel(title: t("settings__about__share"))
                 }
 
                 Button(action: {
                     openURL(URL(string: Env.githubReleasesUrl)!)
                 }) {
                     SettingsListLabel(
-                        title: localizedString("settings__about__version"),
+                        title: t("settings__about__version"),
                         rightText: appVersion,
                         rightIcon: nil
                     )
@@ -60,7 +60,7 @@ struct AboutView: View {
 
             Social()
         }
-        .navigationTitle(localizedString("settings__about__title"))
+        .navigationTitle(t("settings__about__title"))
         .navigationBarTitleDisplayMode(.inline)
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Settings/Advanced/AddressViewer.swift
+++ b/Bitkit/Views/Settings/Advanced/AddressViewer.swift
@@ -69,7 +69,7 @@ struct AddressViewer: View {
                             .onTapGesture {
                                 UIPasteboard.general.string = displayAddress
                                 Haptics.play(.copiedToClipboard)
-                                app.toast(type: .success, title: NSLocalizedString("common__copied", comment: ""), description: displayAddress)
+                                app.toast(type: .success, title: t("common__copied"), description: displayAddress)
                             }
                     }
 
@@ -84,7 +84,7 @@ struct AddressViewer: View {
                                 type: .address
                             )
                         } label: {
-                            CaptionText(NSLocalizedString("wallet__activity_explorer", comment: ""), textColor: .white80)
+                            CaptionText(t("wallet__activity_explorer"), textColor: .white80)
                         }
                         .disabled(displayAddress.isEmpty)
                     }
@@ -102,7 +102,7 @@ struct AddressViewer: View {
                     .frame(width: 24, height: 24)
                     .foregroundColor(.white64)
                 TextField(
-                    NSLocalizedString("common__search", comment: ""), text: $searchText, backgroundColor: .clear,
+                    t("common__search"), text: $searchText, backgroundColor: .clear,
                     font: .custom(Fonts.regular, size: 17)
                 )
             }
@@ -242,7 +242,7 @@ struct AddressViewer: View {
 
                             // Check Balances Button
                             CustomButton(
-                                title: NSLocalizedString("settings__addr__check_balances", comment: ""),
+                                title: t("settings__addr__check_balances"),
                                 variant: .primary,
                                 size: .small,
                                 isLoading: isLoadingBalances,
@@ -425,7 +425,7 @@ struct AddressRow: View {
         .onLongPressGesture(minimumDuration: 0.5) {
             UIPasteboard.general.string = address
             Haptics.play(.copiedToClipboard)
-            app.toast(type: .success, title: NSLocalizedString("common__copied", comment: ""), description: address)
+            app.toast(type: .success, title: t("common__copied"), description: address)
         }
     }
 

--- a/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
+++ b/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
@@ -11,7 +11,7 @@ struct AdvancedSettingsView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
                         BodyMText(
-                            NSLocalizedString("settings__adv__section_payments", comment: ""),
+                            t("settings__adv__section_payments"),
                             textColor: .textSecondary
                         )
                         .padding(.top, 24)
@@ -23,26 +23,26 @@ struct AdvancedSettingsView: View {
                     // Maybe never implemented
                     // NavigationLink(destination: Text("Coming soon")) {
                     //     SettingsListLabel(
-                    //         title: NSLocalizedString("settings__adv__address_type", comment: ""),
+                    //         title: t("settings__adv__address_type"),
                     //         rightText: "Native Segwit"
                     //     )
                     // }
 
                     NavigationLink(value: Route.coinSelection) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__adv__coin_selection", comment: "")
+                            title: t("settings__adv__coin_selection")
                         )
                     }
 
                     // NavigationLink(destination: Text("Coming soon")) {
                     //     SettingsListLabel(
-                    //         title: NSLocalizedString("settings__adv__payment_preference", comment: "")
+                    //         title: t("settings__adv__payment_preference")
                     //     )
                     // }
 
                     // NavigationLink(destination: Text("Coming soon")) {
                     //     SettingsListLabel(
-                    //         title: NSLocalizedString("settings__adv__gap_limit", comment: "")
+                    //         title: t("settings__adv__gap_limit")
                     //     )
                     // }
                 }
@@ -51,7 +51,7 @@ struct AdvancedSettingsView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
                         BodyMText(
-                            NSLocalizedString("settings__adv__section_networks", comment: ""),
+                            t("settings__adv__section_networks"),
                             textColor: .textSecondary
                         )
                         .padding(.top, 24)
@@ -62,25 +62,25 @@ struct AdvancedSettingsView: View {
 
                     NavigationLink(value: Route.connections) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__adv__lightning_connections", comment: "")
+                            title: t("settings__adv__lightning_connections")
                         )
                     }
 
                     NavigationLink(value: Route.node) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__adv__lightning_node", comment: "")
+                            title: t("settings__adv__lightning_node")
                         )
                     }
 
                     NavigationLink(value: Route.electrumSettings) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__adv__electrum_server", comment: "")
+                            title: t("settings__adv__electrum_server")
                         )
                     }
 
                     NavigationLink(destination: Text("Coming soon")) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__adv__rgs_server", comment: "")
+                            title: t("settings__adv__rgs_server")
                         )
                     }
                 }
@@ -89,7 +89,7 @@ struct AdvancedSettingsView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
                         BodyMText(
-                            NSLocalizedString("settings__adv__section_other", comment: ""),
+                            t("settings__adv__section_other"),
                             textColor: .textSecondary
                         )
                         .padding(.top, 24)
@@ -99,12 +99,12 @@ struct AdvancedSettingsView: View {
 
                     NavigationLink(value: Route.addressViewer) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__adv__address_viewer", comment: "")
+                            title: t("settings__adv__address_viewer")
                         )
                     }
 
                     // SettingsListLabel(
-                    //     title: NSLocalizedString("settings__adv__rescan", comment: ""),
+                    //     title: t("settings__adv__rescan"),
                     //     rightIcon: nil
                     // )
 
@@ -112,7 +112,7 @@ struct AdvancedSettingsView: View {
                         showingResetAlert = true
                     }) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__adv__suggestions_reset", comment: "")
+                            title: t("settings__adv__suggestions_reset")
                         )
                     }
 
@@ -123,12 +123,12 @@ struct AdvancedSettingsView: View {
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(NSLocalizedString("settings__advanced_title", comment: ""))
+        .navigationTitle(t("settings__advanced_title"))
         .alert(isPresented: $showingResetAlert) {
             Alert(
-                title: Text(localizedString("settings__adv__reset_title")),
-                message: Text(localizedString("settings__adv__reset_desc")),
-                primaryButton: .destructive(Text(localizedString("settings__adv__reset_confirm"))) {
+                title: Text(t("settings__adv__reset_title")),
+                message: Text(t("settings__adv__reset_desc")),
+                primaryButton: .destructive(Text(t("settings__adv__reset_confirm"))) {
                     suggestionsManager.resetDismissed()
                 },
                 secondaryButton: .cancel()

--- a/Bitkit/Views/Settings/Advanced/CloseConnectionConfirmation.swift
+++ b/Bitkit/Views/Settings/Advanced/CloseConnectionConfirmation.swift
@@ -14,7 +14,7 @@ struct CloseConnectionConfirmation: View {
         VStack(spacing: 0) {
             VStack(spacing: 16) {
                 BodyMText(
-                    NSLocalizedString("lightning__close_text", comment: ""),
+                    t("lightning__close_text"),
                     textColor: .textSecondary
                 )
                 .multilineTextAlignment(.center)
@@ -36,7 +36,7 @@ struct CloseConnectionConfirmation: View {
             // Bottom buttons
             HStack(spacing: 16) {
                 CustomButton(
-                    title: NSLocalizedString("common__cancel", comment: ""),
+                    title: t("common__cancel"),
                     variant: .secondary,
                     isDisabled: isClosing,
                     shouldExpand: true
@@ -45,7 +45,7 @@ struct CloseConnectionConfirmation: View {
                 }
 
                 CustomButton(
-                    title: NSLocalizedString("lightning__close_button", comment: ""),
+                    title: t("lightning__close_button"),
                     variant: .primary,
                     isDisabled: isClosing,
                     shouldExpand: true
@@ -58,7 +58,7 @@ struct CloseConnectionConfirmation: View {
             .padding(.horizontal, 32)
             .padding(.bottom, 32)
         }
-        .navigationTitle(NSLocalizedString("lightning__close_conn", comment: ""))
+        .navigationTitle(t("lightning__close_conn"))
         .navigationBarTitleDisplayMode(.inline)
     }
 
@@ -77,23 +77,23 @@ struct CloseConnectionConfirmation: View {
                     // Show success toast
                     app.toast(
                         type: .success,
-                        title: NSLocalizedString("lightning__close_success_title", comment: ""),
-                        description: NSLocalizedString("lightning__close_success_msg", comment: "")
+                        title: t("lightning__close_success_title"),
+                        description: t("lightning__close_success_msg")
                     )
                 }
             } else {
                 // Failed to close
                 app.toast(
                     type: .error,
-                    title: NSLocalizedString("lightning__close_error", comment: ""),
-                    description: NSLocalizedString("lightning__close_error_msg", comment: "")
+                    title: t("lightning__close_error"),
+                    description: t("lightning__close_error_msg")
                 )
             }
         } catch {
             Logger.error("Failed to close channel: \(error)")
             app.toast(
                 type: .error,
-                title: NSLocalizedString("lightning__close_error", comment: ""),
+                title: t("lightning__close_error"),
                 description: error.localizedDescription
             )
         }

--- a/Bitkit/Views/Settings/Advanced/CoinSelectionSettingsView.swift
+++ b/Bitkit/Views/Settings/Advanced/CoinSelectionSettingsView.swift
@@ -5,9 +5,9 @@ extension CoinSelectionMethod {
     var localizedTitle: String {
         switch self {
         case .manual:
-            return NSLocalizedString("settings__adv__cs_manual", comment: "")
+            return t("settings__adv__cs_manual")
         case .autopilot:
-            return NSLocalizedString("settings__adv__cs_auto", comment: "")
+            return t("settings__adv__cs_auto")
         }
     }
 }
@@ -18,16 +18,16 @@ extension CoinSelectionAlgorithm {
         case .branchAndBound:
             return "Branch and Bound" // TODO: add missing localized text
         case .largestFirst:
-            return NSLocalizedString("settings__adv__cs_min", comment: "")
+            return t("settings__adv__cs_min")
         case .oldestFirst:
-            return NSLocalizedString("settings__adv__cs_first_in_first_out", comment: "")
+            return t("settings__adv__cs_first_in_first_out")
         case .singleRandomDraw:
             return "Single Random Draw" // TODO: add missing localized text
             // Commented out unsupported algorithms
             // case .smallestFirst:
-            //     return NSLocalizedString("settings__adv__cs_max", comment: "")
+            //     return t("settings__adv__cs_max")
             // case .consolidate:
-            //     return NSLocalizedString("settings__adv__cs_consolidate", comment: "")
+            //     return t("settings__adv__cs_consolidate")
         }
     }
 
@@ -36,16 +36,16 @@ extension CoinSelectionAlgorithm {
         case .branchAndBound:
             return "Finds exact amount matches to minimize change" // TODO: add missing localized text
         case .largestFirst:
-            return NSLocalizedString("settings__adv__cs_min_description", comment: "")
+            return t("settings__adv__cs_min_description")
         case .oldestFirst:
-            return NSLocalizedString("settings__adv__cs_first_in_first_out_description", comment: "")
+            return t("settings__adv__cs_first_in_first_out_description")
         case .singleRandomDraw:
             return "Random selection for privacy" // TODO: add missing localized text
             // Commented out unsupported algorithms
             // case .smallestFirst:
-            //     return NSLocalizedString("settings__adv__cs_max_description", comment: "")
+            //     return t("settings__adv__cs_max_description")
             // case .consolidate:
-            //     return NSLocalizedString("settings__adv__cs_consolidate_description", comment: "")
+            //     return t("settings__adv__cs_consolidate_description")
         }
     }
 
@@ -120,7 +120,7 @@ struct CoinSelectionSettingsView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
                         BodyMText(
-                            NSLocalizedString("settings__adv__cs_method", comment: ""),
+                            t("settings__adv__cs_method"),
                             textColor: .textSecondary
                         )
                         .padding(.horizontal, 16)
@@ -153,7 +153,7 @@ struct CoinSelectionSettingsView: View {
                     VStack(alignment: .leading, spacing: 0) {
                         HStack {
                             BodyMText(
-                                NSLocalizedString("settings__adv__cs_auto_mode", comment: ""),
+                                t("settings__adv__cs_auto_mode"),
                                 textColor: .textSecondary
                             )
                             .padding(.horizontal, 16)
@@ -183,7 +183,7 @@ struct CoinSelectionSettingsView: View {
                     .frame(height: 32)
             }
         }
-        .navigationTitle(NSLocalizedString("settings__adv__coin_selection", comment: ""))
+        .navigationTitle(t("settings__adv__coin_selection"))
     }
 }
 

--- a/Bitkit/Views/Settings/Advanced/LightningConnectionDetailView.swift
+++ b/Bitkit/Views/Settings/Advanced/LightningConnectionDetailView.swift
@@ -29,7 +29,7 @@ struct LightningConnectionDetailView: View {
                 // STATUS Section
                 VStack(alignment: .leading, spacing: 16) {
                     HStack {
-                        CaptionText(NSLocalizedString("lightning__status", comment: "").uppercased(), textColor: .textSecondary)
+                        CaptionText(t("lightning__status").uppercased(), textColor: .textSecondary)
                         Spacer()
                     }
                     .padding(.horizontal, 16)
@@ -55,27 +55,27 @@ struct LightningConnectionDetailView: View {
                 if let order = linkedOrder {
                     VStack(alignment: .leading, spacing: 16) {
                         HStack {
-                            CaptionText(NSLocalizedString("lightning__order_details", comment: "").uppercased(), textColor: .textSecondary)
+                            CaptionText(t("lightning__order_details").uppercased(), textColor: .textSecondary)
                             Spacer()
                         }
                         .padding(.horizontal, 16)
 
                         VStack(spacing: 0) {
-                            DetailRow(label: NSLocalizedString("lightning__order", comment: ""), value: order.id, isFirst: true)
+                            DetailRow(label: t("lightning__order"), value: order.id, isFirst: true)
 
                             if let formattedDate = formatDate(order.createdAt) {
                                 Divider().padding(.horizontal, 16)
-                                DetailRow(label: NSLocalizedString("lightning__opened_on", comment: ""), value: formattedDate)
+                                DetailRow(label: t("lightning__opened_on"), value: formattedDate)
                             }
 
                             Divider().padding(.horizontal, 16)
                             DetailRow(
-                                label: NSLocalizedString("lightning__transaction", comment: ""),
+                                label: t("lightning__transaction"),
                                 value: truncateString(order.payment.onchain.address, length: 16)
                             )
                             Divider().padding(.horizontal, 16)
                             DetailRow(
-                                label: NSLocalizedString("lightning__order_fee", comment: ""), value: "₿ \(formatNumber(order.feeSat))", isLast: true
+                                label: t("lightning__order_fee"), value: "₿ \(formatNumber(order.feeSat))", isLast: true
                             )
                         }
                     }
@@ -84,29 +84,29 @@ struct LightningConnectionDetailView: View {
                 // BALANCE Section
                 VStack(alignment: .leading, spacing: 16) {
                     HStack {
-                        CaptionText(NSLocalizedString("lightning__balance", comment: "").uppercased(), textColor: .textSecondary)
+                        CaptionText(t("lightning__balance").uppercased(), textColor: .textSecondary)
                         Spacer()
                     }
                     .padding(.horizontal, 16)
 
                     VStack(spacing: 0) {
                         DetailRow(
-                            label: NSLocalizedString("lightning__receiving_label", comment: ""),
+                            label: t("lightning__receiving_label"),
                             value: "₿ \(formatNumber(channel.inboundCapacityMsat / 1000))", isFirst: true
                         )
                         Divider().padding(.horizontal, 16)
                         DetailRow(
-                            label: NSLocalizedString("lightning__spending_label", comment: ""),
+                            label: t("lightning__spending_label"),
                             value: "₿ \(formatNumber(channel.outboundCapacityMsat / 1000))"
                         )
                         Divider().padding(.horizontal, 16)
                         DetailRow(
-                            label: NSLocalizedString("lightning__reserve_balance", comment: ""),
+                            label: t("lightning__reserve_balance"),
                             value: "₿ \(formatNumber(channel.unspendablePunishmentReserve ?? 0))"
                         )
                         Divider().padding(.horizontal, 16)
                         DetailRow(
-                            label: NSLocalizedString("lightning__total_size", comment: ""), value: "₿ \(formatNumber(channel.channelValueSats))",
+                            label: t("lightning__total_size"), value: "₿ \(formatNumber(channel.channelValueSats))",
                             isLast: true
                         )
                     }
@@ -115,13 +115,13 @@ struct LightningConnectionDetailView: View {
                 // FEES Section
                 VStack(alignment: .leading, spacing: 16) {
                     HStack {
-                        CaptionText(NSLocalizedString("lightning__fees", comment: "").uppercased(), textColor: .textSecondary)
+                        CaptionText(t("lightning__fees").uppercased(), textColor: .textSecondary)
                         Spacer()
                     }
                     .padding(.horizontal, 16)
 
                     VStack(spacing: 0) {
-                        DetailRow(label: NSLocalizedString("lightning__base_fee", comment: ""), value: "₿ 1", isFirst: true)
+                        DetailRow(label: t("lightning__base_fee"), value: "₿ 1", isFirst: true)
                         Divider().padding(.horizontal, 16)
                         DetailRow(label: "Receiving base fee", value: "₿ 1", isLast: true) // TODO: Add localization key for receiving base fee
                     }
@@ -130,7 +130,7 @@ struct LightningConnectionDetailView: View {
                 // OTHER Section
                 VStack(alignment: .leading, spacing: 16) {
                     HStack {
-                        CaptionText(NSLocalizedString("lightning__other", comment: "").uppercased(), textColor: .textSecondary)
+                        CaptionText(t("lightning__other").uppercased(), textColor: .textSecondary)
                         Spacer()
                     }
                     .padding(.horizontal, 16)
@@ -140,18 +140,18 @@ struct LightningConnectionDetailView: View {
 
                         if hasDate, let formattedDate = formatDate(linkedOrder?.createdAt ?? "") {
                             DetailRow(
-                                label: NSLocalizedString("lightning__opened_on", comment: ""),
+                                label: t("lightning__opened_on"),
                                 value: formattedDate,
                                 isFirst: true
                             )
                             Divider().padding(.horizontal, 16)
                             DetailRow(
-                                label: NSLocalizedString("lightning__channel_node_id", comment: ""),
+                                label: t("lightning__channel_node_id"),
                                 value: truncateString(channel.counterpartyNodeId.description, length: 16), isLast: true
                             )
                         } else {
                             DetailRow(
-                                label: NSLocalizedString("lightning__channel_node_id", comment: ""),
+                                label: t("lightning__channel_node_id"),
                                 value: truncateString(channel.counterpartyNodeId.description, length: 16),
                                 isFirst: true, isLast: true
                             )
@@ -162,7 +162,7 @@ struct LightningConnectionDetailView: View {
                 // Bottom buttons
                 HStack(spacing: 16) {
                     CustomButton(
-                        title: NSLocalizedString("lightning__support", comment: ""),
+                        title: t("lightning__support"),
                         variant: .secondary,
                         shouldExpand: true
                     ) {
@@ -171,7 +171,7 @@ struct LightningConnectionDetailView: View {
 
                     if channelStatus == .open {
                         CustomButton(
-                            title: NSLocalizedString("lightning__close_conn", comment: ""),
+                            title: t("lightning__close_conn"),
                             variant: .primary,
                             shouldExpand: true,
                             destination: CloseConnectionConfirmation(channel: channel)
@@ -221,11 +221,11 @@ struct LightningConnectionDetailView: View {
     private var statusText: String {
         switch channelStatus {
         case .pending:
-            return NSLocalizedString("lightning__order_state__opening", comment: "").capitalized
+            return t("lightning__order_state__opening").capitalized
         case .open:
-            return NSLocalizedString("lightning__order_state__open", comment: "").capitalized
+            return t("lightning__order_state__open").capitalized
         case .closed:
-            return NSLocalizedString("lightning__order_state__closed", comment: "").capitalized
+            return t("lightning__order_state__closed").capitalized
         }
     }
 

--- a/Bitkit/Views/Settings/Advanced/LightningConnectionsView.swift
+++ b/Bitkit/Views/Settings/Advanced/LightningConnectionsView.swift
@@ -16,7 +16,7 @@ struct LightningConnectionsView: View {
                 // Header section with spending balance and receiving capacity
                 HStack {
                     VStack(alignment: .leading, spacing: 4) {
-                        CaptionMText(NSLocalizedString("lightning__spending_label", comment: ""))
+                        CaptionMText(t("lightning__spending_label"))
                         HStack(spacing: 4) {
                             Image("arrow-up")
                                 .resizable()
@@ -28,7 +28,7 @@ struct LightningConnectionsView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                     VStack(alignment: .leading, spacing: 4) {
-                        CaptionMText(NSLocalizedString("lightning__receiving_label", comment: ""))
+                        CaptionMText(t("lightning__receiving_label"))
                         HStack(spacing: 4) {
                             Image("arrow-down")
                                 .resizable()
@@ -48,7 +48,7 @@ struct LightningConnectionsView: View {
                 if !pendingChannels.isEmpty {
                     VStack(alignment: .leading, spacing: 0) {
                         HStack {
-                            CaptionMText(NSLocalizedString("lightning__conn_pending", comment: ""))
+                            CaptionMText(t("lightning__conn_pending"))
                                 .padding(.top, 32)
                                 .padding(.bottom, 16)
                             Spacer()
@@ -59,12 +59,12 @@ struct LightningConnectionsView: View {
                                 destination: LightningConnectionDetailView(
                                     channel: channel,
                                     linkedOrder: findLinkedOrder(for: channel),
-                                    title: "\(NSLocalizedString("lightning__connection", comment: "")) \(index + 1)"
+                                    title: "\(t("lightning__connection")) \(index + 1)"
                                 )
                             ) {
                                 VStack(spacing: 0) {
                                     HStack {
-                                        SubtitleText("\(NSLocalizedString("lightning__connection", comment: "")) \(index + 1)")
+                                        SubtitleText("\(t("lightning__connection")) \(index + 1)")
                                         Spacer()
                                         Image("chevron")
                                             .resizable()
@@ -94,7 +94,7 @@ struct LightningConnectionsView: View {
                 if !openChannels.isEmpty {
                     VStack(alignment: .leading, spacing: 0) {
                         HStack {
-                            CaptionMText(NSLocalizedString("lightning__conn_open", comment: ""))
+                            CaptionMText(t("lightning__conn_open"))
                                 .padding(.top, 16)
                                 .padding(.bottom, 16)
                             Spacer()
@@ -105,12 +105,12 @@ struct LightningConnectionsView: View {
                                 destination: LightningConnectionDetailView(
                                     channel: channel,
                                     linkedOrder: findLinkedOrder(for: channel),
-                                    title: "\(NSLocalizedString("lightning__connection", comment: "")) \(index + 1)"
+                                    title: "\(t("lightning__connection")) \(index + 1)"
                                 )
                             ) {
                                 VStack(spacing: 0) {
                                     HStack {
-                                        SubtitleText("\(NSLocalizedString("lightning__connection", comment: "")) \(index + 1)")
+                                        SubtitleText("\(t("lightning__connection")) \(index + 1)")
                                         Spacer()
                                         Image("chevron")
                                             .resizable()
@@ -139,7 +139,7 @@ struct LightningConnectionsView: View {
                 if showClosedConnections && !closedConnections.isEmpty {
                     VStack(alignment: .leading, spacing: 0) {
                         HStack {
-                            CaptionMText(NSLocalizedString("lightning__conn_closed", comment: ""))
+                            CaptionMText(t("lightning__conn_closed"))
                                 .padding(.top, 16)
                                 .padding(.bottom, 16)
                             Spacer()
@@ -148,7 +148,7 @@ struct LightningConnectionsView: View {
                         ForEach(Array(closedConnections.enumerated()), id: \.element.id) { index, order in
                             VStack(spacing: 0) {
                                 HStack {
-                                    SubtitleText("\(NSLocalizedString("lightning__connection", comment: "")) \(index + 1)")
+                                    SubtitleText("\(t("lightning__connection")) \(index + 1)")
                                     Spacer()
                                     Image("chevron")
                                         .resizable()
@@ -181,8 +181,8 @@ struct LightningConnectionsView: View {
                     // Show Closed & Failed button
                     CustomButton(
                         title: showClosedConnections
-                            ? localizedString("lightning__conn_closed_hide")
-                            : localizedString("lightning__conn_closed_show"),
+                            ? t("lightning__conn_closed_hide")
+                            : t("lightning__conn_closed_show"),
                         variant: .tertiary,
                     ) {
                         showClosedConnections.toggle()
@@ -196,7 +196,7 @@ struct LightningConnectionsView: View {
             .padding(.horizontal, 16)
         }
         .background(Color.black)
-        .navigationTitle(NSLocalizedString("lightning__connections", comment: ""))
+        .navigationTitle(t("lightning__connections"))
         .navigationBarTitleDisplayMode(.inline)
         .refreshable {
             await refreshData()
@@ -212,7 +212,7 @@ struct LightningConnectionsView: View {
         .safeAreaInset(edge: .bottom) {
             HStack(spacing: 16) {
                 CustomButton(
-                    title: NSLocalizedString("lightning__conn_button_export_logs", comment: ""),
+                    title: t("lightning__conn_button_export_logs"),
                     variant: .secondary,
                     shouldExpand: true
                 ) {
@@ -220,7 +220,7 @@ struct LightningConnectionsView: View {
                 }
 
                 CustomButton(
-                    title: NSLocalizedString("lightning__conn_button_add", comment: ""),
+                    title: t("lightning__conn_button_add"),
                     variant: .primary,
                     shouldExpand: true,
                 ) {

--- a/Bitkit/Views/Settings/AppStatusView.swift
+++ b/Bitkit/Views/Settings/AppStatusView.swift
@@ -12,7 +12,7 @@ struct AppStatusView: View {
             }
             lightningConnectionStatusView // TODO: navigate to channel list view
         }
-        .navigationTitle(NSLocalizedString("settings__status__title", comment: ""))
+        .navigationTitle(t("settings__status__title"))
         .navigationBarTitleDisplayMode(.inline)
         .scrollContentBackground(.hidden)
         .listStyle(PlainListStyle())
@@ -27,15 +27,15 @@ struct AppStatusView: View {
         let iconColor: Color = isConnected ? .greenAccent : .redAccent
         let status =
             isConnected
-                ? NSLocalizedString("settings__status__internet__ready", comment: "Connected")
-                : NSLocalizedString("settings__status__internet__error", comment: "Disconnected")
+                ? t("settings__status__internet__ready", comment: "Connected")
+                : t("settings__status__internet__error", comment: "Disconnected")
         let statusColor: Color = isConnected ? .greenAccent : .redAccent
 
         return StatusItemView(
             imageName: "status-internet",
             iconBackgroundColor: iconBackgroundColor,
             iconColor: iconColor,
-            title: NSLocalizedString("settings__status__internet__title", comment: ""),
+            title: t("settings__status__internet__title"),
             status: status,
             statusColor: statusColor
         )
@@ -46,7 +46,7 @@ struct AppStatusView: View {
             imageName: "status-node",
             iconBackgroundColor: .green16,
             iconColor: wallet.nodeLifecycleState.statusColor,
-            title: NSLocalizedString("settings__status__lightning_node__title", comment: ""),
+            title: t("settings__status__lightning_node__title"),
             status: wallet.nodeLifecycleState.displayState,
             statusColor: wallet.nodeLifecycleState.statusColor
         )
@@ -79,13 +79,13 @@ struct AppStatusView: View {
 
         let connectionStatus: String = {
             if !hasChannels {
-                return NSLocalizedString("settings__status__lightning_connection__error", comment: "")
+                return t("settings__status__lightning_connection__error")
             } else if hasUsableChannels && hasReadyChannels {
-                return NSLocalizedString("settings__status__lightning_connection__ready", comment: "")
+                return t("settings__status__lightning_connection__ready")
             } else if !hasUsableChannels && hasReadyChannels {
-                return NSLocalizedString("settings__status__lightning_connection__pending", comment: "")
+                return t("settings__status__lightning_connection__pending")
             } else {
-                return NSLocalizedString("settings__status__lightning_connection__ready", comment: "")
+                return t("settings__status__lightning_connection__ready")
             }
         }()
 
@@ -93,7 +93,7 @@ struct AppStatusView: View {
             imageName: "status-lightning",
             iconBackgroundColor: iconBackgroundColor,
             iconColor: connectionColor,
-            title: NSLocalizedString("settings__status__lightning_connection__title", comment: ""),
+            title: t("settings__status__lightning_connection__title"),
             status: connectionStatus,
             statusColor: connectionColor,
         )

--- a/Bitkit/Views/Settings/Backup/BackupSettings.swift
+++ b/Bitkit/Views/Settings/Backup/BackupSettings.swift
@@ -100,54 +100,54 @@ struct BackupSettings: View {
                     Button(action: {
                         sheets.showSheet(.backup, data: BackupConfig(view: .mnemonic))
                     }) {
-                        SettingsListLabel(title: localizedString("settings__backup__wallet"))
+                        SettingsListLabel(title: t("settings__backup__wallet"))
                     }
 
                     NavigationLink(value: Route.resetAndRestore) {
-                        SettingsListLabel(title: localizedString("settings__backup__reset"))
+                        SettingsListLabel(title: t("settings__backup__reset"))
                     }
 
-                    SettingsLabel(localizedString("settings__backup__latest"))
+                    SettingsLabel(t("settings__backup__latest"))
                         .padding(.top, 16)
 
                     StatusItemView(
                         imageName: "bolt-hollow",
-                        title: localizedString("settings__backup__category_connections"),
+                        title: t("settings__backup__category_connections"),
                         status: .required(1_718_281_828)
                     )
                     StatusItemView(
                         imageName: "note",
-                        title: localizedString("settings__backup__category_connection_receipts"),
+                        title: t("settings__backup__category_connection_receipts"),
                         status: .synced(1_718_281_828)
                     )
                     StatusItemView(
                         imageName: "arrow-up-down",
-                        title: localizedString("settings__backup__category_transaction_log"),
+                        title: t("settings__backup__category_transaction_log"),
                         status: .synced(1_718_281_828)
                     )
                     StatusItemView(
                         imageName: "rewind",
-                        title: localizedString("settings__backup__category_wallet"),
+                        title: t("settings__backup__category_wallet"),
                         status: .synced(1_718_281_828)
                     )
                     StatusItemView(
                         imageName: "gear-six",
-                        title: localizedString("settings__backup__category_settings"),
+                        title: t("settings__backup__category_settings"),
                         status: .running
                     )
                     StatusItemView(
                         imageName: "bolt-hollow",
-                        title: localizedString("settings__backup__category_widgets"),
+                        title: t("settings__backup__category_widgets"),
                         status: .running
                     )
                     StatusItemView(
                         imageName: "tag",
-                        title: localizedString("settings__backup__category_tags"),
+                        title: t("settings__backup__category_tags"),
                         status: .running
                     )
                     StatusItemView(
                         imageName: "users",
-                        title: localizedString("settings__backup__category_contacts"),
+                        title: t("settings__backup__category_contacts"),
                         status: .running
                     )
 
@@ -159,7 +159,7 @@ struct BackupSettings: View {
                 .bottomSafeAreaPadding()
             }
         }
-        .navigationTitle(localizedString("settings__backup_title"))
+        .navigationTitle(t("settings__backup_title"))
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Bitkit/Views/Settings/Backup/ResetAndRestore.swift
+++ b/Bitkit/Views/Settings/Backup/ResetAndRestore.swift
@@ -10,7 +10,7 @@ struct ResetAndRestore: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            BodyMText(localizedString("security__reset_text"))
+            BodyMText(t("security__reset_text"))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 32)
 
@@ -26,13 +26,13 @@ struct ResetAndRestore: View {
 
             HStack(spacing: 16) {
                 CustomButton(
-                    title: localizedString("security__reset_button_backup"),
+                    title: t("security__reset_button_backup"),
                     variant: .secondary
                 ) {
                     sheets.showSheet(.backup, data: BackupConfig(view: .mnemonic))
                 }
 
-                CustomButton(title: localizedString("security__reset_button_reset")) {
+                CustomButton(title: t("security__reset_button_reset")) {
                     showAlert = true
                 }
             }
@@ -42,9 +42,9 @@ struct ResetAndRestore: View {
         .accessibilityIdentifier("ResetAndRestore")
         .alert(isPresented: $showAlert) {
             Alert(
-                title: Text(localizedString("security__reset_dialog_title")),
-                message: Text(localizedString("security__reset_dialog_desc")),
-                primaryButton: .destructive(Text(localizedString("security__reset_confirm"))) {
+                title: Text(t("security__reset_dialog_title")),
+                message: Text(t("security__reset_dialog_desc")),
+                primaryButton: .destructive(Text(t("security__reset_confirm"))) {
                     onReset()
                 },
                 secondaryButton: .cancel()

--- a/Bitkit/Views/Settings/DevSettingsView.swift
+++ b/Bitkit/Views/Settings/DevSettingsView.swift
@@ -97,7 +97,7 @@ struct DevSettingsView: View {
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(localizedString("settings__dev_title"))
+        .navigationTitle(t("settings__dev_title"))
     }
 }
 

--- a/Bitkit/Views/Settings/General/DefaultUnitSettingsView.swift
+++ b/Bitkit/Views/Settings/General/DefaultUnitSettingsView.swift
@@ -6,7 +6,7 @@ struct DefaultUnitSettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 8) {
-                CaptionText(NSLocalizedString("settings__general__unit_display", comment: "").uppercased())
+                CaptionText(t("settings__general__unit_display").uppercased())
                     .padding(.vertical, 16)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -14,7 +14,7 @@ struct DefaultUnitSettingsView: View {
                     currency.primaryDisplay = .bitcoin
                 }) {
                     SettingsListLabel(
-                        title: NSLocalizedString("settings__general__unit_bitcoin", comment: ""),
+                        title: t("settings__general__unit_bitcoin"),
                         iconName: "b-unit",
                         rightIcon: currency.primaryDisplay == .bitcoin ? .checkmark : nil
                     )
@@ -34,13 +34,13 @@ struct DefaultUnitSettingsView: View {
                     .buttonStyle(PlainButtonStyle())
                 }
 
-                BodyMText(localizedString("settings__general__unit_note", comment: "", variables: ["currency": currency.selectedCurrency]))
+                BodyMText(t("settings__general__unit_note", variables: ["currency": currency.selectedCurrency]))
                     .padding(.vertical, 16)
             }
             .padding(.horizontal, 16)
 
             VStack(alignment: .leading, spacing: 8) {
-                CaptionText(NSLocalizedString("settings__general__denomination_label", comment: "").uppercased())
+                CaptionText(t("settings__general__denomination_label").uppercased())
                     .padding(.vertical, 16)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -58,7 +58,7 @@ struct DefaultUnitSettingsView: View {
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(NSLocalizedString("settings__general__unit_title", comment: ""))
+        .navigationTitle(t("settings__general__unit_title"))
     }
 }
 

--- a/Bitkit/Views/Settings/General/LanguageSettingsScreen.swift
+++ b/Bitkit/Views/Settings/General/LanguageSettingsScreen.swift
@@ -26,7 +26,7 @@ struct LanguageSettingsScreen: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionMText(localizedString("settings__general__language_other"))
+                CaptionMText(t("settings__general__language_other"))
                     .padding(.vertical, 16)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -35,7 +35,7 @@ struct LanguageSettingsScreen: View {
                 }
             }
         }
-        .navigationTitle(localizedString("settings__general__language_title"))
+        .navigationTitle(t("settings__general__language_title"))
         .padding(.horizontal, 16)
         .alert("Language Changed", isPresented: $showAlert) {
             Button("OK", role: .cancel) {}

--- a/Bitkit/Views/Settings/General/LocalCurrencySettingsView.swift
+++ b/Bitkit/Views/Settings/General/LocalCurrencySettingsView.swift
@@ -43,7 +43,7 @@ struct LocalCurrencySettingsView: View {
         ScrollView(showsIndicators: false) {
             if !availableMostUsed.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
-                    CaptionText(NSLocalizedString("settings__general__currency_most_used", comment: "").uppercased())
+                    CaptionText(t("settings__general__currency_most_used").uppercased())
                         .padding(.vertical, 16)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -55,7 +55,7 @@ struct LocalCurrencySettingsView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                CaptionText(NSLocalizedString("settings__general__currency_other", comment: "").uppercased())
+                CaptionText(t("settings__general__currency_other").uppercased())
                     .padding(.vertical, 16)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -65,8 +65,8 @@ struct LocalCurrencySettingsView: View {
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(NSLocalizedString("settings__general__currency_local_title", comment: ""))
-        .searchable(text: $searchText, prompt: NSLocalizedString("common__search", comment: ""))
+        .navigationTitle(t("settings__general__currency_local_title"))
+        .searchable(text: $searchText, prompt: t("common__search"))
     }
 }
 

--- a/Bitkit/Views/Settings/General/TagSettingsView.swift
+++ b/Bitkit/Views/Settings/General/TagSettingsView.swift
@@ -7,7 +7,7 @@ struct TagSettingsView: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(NSLocalizedString("settings__general__tags_previously", comment: ""))
+                CaptionText(t("settings__general__tags_previously"))
                     .textCase(.uppercase)
                     .padding(.top, 24)
                     .padding(.bottom, 16)
@@ -27,7 +27,7 @@ struct TagSettingsView: View {
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(NSLocalizedString("settings__general__tags", comment: ""))
+        .navigationTitle(t("settings__general__tags"))
         .task {
             await activityViewModel.syncState()
         }

--- a/Bitkit/Views/Settings/General/WidgetsSettingsView.swift
+++ b/Bitkit/Views/Settings/General/WidgetsSettingsView.swift
@@ -7,18 +7,18 @@ struct WidgetsSettingsView: View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
                 SettingsListLabel(
-                    title: localizedString("settings__widgets__showWidgets"),
+                    title: t("settings__widgets__showWidgets"),
                     toggle: $settings.showWidgets
                 )
 
                 SettingsListLabel(
-                    title: localizedString("settings__widgets__showWidgetTitles"),
+                    title: t("settings__widgets__showWidgetTitles"),
                     toggle: $settings.showWidgetTitles
                 )
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(localizedString("settings__widgets__nav_title"))
+        .navigationTitle(t("settings__widgets__nav_title"))
     }
 }
 

--- a/Bitkit/Views/Settings/GeneralSettingsView.swift
+++ b/Bitkit/Views/Settings/GeneralSettingsView.swift
@@ -12,28 +12,28 @@ struct GeneralSettingsView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationLink(value: Route.languageSettings) {
                     SettingsListLabel(
-                        title: localizedString("settings__general__language"),
+                        title: t("settings__general__language"),
                         rightText: languageManager.currentLanguageDisplayName
                     )
                 }
 
                 NavigationLink(value: Route.currencySettings) {
                     SettingsListLabel(
-                        title: localizedString("settings__general__currency_local"),
+                        title: t("settings__general__currency_local"),
                         rightText: currency.selectedCurrency
                     )
                 }
 
                 NavigationLink(value: Route.unitSettings) {
                     SettingsListLabel(
-                        title: localizedString("settings__general__unit"),
+                        title: t("settings__general__unit"),
                         rightText: currency.primaryDisplay == .bitcoin ? currency.primaryDisplay.rawValue : currency.selectedCurrency
                     )
                 }
 
                 NavigationLink(value: Route.transactionSpeedSettings) {
                     SettingsListLabel(
-                        title: localizedString("settings__general__speed"),
+                        title: t("settings__general__speed"),
                         rightText: settings.defaultTransactionSpeed.displayTitle
                     )
                 }
@@ -41,7 +41,7 @@ struct GeneralSettingsView: View {
                 if !activityViewModel.recentlyUsedTags.isEmpty {
                     NavigationLink(value: Route.tagSettings) {
                         SettingsListLabel(
-                            title: localizedString("settings__general__tags"),
+                            title: t("settings__general__tags"),
                             rightText: String(activityViewModel.recentlyUsedTags.count)
                         )
                     }
@@ -49,28 +49,28 @@ struct GeneralSettingsView: View {
 
                 NavigationLink(value: Route.widgetsSettings) {
                     SettingsListLabel(
-                        title: localizedString("settings__widgets__nav_title"),
+                        title: t("settings__widgets__nav_title"),
                         rightText: settings.showWidgets ? "On" : "Off"
                     )
                 }
 
                 NavigationLink(value: app.hasSeenQuickpayIntro ? Route.quickpay : Route.quickpayIntro) {
                     SettingsListLabel(
-                        title: localizedString("settings__quickpay__nav_title"),
+                        title: t("settings__quickpay__nav_title"),
                         rightText: settings.enableQuickpay ? "On" : "Off"
                     )
                 }
 
                 NavigationLink(value: app.hasSeenNotificationsIntro ? Route.notifications : Route.notificationsIntro) {
                     SettingsListLabel(
-                        title: localizedString("settings__notifications__nav_title"),
+                        title: t("settings__notifications__nav_title"),
                         rightText: settings.notificationServerRegistered ? "On" : "Off"
                     )
                 }
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(localizedString("settings__general_title"))
+        .navigationTitle(t("settings__general_title"))
     }
 }
 

--- a/Bitkit/Views/Settings/MainSettings.swift
+++ b/Bitkit/Views/Settings/MainSettings.swift
@@ -16,42 +16,42 @@ struct MainSettings: View {
                 VStack(alignment: .leading, spacing: 0) {
                     NavigationLink(value: Route.generalSettings) {
                         SettingsListLabel(
-                            title: localizedString("settings__general_title"),
+                            title: t("settings__general_title"),
                             iconName: "gear-six"
                         )
                     }
 
                     NavigationLink(value: Route.securitySettings) {
                         SettingsListLabel(
-                            title: localizedString("settings__security_title"),
+                            title: t("settings__security_title"),
                             iconName: "shield"
                         )
                     }
 
                     NavigationLink(value: Route.backupSettings) {
                         SettingsListLabel(
-                            title: localizedString("settings__backup_title"),
+                            title: t("settings__backup_title"),
                             iconName: "rewind"
                         )
                     }
 
                     NavigationLink(value: Route.advancedSettings) {
                         SettingsListLabel(
-                            title: localizedString("settings__advanced_title"),
+                            title: t("settings__advanced_title"),
                             iconName: "sliders"
                         )
                     }
 
                     NavigationLink(value: Route.support) {
                         SettingsListLabel(
-                            title: localizedString("settings__support_title"),
+                            title: t("settings__support_title"),
                             iconName: "chat"
                         )
                     }
 
                     NavigationLink(value: Route.about) {
                         SettingsListLabel(
-                            title: localizedString("settings__about_title"),
+                            title: t("settings__about_title"),
                             iconName: "info"
                         )
                     }
@@ -59,7 +59,7 @@ struct MainSettings: View {
                     if showDevSettings {
                         NavigationLink(value: Route.devSettings) {
                             SettingsListLabel(
-                                title: localizedString("settings__dev_title"),
+                                title: t("settings__dev_title"),
                                 iconName: "game-controller"
                             )
                         }
@@ -83,8 +83,8 @@ struct MainSettings: View {
 
                                 app.toast(
                                     type: .success,
-                                    title: localizedString(showDevSettings ? "settings__dev_enabled_title" : "settings__dev_disabled_title"),
-                                    description: localizedString(showDevSettings ? "settings__dev_enabled_message" : "settings__dev_disabled_message")
+                                    title: t(showDevSettings ? "settings__dev_enabled_title" : "settings__dev_disabled_title"),
+                                    description: t(showDevSettings ? "settings__dev_enabled_message" : "settings__dev_disabled_message")
                                 )
                             }
                         }
@@ -96,7 +96,7 @@ struct MainSettings: View {
                 .padding(.horizontal, 16)
             }
         }
-        .navigationTitle(localizedString("settings__settings"))
+        .navigationTitle(t("settings__settings"))
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Bitkit/Views/Settings/Notifications/NotificationsIntro.swift
+++ b/Bitkit/Views/Settings/Notifications/NotificationsIntro.swift
@@ -13,16 +13,16 @@ struct NotificationsIntro: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("settings__notifications__intro__title"),
-            description: localizedString("settings__notifications__intro__text"),
+            title: t("settings__notifications__intro__title"),
+            description: t("settings__notifications__intro__text"),
             imageName: "bell-figure",
-            buttonText: localizedString("settings__notifications__intro__button"),
+            buttonText: t("settings__notifications__intro__button"),
             onButtonPress: onEnable,
             accentColor: .blueAccent,
             imagePosition: .center,
             testID: "NotificationsIntro"
         )
-        .navigationTitle(localizedString("settings__notifications__nav_title"))
+        .navigationTitle(t("settings__notifications__nav_title"))
         .backToWalletButton()
     }
 }

--- a/Bitkit/Views/Settings/Notifications/NotificationsSettings.swift
+++ b/Bitkit/Views/Settings/Notifications/NotificationsSettings.swift
@@ -8,17 +8,17 @@ struct NotificationsSettings: View {
 
     var text: String {
         if settings.notificationServerRegistered {
-            return localizedString("settings__notifications__settings__enabled")
+            return t("settings__notifications__settings__enabled")
         } else {
-            return localizedString("settings__notifications__settings__disabled")
+            return t("settings__notifications__settings__disabled")
         }
     }
 
     var buttonTitle: String {
         if settings.notificationAuthorizationStatus == .denied {
-            return localizedString("settings__notifications__settings__button__disabled", variables: ["platform": "iOS"])
+            return t("settings__notifications__settings__button__disabled", variables: ["platform": "iOS"])
         } else {
-            return localizedString("settings__notifications__settings__button__enabled", variables: ["platform": "iOS"])
+            return t("settings__notifications__settings__button__enabled", variables: ["platform": "iOS"])
         }
     }
 
@@ -26,7 +26,7 @@ struct NotificationsSettings: View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
                 SettingsListLabel(
-                    title: localizedString("settings__notifications__settings__toggle"),
+                    title: t("settings__notifications__settings__toggle"),
                     toggle: Binding(
                         get: { settings.notificationServerRegistered },
                         set: { newValue in
@@ -50,7 +50,7 @@ struct NotificationsSettings: View {
                 .padding(.top, 16)
 
                 if settings.notificationAuthorizationStatus == .denied {
-                    BodyMBoldText(localizedString("settings__notifications__settings__denied"), textColor: .redAccent)
+                    BodyMBoldText(t("settings__notifications__settings__denied"), textColor: .redAccent)
                         .padding(.top, 16)
                 }
 
@@ -68,26 +68,26 @@ struct NotificationsSettings: View {
                 if settings.notificationAuthorizationStatus != .denied {
                     VStack(alignment: .leading, spacing: 16) {
                         CaptionText(
-                            localizedString("settings__notifications__settings__privacy__label").uppercased(),
+                            t("settings__notifications__settings__privacy__label").uppercased(),
                         )
                     }
                     .padding(.top, 32)
 
                     SettingsListLabel(
-                        title: localizedString("settings__notifications__settings__privacy__text"),
+                        title: t("settings__notifications__settings__privacy__text"),
                         toggle: $settings.enableNotificationsAmount
                     )
                 }
 
                 VStack(alignment: .leading, spacing: 16) {
                     CaptionText(
-                        localizedString("settings__notifications__settings__notifications__label").uppercased(),
+                        t("settings__notifications__settings__notifications__label").uppercased(),
                     )
                 }
                 .padding(.top, 32)
 
                 if settings.notificationAuthorizationStatus == .denied {
-                    BodyMText(localizedString("settings__notifications__settings__notifications__text"))
+                    BodyMText(t("settings__notifications__settings__notifications__text"))
                         .padding(.top, 16)
                 }
 
@@ -105,7 +105,7 @@ struct NotificationsSettings: View {
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(localizedString("settings__notifications__nav_title"))
+        .navigationTitle(t("settings__notifications__nav_title"))
         .backToWalletButton()
         .onAppear {
             settings.checkNotificationPermission()
@@ -131,7 +131,7 @@ struct NotificationsSettings: View {
             if enableAmount {
                 return "₿ 21 000 ($21.00)"
             } else {
-                return localizedString("settings__notifications__settings__preview__text")
+                return t("settings__notifications__settings__preview__text")
             }
         }
 
@@ -143,11 +143,11 @@ struct NotificationsSettings: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     HStack {
-                        Text(localizedString("settings__notifications__settings__preview__title"))
+                        Text(t("settings__notifications__settings__preview__title"))
                             .font(.system(size: 15, weight: .semibold))
                             .foregroundColor(Color(hex: 0x222222))
                         Spacer()
-                        Text(localizedString("settings__notifications__settings__preview__time"))
+                        Text(t("settings__notifications__settings__preview__time"))
                             .font(.system(size: 12, weight: .medium))
                             .foregroundColor(Color(hex: 0x3F3F3F).opacity(0.5))
                     }

--- a/Bitkit/Views/Settings/Quickpay/QuickpayIntroView.swift
+++ b/Bitkit/Views/Settings/Quickpay/QuickpayIntroView.swift
@@ -6,10 +6,10 @@ struct QuickpayIntroView: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("settings__quickpay__intro__title"),
-            description: localizedString("settings__quickpay__intro__description"),
+            title: t("settings__quickpay__intro__title"),
+            description: t("settings__quickpay__intro__description"),
             imageName: "fast-forward",
-            buttonText: localizedString("common__continue"),
+            buttonText: t("common__continue"),
             onButtonPress: {
                 app.hasSeenQuickpayIntro = true
                 navigation.navigate(.quickpay)
@@ -18,7 +18,7 @@ struct QuickpayIntroView: View {
             imagePosition: .center,
             testID: "QuickpayIntro"
         )
-        .navigationTitle(localizedString("settings__quickpay__nav_title"))
+        .navigationTitle(t("settings__quickpay__nav_title"))
         .backToWalletButton()
     }
 }

--- a/Bitkit/Views/Settings/Quickpay/QuickpaySettings.swift
+++ b/Bitkit/Views/Settings/Quickpay/QuickpaySettings.swift
@@ -12,19 +12,19 @@ struct QuickpaySettings: View {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
                     SettingsListLabel(
-                        title: localizedString("settings__quickpay__settings__toggle"),
+                        title: t("settings__quickpay__settings__toggle"),
                         toggle: $settings.enableQuickpay
                     )
                     .padding(.top, 16)
 
                     BodyMText(
-                        localizedString("settings__quickpay__settings__text", variables: ["amount": String(Int(settings.quickpayAmount))]),
+                        t("settings__quickpay__settings__text", variables: ["amount": String(Int(settings.quickpayAmount))]),
                     )
                     .padding(.top, 16)
 
                     VStack(alignment: .leading, spacing: 16) {
                         CaptionText(
-                            localizedString("settings__quickpay__settings__label").uppercased(),
+                            t("settings__quickpay__settings__label").uppercased(),
                         )
 
                         CustomSlider(value: $settings.quickpayAmount, steps: sliderSteps)
@@ -46,7 +46,7 @@ struct QuickpaySettings: View {
                     .padding(.vertical, 32)
 
                     BodySText(
-                        localizedString("settings__quickpay__settings__note"),
+                        t("settings__quickpay__settings__note"),
                         textColor: .textSecondary
                     )
                 }
@@ -55,7 +55,7 @@ struct QuickpaySettings: View {
                 .bottomSafeAreaPadding()
             }
         }
-        .navigationTitle(localizedString("settings__quickpay__nav_title"))
+        .navigationTitle(t("settings__quickpay__nav_title"))
         .navigationBarTitleDisplayMode(.inline)
         .backToWalletButton()
     }

--- a/Bitkit/Views/Settings/Security/DisablePinView.swift
+++ b/Bitkit/Views/Settings/Security/DisablePinView.swift
@@ -6,7 +6,7 @@ struct DisablePinView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            BodyMText(localizedString("security__pin_disable_text"))
+            BodyMText(t("security__pin_disable_text"))
 
             Spacer()
 
@@ -20,9 +20,9 @@ struct DisablePinView: View {
             Spacer()
 
             CustomButton(
-                title: localizedString("security__pin_disable_button"),
+                title: t("security__pin_disable_button"),
                 destination: PinCheckView(
-                    title: localizedString("security__pin_enter"),
+                    title: t("security__pin_enter"),
                     explanation: "",
                     onCancel: {},
                     onPinVerified: { pin in
@@ -38,7 +38,7 @@ struct DisablePinView: View {
                 )
             )
         }
-        .navigationTitle(localizedString("security__pin_disable_title"))
+        .navigationTitle(t("security__pin_disable_title"))
         .navigationBarTitleDisplayMode(.inline)
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Settings/Security/PinChangeView.swift
+++ b/Bitkit/Views/Settings/Security/PinChangeView.swift
@@ -26,26 +26,26 @@ struct PinChangeView: View {
     var navTitle: String {
         switch step {
         case .verifyCurrentPin:
-            return NSLocalizedString("security__cp_title", comment: "Change PIN")
+            return t("security__cp_title", comment: "Change PIN")
         case .enterNewPin:
-            return NSLocalizedString("security__cp_setnew_title", comment: "Set new PIN title")
+            return t("security__cp_setnew_title", comment: "Set new PIN title")
         case .confirmNewPin:
-            return NSLocalizedString("security__cp_retype_title", comment: "Retype New PIN")
+            return t("security__cp_retype_title", comment: "Retype New PIN")
         case .success:
-            return NSLocalizedString("security__cp_changed_title", comment: "PIN changed title")
+            return t("security__cp_changed_title", comment: "PIN changed title")
         }
     }
 
     var description: String {
         switch step {
         case .verifyCurrentPin:
-            return NSLocalizedString("security__cp_text", comment: "Change PIN description")
+            return t("security__cp_text", comment: "Change PIN description")
         case .enterNewPin:
-            return NSLocalizedString("security__cp_setnew_text", comment: "Set new PIN description")
+            return t("security__cp_setnew_text", comment: "Set new PIN description")
         case .confirmNewPin:
-            return NSLocalizedString("security__cp_retype_text", comment: "Retype PIN description")
+            return t("security__cp_retype_text", comment: "Retype PIN description")
         case .success:
-            return NSLocalizedString("security__cp_changed_text", comment: "PIN changed description")
+            return t("security__cp_changed_text", comment: "PIN changed description")
         }
     }
 
@@ -102,14 +102,14 @@ struct PinChangeView: View {
             Haptics.notify(.success)
         } catch {
             Logger.error("Failed to change PIN: \(error)", context: "PinChangeView")
-            errorMessage = NSLocalizedString("security__cp_try_again", comment: "Try again, this is not the same PIN")
+            errorMessage = t("security__cp_try_again", comment: "Try again, this is not the same PIN")
             pinInput = ""
             Haptics.notify(.error)
         }
     }
 
     private func handlePinMismatch() {
-        errorMessage = NSLocalizedString("security__cp_try_again", comment: "Try again, this is not the same PIN")
+        errorMessage = t("security__cp_try_again", comment: "Try again, this is not the same PIN")
         step = .enterNewPin
         newPin = ""
         resetPinInput()
@@ -154,13 +154,13 @@ struct PinChangeView: View {
 
         if remainingAttempts == 1 {
             // Last attempt warning
-            errorMessage = NSLocalizedString(
+            errorMessage = t(
                 "security__pin_last_attempt",
                 comment: "Last attempt. Entering the wrong PIN again will reset your wallet."
             )
         } else {
             // Show remaining attempts
-            errorMessage = localizedString(
+            errorMessage = t(
                 "security__pin_attempts",
                 comment: "%d attempts remaining. Forgot your PIN?",
                 variables: ["attemptsRemaining": "\(remainingAttempts)"]
@@ -203,7 +203,7 @@ struct PinChangeView: View {
 
     private var successScreen: some View {
         VStack(spacing: 0) {
-            BodyMText(localizedString("security__cp_changed_text"))
+            BodyMText(t("security__cp_changed_text"))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 32)
 
@@ -216,7 +216,7 @@ struct PinChangeView: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("common__ok")) {
+            CustomButton(title: t("common__ok")) {
                 dismiss()
             }
         }

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityBiometrics.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityBiometrics.swift
@@ -14,11 +14,11 @@ struct SecurityBiometrics: View {
     private var biometryTypeName: String {
         switch Env.biometryType {
         case .touchID:
-            return NSLocalizedString("security__bio_touch_id", comment: "")
+            return t("security__bio_touch_id")
         case .faceID:
-            return NSLocalizedString("security__bio_face_id", comment: "")
+            return t("security__bio_face_id")
         default:
-            return NSLocalizedString("security__bio_face_id", comment: "") // Default to Face ID
+            return t("security__bio_face_id") // Default to Face ID
         }
     }
 
@@ -27,7 +27,7 @@ struct SecurityBiometrics: View {
             SheetHeader(title: biometryTypeName)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__bio_ask", variables: ["biometricsName": biometryTypeName]))
+                BodyMText(t("security__bio_ask", variables: ["biometricsName": biometryTypeName]))
 
                 Spacer()
 
@@ -39,7 +39,7 @@ struct SecurityBiometrics: View {
                 Spacer()
 
                 HStack(alignment: .center, spacing: 0) {
-                    BodyMSBText(localizedString("security__bio_use", variables: ["biometricsName": biometryTypeName]))
+                    BodyMSBText(t("security__bio_use", variables: ["biometricsName": biometryTypeName]))
 
                     Spacer()
 
@@ -49,7 +49,7 @@ struct SecurityBiometrics: View {
                 }
                 .padding(.bottom, 32)
 
-                CustomButton(title: localizedString("common__continue")) {
+                CustomButton(title: t("common__continue")) {
                     if useBiometrics {
                         requestBiometricPermission()
                     } else {
@@ -63,10 +63,10 @@ struct SecurityBiometrics: View {
         .padding(.horizontal, 16)
         .sheetBackground()
         .alert(
-            NSLocalizedString("security__bio_error_title", comment: ""),
+            t("security__bio_error_title"),
             isPresented: $showingError
         ) {
-            Button(NSLocalizedString("common__ok", comment: "")) {
+            Button(t("common__ok")) {
                 useBiometrics = false
                 navigateToNoBiometricsSupport = true
             }
@@ -86,7 +86,7 @@ struct SecurityBiometrics: View {
         }
 
         // Request biometric authentication
-        let reason = localizedString("security__bio_confirm", variables: ["biometricsName": biometryTypeName])
+        let reason = t("security__bio_confirm", variables: ["biometricsName": biometryTypeName])
 
         context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, authenticationError in
             DispatchQueue.main.async {
@@ -111,12 +111,12 @@ struct SecurityBiometrics: View {
 
         switch nsError.code {
         case LAError.biometryNotAvailable.rawValue:
-            errorMessage = NSLocalizedString("security__bio_not_available", comment: "")
+            errorMessage = t("security__bio_not_available")
             // Navigate directly to NoBiometricsSupport for this case
             navigateToNoBiometricsSupport = true
             return
         case LAError.biometryNotEnrolled.rawValue:
-            errorMessage = NSLocalizedString("security__bio_not_available", comment: "")
+            errorMessage = t("security__bio_not_available")
             // Navigate directly to NoBiometricsSupport for this case
             navigateToNoBiometricsSupport = true
             return
@@ -124,8 +124,8 @@ struct SecurityBiometrics: View {
             // User cancelled - don't show error, just turn off toggle
             return
         default:
-            errorMessage = localizedString(
-                "security__bio_error_message", comment: "",
+            errorMessage = t(
+                "security__bio_error_message",
                 variables: ["type": biometryTypeName]
             )
         }

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityIntro.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityIntro.swift
@@ -8,12 +8,12 @@ struct SecurityIntro: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             SheetIntro(
-                navTitle: localizedString("security__pin_security_header"),
-                title: localizedString("security__pin_security_title"),
-                description: localizedString("security__pin_security_text"),
+                navTitle: t("security__pin_security_header"),
+                title: t("security__pin_security_title"),
+                description: t("security__pin_security_text"),
                 image: "shield-figure",
-                continueText: localizedString("security__pin_security_button"),
-                cancelText: showLaterButton ? localizedString("common__later") : nil,
+                continueText: t("security__pin_security_button"),
+                cancelText: showLaterButton ? t("common__later") : nil,
                 accentColor: .greenAccent,
                 testID: "SecureWallet",
                 onCancel: {

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityNoBiometrics.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityNoBiometrics.swift
@@ -6,11 +6,11 @@ struct SecurityNoBiometrics: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("security__bio"))
+            SheetHeader(title: t("security__bio"))
                 .padding(.horizontal, 16)
 
             VStack(spacing: 0) {
-                BodyMText(localizedString("security__bio_not_available"))
+                BodyMText(t("security__bio_not_available"))
 
                 Spacer()
 
@@ -23,7 +23,7 @@ struct SecurityNoBiometrics: View {
 
                 HStack(spacing: 16) {
                     CustomButton(
-                        title: localizedString("common__skip"),
+                        title: t("common__skip"),
                         variant: .secondary
                     ) {
                         // Set biometrics to false and continue
@@ -32,7 +32,7 @@ struct SecurityNoBiometrics: View {
                     }
 
                     // Phone Settings button
-                    CustomButton(title: localizedString("security__bio_phone_settings")) {
+                    CustomButton(title: t("security__bio_phone_settings")) {
                         openPhoneSettings()
                     }
                 }

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityPin.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityPin.swift
@@ -9,14 +9,14 @@ struct SecurityPin: View {
 
     private var navTitle: String {
         pinToCheck == nil
-            ? localizedString("security__pin_choose_header")
-            : localizedString("security__pin_retype_header")
+            ? t("security__pin_choose_header")
+            : t("security__pin_retype_header")
     }
 
     private var text: String {
         pinToCheck == nil
-            ? localizedString("security__pin_choose_text")
-            : localizedString("security__pin_retype_text")
+            ? t("security__pin_choose_text")
+            : t("security__pin_retype_text")
     }
 
     var body: some View {
@@ -73,7 +73,7 @@ struct SecurityPin: View {
                 }
             } else {
                 // PINs don't match, show error and reset
-                errorMessage = NSLocalizedString("security__pin_not_match", comment: "")
+                errorMessage = t("security__pin_not_match")
                 pinInput = ""
             }
         } else {

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecuritySuccess.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecuritySuccess.swift
@@ -8,27 +8,27 @@ struct SecuritySuccess: View {
     private var biometryTypeName: String {
         switch Env.biometryType {
         case .touchID:
-            return NSLocalizedString("security__bio_touch_id", comment: "")
+            return t("security__bio_touch_id")
         case .faceID:
-            return NSLocalizedString("security__bio_face_id", comment: "")
+            return t("security__bio_face_id")
         default:
-            return NSLocalizedString("security__bio_face_id", comment: "") // Default to Face ID
+            return t("security__bio_face_id") // Default to Face ID
         }
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("security__success_title"))
+            SheetHeader(title: t("security__success_title"))
                 .padding(.horizontal, 16)
 
             VStack(spacing: 0) {
                 BodyMText(
                     settings.useBiometrics
-                        ? localizedString(
+                        ? t(
                             "security__success_bio",
                             variables: ["biometricsName": biometryTypeName]
                         )
-                        : localizedString("security__success_no_bio"),
+                        : t("security__success_no_bio"),
                     textColor: .textSecondary,
                 )
 
@@ -42,7 +42,7 @@ struct SecuritySuccess: View {
                 Spacer()
 
                 HStack(alignment: .center, spacing: 0) {
-                    BodyMSBText(localizedString("security__success_payments"))
+                    BodyMSBText(t("security__success_payments"))
 
                     Spacer()
 
@@ -52,7 +52,7 @@ struct SecuritySuccess: View {
                 }
                 .padding(.bottom, 32)
 
-                CustomButton(title: localizedString("common__ok")) {
+                CustomButton(title: t("common__ok")) {
                     sheets.hideSheet()
                 }
             }

--- a/Bitkit/Views/Settings/SecurityPrivacySettingsView.swift
+++ b/Bitkit/Views/Settings/SecurityPrivacySettingsView.swift
@@ -15,11 +15,11 @@ struct SecurityPrivacySettingsView: View {
     private var biometryTypeName: String {
         switch Env.biometryType {
         case .touchID:
-            return NSLocalizedString("security__bio_touch_id", comment: "")
+            return t("security__bio_touch_id")
         case .faceID:
-            return NSLocalizedString("security__bio_face_id", comment: "")
+            return t("security__bio_face_id")
         default:
-            return NSLocalizedString("security__bio_face_id", comment: "") // Default to Face ID
+            return t("security__bio_face_id") // Default to Face ID
         }
     }
 
@@ -34,22 +34,22 @@ struct SecurityPrivacySettingsView: View {
             VStack(alignment: .leading, spacing: 0) {
                 // Privacy Settings Section
                 SettingsListLabel(
-                    title: NSLocalizedString("settings__security__swipe_balance_to_hide", comment: ""),
+                    title: t("settings__security__swipe_balance_to_hide"),
                     toggle: $settings.swipeBalanceToHide
                 )
 
                 SettingsListLabel(
-                    title: NSLocalizedString("settings__security__hide_balance_on_open", comment: ""),
+                    title: t("settings__security__hide_balance_on_open"),
                     toggle: $settings.hideBalanceOnOpen
                 )
 
                 SettingsListLabel(
-                    title: NSLocalizedString("settings__security__clipboard", comment: ""),
+                    title: t("settings__security__clipboard"),
                     toggle: $settings.readClipboard
                 )
 
                 SettingsListLabel(
-                    title: NSLocalizedString("settings__security__warn_100", comment: ""),
+                    title: t("settings__security__warn_100"),
                     toggle: $settings.warnWhenSendingOver100
                 )
 
@@ -59,15 +59,15 @@ struct SecurityPrivacySettingsView: View {
                         sheets.showSheet(.security, data: SecurityConfig(showLaterButton: false))
                     } label: {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__security__pin", comment: ""),
-                            rightText: NSLocalizedString("settings__security__pin_disabled", comment: "")
+                            title: t("settings__security__pin"),
+                            rightText: t("settings__security__pin_disabled")
                         )
                     }
                 } else {
                     NavigationLink(value: Route.disablePin) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__security__pin", comment: ""),
-                            rightText: NSLocalizedString("settings__security__pin_enabled", comment: "")
+                            title: t("settings__security__pin"),
+                            rightText: t("settings__security__pin_enabled")
                         )
                     }
                 }
@@ -75,7 +75,7 @@ struct SecurityPrivacySettingsView: View {
                 if settings.pinEnabled {
                     NavigationLink(value: Route.changePin) {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__security__pin_change", comment: "")
+                            title: t("settings__security__pin_change")
                         )
                     }
 
@@ -83,7 +83,7 @@ struct SecurityPrivacySettingsView: View {
                         showPinCheckForLaunch = true
                     } label: {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__security__pin_launch", comment: ""),
+                            title: t("settings__security__pin_launch"),
                             rightIcon: nil,
                             toggle: Binding(
                                 get: { settings.requirePinOnLaunch },
@@ -96,7 +96,7 @@ struct SecurityPrivacySettingsView: View {
                         showPinCheckForIdle = true
                     } label: {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__security__pin_idle", comment: ""),
+                            title: t("settings__security__pin_idle"),
                             rightIcon: nil,
                             toggle: Binding(
                                 get: { settings.requirePinWhenIdle },
@@ -109,7 +109,7 @@ struct SecurityPrivacySettingsView: View {
                         showPinCheckForPayments = true
                     } label: {
                         SettingsListLabel(
-                            title: NSLocalizedString("settings__security__pin_payments", comment: ""),
+                            title: t("settings__security__pin_payments"),
                             rightIcon: nil,
                             toggle: Binding(
                                 get: { settings.requirePinForPayments },
@@ -120,8 +120,8 @@ struct SecurityPrivacySettingsView: View {
 
                     // Biometrics toggle with custom handling
                     SettingsListLabel(
-                        title: localizedString(
-                            "settings__security__use_bio", comment: "",
+                        title: t(
+                            "settings__security__use_bio",
                             variables: ["biometryTypeName": biometryTypeName]
                         ),
                         toggle: Binding(
@@ -133,16 +133,16 @@ struct SecurityPrivacySettingsView: View {
                     )
 
                     // Footer text for Biometrics
-                    BodySText(localizedString("settings__security__footer", variables: ["biometryTypeName": biometryTypeName]))
+                    BodySText(t("settings__security__footer", variables: ["biometryTypeName": biometryTypeName]))
                         .padding(.top, 16)
                 }
             }
             .padding(.horizontal, 16)
         }
-        .navigationTitle(NSLocalizedString("settings__security__title", comment: ""))
+        .navigationTitle(t("settings__security__title"))
         .navigationDestination(isPresented: $showPinCheckForLaunch) {
             PinCheckView(
-                title: NSLocalizedString("security__pin_enter", comment: ""),
+                title: t("security__pin_enter"),
                 explanation: "",
                 onCancel: {},
                 onPinVerified: { _ in
@@ -152,7 +152,7 @@ struct SecurityPrivacySettingsView: View {
         }
         .navigationDestination(isPresented: $showPinCheckForIdle) {
             PinCheckView(
-                title: NSLocalizedString("security__pin_enter", comment: ""),
+                title: t("security__pin_enter"),
                 explanation: "",
                 onCancel: {},
                 onPinVerified: { _ in
@@ -162,7 +162,7 @@ struct SecurityPrivacySettingsView: View {
         }
         .navigationDestination(isPresented: $showPinCheckForPayments) {
             PinCheckView(
-                title: NSLocalizedString("security__pin_enter", comment: ""),
+                title: t("security__pin_enter"),
                 explanation: "",
                 onCancel: {},
                 onPinVerified: { _ in
@@ -171,10 +171,10 @@ struct SecurityPrivacySettingsView: View {
             )
         }
         .alert(
-            NSLocalizedString("security__bio_error_title", comment: ""),
+            t("security__bio_error_title"),
             isPresented: $showingBiometricError
         ) {
-            Button(NSLocalizedString("common__ok", comment: "")) {
+            Button(t("common__ok")) {
                 // Error handled, user acknowledged
             }
         } message: {
@@ -231,8 +231,8 @@ struct SecurityPrivacySettingsView: View {
         }
 
         // Request biometric authentication
-        let reason = localizedString(
-            "security__bio_confirm", comment: "",
+        let reason = t(
+            "security__bio_confirm",
             variables: ["biometricsName": biometryTypeName]
         )
 
@@ -257,17 +257,17 @@ struct SecurityPrivacySettingsView: View {
 
         switch nsError.code {
         case LAError.biometryNotAvailable.rawValue:
-            biometricErrorMessage = NSLocalizedString("security__bio_not_available", comment: "")
+            biometricErrorMessage = t("security__bio_not_available")
             showingBiometricError = true
         case LAError.biometryNotEnrolled.rawValue:
-            biometricErrorMessage = NSLocalizedString("security__bio_not_available", comment: "")
+            biometricErrorMessage = t("security__bio_not_available")
             showingBiometricError = true
         case LAError.userCancel.rawValue, LAError.userFallback.rawValue:
             // User cancelled - don't show error, just keep current state
             return
         default:
-            biometricErrorMessage = localizedString(
-                "security__bio_error_message", comment: "",
+            biometricErrorMessage = t(
+                "security__bio_error_message",
                 variables: ["type": biometryTypeName]
             )
             showingBiometricError = true

--- a/Bitkit/Views/Settings/Support/ReportError.swift
+++ b/Bitkit/Views/Settings/Support/ReportError.swift
@@ -6,7 +6,7 @@ struct ReportError: View {
     var body: some View {
         VStack(spacing: 0) {
             BodyMText(
-                localizedString("settings__support__text_unsuccess"),
+                t("settings__support__text_unsuccess"),
                 textColor: .textSecondary
             )
             .padding(.top, 16)
@@ -22,12 +22,12 @@ struct ReportError: View {
             Spacer()
 
             CustomButton(
-                title: localizedString("settings__support__text_unsuccess_button")
+                title: t("settings__support__text_unsuccess_button")
             ) {
                 dismiss()
             }
         }
-        .navigationTitle(localizedString("settings__support__title_unsuccess"))
+        .navigationTitle(t("settings__support__title_unsuccess"))
         .navigationBarTitleDisplayMode(.inline)
         .padding(.horizontal, 16)
         .bottomSafeAreaPadding()

--- a/Bitkit/Views/Settings/Support/ReportIssue.swift
+++ b/Bitkit/Views/Settings/Support/ReportIssue.swift
@@ -96,16 +96,16 @@ struct ReportIssue: View {
         GeometryReader { geometry in
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    BodyMText(localizedString("settings__support__report_text"))
+                    BodyMText(t("settings__support__report_text"))
                         .padding(.top, 16)
                         .padding(.bottom, 32)
 
                     VStack(alignment: .leading, spacing: 26) {
                         VStack(alignment: .leading, spacing: 8) {
-                            CaptionText(localizedString("settings__support__label_address").uppercased())
+                            CaptionText(t("settings__support__label_address").uppercased())
 
                             TextField(
-                                localizedString("settings__support__placeholder_address"),
+                                t("settings__support__placeholder_address"),
                                 text: $email
                             )
                             .keyboardType(.emailAddress)
@@ -115,13 +115,13 @@ struct ReportIssue: View {
 
                         VStack(alignment: .leading, spacing: 8) {
                             CaptionText(
-                                localizedString("settings__support__label_message").uppercased(),
+                                t("settings__support__label_message").uppercased(),
                                 textColor: .textSecondary
                             )
 
                             ZStack(alignment: .topLeading) {
                                 if message.isEmpty {
-                                    Text(localizedString("settings__support__placeholder_message"))
+                                    Text(t("settings__support__placeholder_message"))
                                         .foregroundColor(.textSecondary)
                                         .font(.custom(Fonts.semiBold, size: 15))
                                         .padding(4)
@@ -146,7 +146,7 @@ struct ReportIssue: View {
                     Spacer(minLength: 16)
 
                     CustomButton(
-                        title: localizedString("settings__support__text_button"),
+                        title: t("settings__support__text_button"),
                         isDisabled: !isFormValid,
                         isLoading: isLoading
                     ) {
@@ -157,7 +157,7 @@ struct ReportIssue: View {
                 .padding(.horizontal, 16)
                 .bottomSafeAreaPadding()
             }
-            .navigationTitle(localizedString("settings__support__report"))
+            .navigationTitle(t("settings__support__report"))
             .navigationBarTitleDisplayMode(.inline)
             .scrollDismissesKeyboard(.interactively)
             .navigationDestination(isPresented: $showingSuccess) {

--- a/Bitkit/Views/Settings/Support/ReportSuccess.swift
+++ b/Bitkit/Views/Settings/Support/ReportSuccess.swift
@@ -7,7 +7,7 @@ struct ReportSuccess: View {
     var body: some View {
         VStack(spacing: 0) {
             BodyMText(
-                localizedString("settings__support__text_success"),
+                t("settings__support__text_success"),
                 textColor: .textSecondary
             )
             .padding(.top, 16)
@@ -23,13 +23,13 @@ struct ReportSuccess: View {
             Spacer()
 
             CustomButton(
-                title: localizedString("settings__support__text_success_button")
+                title: t("settings__support__text_success_button")
             ) {
                 // TODO: Implement navigation to wallet
                 dismiss()
             }
         }
-        .navigationTitle(localizedString("settings__support__title_success"))
+        .navigationTitle(t("settings__support__title_success"))
         .navigationBarTitleDisplayMode(.inline)
         .padding(.horizontal, 16)
         .bottomSafeAreaPadding()

--- a/Bitkit/Views/Settings/SupportView.swift
+++ b/Bitkit/Views/Settings/SupportView.swift
@@ -5,23 +5,23 @@ struct SupportView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            BodyMText(localizedString("settings__support__text"))
+            BodyMText(t("settings__support__text"))
                 .padding(.vertical, 16)
 
             VStack(spacing: 0) {
                 NavigationLink(value: Route.reportIssue) {
-                    SettingsListLabel(title: localizedString("settings__support__report"))
+                    SettingsListLabel(title: t("settings__support__report"))
                 }
 
                 Button(action: {
                     openURL(URL(string: Env.helpUrl)!)
                 }) {
-                    SettingsListLabel(title: localizedString("settings__support__help"))
+                    SettingsListLabel(title: t("settings__support__help"))
                 }
 
                 NavigationLink(value: Route.appStatus) {
                     SettingsListLabel(
-                        title: localizedString("settings__support__status")
+                        title: t("settings__support__status")
                     )
                 }
             }
@@ -39,7 +39,7 @@ struct SupportView: View {
 
             Social()
         }
-        .navigationTitle(localizedString("settings__support__title"))
+        .navigationTitle(t("settings__support__title"))
         .navigationBarTitleDisplayMode(.inline)
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Settings/TransactionSpeed/CustomSpeedView.swift
+++ b/Bitkit/Views/Settings/TransactionSpeed/CustomSpeedView.swift
@@ -20,7 +20,7 @@ struct CustomSpeedView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            CaptionMText(localizedString("common__sat_vbyte"))
+            CaptionMText(t("common__sat_vbyte"))
                 .padding(.bottom, 16)
 
             MoneyText(sats: Int(feeRate), symbol: true)
@@ -30,7 +30,7 @@ struct CustomSpeedView: View {
             if isValid {
                 if let fiatAmount = currency.convert(sats: totalFee) {
                     BodyMText(
-                        localizedString(
+                        t(
                             "settings__general__speed_fee_total_fiat",
                             variables: [
                                 "feeSats": String(totalFee),
@@ -41,7 +41,7 @@ struct CustomSpeedView: View {
                     )
                 } else {
                     BodyMText(
-                        localizedString(
+                        t(
                             "settings__general__speed_fee_total",
                             variables: [
                                 "feeSats": String(totalFee),
@@ -58,7 +58,7 @@ struct CustomSpeedView: View {
             }
 
             CustomButton(
-                title: localizedString("common__continue"),
+                title: t("common__continue"),
                 isDisabled: !isValid
             ) {
                 // Save the custom speed setting
@@ -67,7 +67,7 @@ struct CustomSpeedView: View {
             }
             .padding(.top, 16)
         }
-        .navigationTitle(localizedString("settings__general__speed_fee_custom"))
+        .navigationTitle(t("settings__general__speed_fee_custom"))
         .navigationBarTitleDisplayMode(.inline)
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Settings/TransactionSpeed/TransactionSpeedSettingsView.swift
+++ b/Bitkit/Views/Settings/TransactionSpeed/TransactionSpeedSettingsView.swift
@@ -61,7 +61,7 @@ struct TransactionSpeedSettingsView: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionMText(localizedString("settings__general__speed_default"))
+                CaptionMText(t("settings__general__speed_default"))
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(spacing: 0) {
@@ -108,7 +108,7 @@ struct TransactionSpeedSettingsView: View {
                 }
             }
         }
-        .navigationTitle(localizedString("settings__general__speed_title"))
+        .navigationTitle(t("settings__general__speed_title"))
         .navigationBarTitleDisplayMode(.inline)
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Sheets/AppUpdateSheet.swift
+++ b/Bitkit/Views/Sheets/AppUpdateSheet.swift
@@ -15,12 +15,12 @@ struct AppUpdateSheet: View {
     var body: some View {
         Sheet(id: .appUpdate, data: config) {
             SheetIntro(
-                navTitle: localizedString("other__update_nav_title"),
-                title: localizedString("other__update_title"),
-                description: localizedString("other__update_text"),
+                navTitle: t("other__update_nav_title"),
+                title: t("other__update_title"),
+                description: t("other__update_text"),
                 image: "wand",
-                continueText: localizedString("other__update_button"),
-                cancelText: localizedString("common__cancel"),
+                continueText: t("other__update_button"),
+                cancelText: t("common__cancel"),
                 testID: "AppUpdateSheet",
                 onCancel: onCancel,
                 onContinue: onContinue

--- a/Bitkit/Views/Sheets/ForgotPinSheet.swift
+++ b/Bitkit/Views/Sheets/ForgotPinSheet.swift
@@ -16,10 +16,10 @@ struct ForgotPinSheet: View {
     var body: some View {
         Sheet(id: .forgotPin, data: config) {
             VStack(alignment: .leading, spacing: 0) {
-                SheetHeader(title: localizedString("security__pin_forgot_title"))
+                SheetHeader(title: t("security__pin_forgot_title"))
 
                 VStack(spacing: 0) {
-                    BodyMText(localizedString("security__pin_forgot_text"))
+                    BodyMText(t("security__pin_forgot_text"))
 
                     Spacer()
 
@@ -30,7 +30,7 @@ struct ForgotPinSheet: View {
 
                     Spacer()
 
-                    CustomButton(title: localizedString("security__pin_forgot_reset")) {
+                    CustomButton(title: t("security__pin_forgot_reset")) {
                         onReset()
                     }
                 }

--- a/Bitkit/Views/Sheets/HighBalanceSheet.swift
+++ b/Bitkit/Views/Sheets/HighBalanceSheet.swift
@@ -13,12 +13,12 @@ struct HighBalanceSheet: View {
     var body: some View {
         Sheet(id: .highBalance, data: config) {
             SheetIntro(
-                navTitle: localizedString("other__high_balance__nav_title"),
-                title: localizedString("other__high_balance__title"),
-                description: localizedString("other__high_balance__text"),
+                navTitle: t("other__high_balance__nav_title"),
+                title: t("other__high_balance__title"),
+                description: t("other__high_balance__text"),
                 image: "exclamation-mark",
-                continueText: localizedString("other__high_balance__continue"),
-                cancelText: localizedString("other__high_balance__cancel"),
+                continueText: t("other__high_balance__continue"),
+                cancelText: t("other__high_balance__cancel"),
                 accentColor: .yellowAccent,
                 accentFont: Fonts.bold,
                 testID: "HighBalanceSheet",

--- a/Bitkit/Views/Sheets/LnurlAuth/LnurlAuthSheet.swift
+++ b/Bitkit/Views/Sheets/LnurlAuth/LnurlAuthSheet.swift
@@ -80,7 +80,7 @@ struct LnurlAuthSheet: View {
 
                 HStack(alignment: .center, spacing: 16) {
                     CustomButton(
-                        title: localizedString("common__cancel"),
+                        title: t("common__cancel"),
                         variant: .secondary
                     ) {
                         onCancel()
@@ -139,8 +139,8 @@ struct LnurlAuthSheet: View {
             // Close the sheet on success
             app.toast(
                 type: .success,
-                title: localizedString("other__lnurl_auth_success_title"),
-                description: localizedString("other__lnurl_auth_success_msg_no_domain")
+                title: t("other__lnurl_auth_success_title"),
+                description: t("other__lnurl_auth_success_msg_no_domain")
             )
             sheets.hideSheet()
         } catch {
@@ -148,8 +148,8 @@ struct LnurlAuthSheet: View {
 
             app.toast(
                 type: .error,
-                title: localizedString("other__lnurl_auth_error"),
-                description: localizedString("other__lnurl_auth_error_msg")
+                title: t("other__lnurl_auth_error"),
+                description: t("other__lnurl_auth_error_msg")
             )
         }
     }

--- a/Bitkit/Views/Sheets/NotificationsSheet.swift
+++ b/Bitkit/Views/Sheets/NotificationsSheet.swift
@@ -14,12 +14,12 @@ struct NotificationsSheet: View {
     var body: some View {
         Sheet(id: .notifications, data: config) {
             SheetIntro(
-                navTitle: localizedString("settings__notifications__nav_title"),
-                title: localizedString("settings__notifications__intro__title"),
-                description: localizedString("settings__notifications__intro__text"),
+                navTitle: t("settings__notifications__nav_title"),
+                title: t("settings__notifications__intro__title"),
+                description: t("settings__notifications__intro__text"),
                 image: "bell-figure",
-                continueText: localizedString("settings__notifications__intro__button"),
-                cancelText: localizedString("common__later"),
+                continueText: t("settings__notifications__intro__button"),
+                cancelText: t("common__later"),
                 accentColor: .blueAccent,
                 testID: "NotificationsSheet",
                 onCancel: onLater,

--- a/Bitkit/Views/Sheets/QuickpaySheet.swift
+++ b/Bitkit/Views/Sheets/QuickpaySheet.swift
@@ -14,12 +14,12 @@ struct QuickpaySheet: View {
     var body: some View {
         Sheet(id: .quickpay, data: config) {
             SheetIntro(
-                navTitle: localizedString("settings__quickpay__nav_title"),
-                title: localizedString("settings__quickpay__intro__title"),
-                description: localizedString("settings__quickpay__intro__description"),
+                navTitle: t("settings__quickpay__nav_title"),
+                title: t("settings__quickpay__intro__title"),
+                description: t("settings__quickpay__intro__description"),
                 image: "fast-forward",
-                continueText: localizedString("common__learn_more"),
-                cancelText: localizedString("common__later"),
+                continueText: t("common__learn_more"),
+                cancelText: t("common__later"),
                 accentColor: .greenAccent,
                 testID: "QuickpaySheet",
                 onCancel: onLater,

--- a/Bitkit/Views/Shop/ShopDiscover.swift
+++ b/Bitkit/Views/Shop/ShopDiscover.swift
@@ -50,29 +50,29 @@ struct ShopDiscover: View {
     // Featured cards data
     private let cards: [ShopCard] = [
         ShopCard(
-            title: localizedString("other__shop__discover__gift-cards__title"),
-            description: localizedString("other__shop__discover__gift-cards__description"),
+            title: t("other__shop__discover__gift-cards__title"),
+            description: t("other__shop__discover__gift-cards__description"),
             imageName: "gift-figure",
             color: .green24,
             route: "gift-cards"
         ),
         ShopCard(
-            title: localizedString("other__shop__discover__esims__title"),
-            description: localizedString("other__shop__discover__esims__description"),
+            title: t("other__shop__discover__esims__title"),
+            description: t("other__shop__discover__esims__description"),
             imageName: "globe-sphere",
             color: .yellow24,
             route: "esims"
         ),
         ShopCard(
-            title: localizedString("other__shop__discover__refill__title"),
-            description: localizedString("other__shop__discover__refill__description"),
+            title: t("other__shop__discover__refill__title"),
+            description: t("other__shop__discover__refill__description"),
             imageName: "phone",
             color: .purple24,
             route: "refill"
         ),
         ShopCard(
-            title: localizedString("other__shop__discover__travel__title"),
-            description: localizedString("other__shop__discover__travel__description"),
+            title: t("other__shop__discover__travel__title"),
+            description: t("other__shop__discover__travel__description"),
             imageName: "rocket2",
             color: .red24,
             route: "buy/travel"
@@ -107,7 +107,7 @@ struct ShopDiscover: View {
                     .padding(.bottom, 16)
 
                     VStack {
-                        CaptionText(localizedString("other__shop__discover__label"))
+                        CaptionText(t("other__shop__discover__label"))
                             .textCase(.uppercase)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -130,7 +130,7 @@ struct ShopDiscover: View {
                 .padding(.horizontal, 16)
             }
         }
-        .navigationTitle(localizedString("other__shop__discover__nav_title"))
+        .navigationTitle(t("other__shop__discover__nav_title"))
         .navigationBarTitleDisplayMode(.inline)
         .backToWalletButton()
     }

--- a/Bitkit/Views/Shop/ShopIntro.swift
+++ b/Bitkit/Views/Shop/ShopIntro.swift
@@ -6,10 +6,10 @@ struct ShopIntro: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("other__shop__intro__title"),
-            description: localizedString("other__shop__intro__description"),
+            title: t("other__shop__intro__title"),
+            description: t("other__shop__intro__description"),
             imageName: "bag",
-            buttonText: localizedString("other__shop__intro__button"),
+            buttonText: t("other__shop__intro__button"),
             onButtonPress: {
                 app.hasSeenShopIntro = true
                 navigation.navigate(.shopDiscover)

--- a/Bitkit/Views/Shop/ShopMain.swift
+++ b/Bitkit/Views/Shop/ShopMain.swift
@@ -29,7 +29,7 @@ struct ShopMain: View {
             .padding(.top, 16)
             .padding(.horizontal, 16)
         }
-        .navigationTitle(localizedString("other__shop__main__nav_title"))
+        .navigationTitle(t("other__shop__main__nav_title"))
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(false)
         .backToWalletButton()

--- a/Bitkit/Views/Transfer/FundAdvancedOptions.swift
+++ b/Bitkit/Views/Transfer/FundAdvancedOptions.swift
@@ -9,12 +9,12 @@ struct FundAdvancedOptions: View {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 0) {
                     DisplayText(
-                        localizedString("lightning__funding_advanced__title"),
+                        t("lightning__funding_advanced__title"),
                         accentColor: .purpleAccent
                     )
                     .padding(.bottom, 8)
 
-                    BodyMText(localizedString("lightning__funding_advanced__text"))
+                    BodyMText(t("lightning__funding_advanced__text"))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.bottom, 32)
 
@@ -26,7 +26,7 @@ struct FundAdvancedOptions: View {
                                     .scaledToFit()
                                     .frame(width: 32, height: 32)
                                     .foregroundColor(.purpleAccent),
-                                title: localizedString("lightning__funding_advanced__button1")
+                                title: t("lightning__funding_advanced__button1")
                             )
                         }
 
@@ -36,7 +36,7 @@ struct FundAdvancedOptions: View {
                                 .scaledToFit()
                                 .frame(width: 32, height: 32)
                                 .foregroundColor(.purpleAccent),
-                            title: localizedString("lightning__funding_advanced__button2")
+                            title: t("lightning__funding_advanced__button2")
                         ) {
                             navigation.navigate(.fundManual(nodeUri: nil))
                         }
@@ -47,7 +47,7 @@ struct FundAdvancedOptions: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__funding_advanced__nav_title"))
+        .navigationTitle(t("lightning__funding_advanced__nav_title"))
         .backToWalletButton()
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Transfer/FundManualAmountView.swift
+++ b/Bitkit/Views/Transfer/FundManualAmountView.swift
@@ -13,7 +13,7 @@ struct FundManualAmountView: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
-                DisplayText(NSLocalizedString("lightning__external_amount__title", comment: ""), accentColor: .purpleAccent)
+                DisplayText(t("lightning__external_amount__title"), accentColor: .purpleAccent)
                     .padding(.top, 16)
 
                 // Visible balance display that acts as a button
@@ -26,7 +26,7 @@ struct FundManualAmountView: View {
                 Spacer()
 
                 HStack(alignment: .bottom) {
-                    AvailableAmount(label: localizedString("wallet__send_available"), amount: wallet.totalOnchainSats)
+                    AvailableAmount(label: t("wallet__send_available"), amount: wallet.totalOnchainSats)
                         .onTapGesture {
                             overrideSats = UInt64(wallet.totalOnchainSats)
                         }
@@ -42,7 +42,7 @@ struct FundManualAmountView: View {
             Spacer()
 
             CustomButton(
-                title: NSLocalizedString("common__continue", comment: ""),
+                title: t("common__continue"),
                 isDisabled: satsAmount == 0,
                 destination: FundManualConfirmView(lnPeer: lnPeer, satsAmount: satsAmount)
             )
@@ -50,7 +50,7 @@ struct FundManualAmountView: View {
             .padding(.vertical, 16)
         }
         .background(Color.black)
-        .navigationTitle(NSLocalizedString("lightning__connections", comment: ""))
+        .navigationTitle(t("lightning__connections"))
         .navigationBarTitleDisplayMode(.inline)
         .backToWalletButton()
     }
@@ -66,11 +66,11 @@ struct FundManualAmountView: View {
                 }
             }
 
-            NumberPadActionButton(text: localizedString("lightning__spending_amount__quarter")) {
+            NumberPadActionButton(text: t("lightning__spending_amount__quarter")) {
                 overrideSats = UInt64(wallet.totalOnchainSats) / 4
             }
 
-            NumberPadActionButton(text: NSLocalizedString("common__max", comment: "")) {
+            NumberPadActionButton(text: t("common__max")) {
                 overrideSats = UInt64(wallet.totalOnchainSats)
             }
         }

--- a/Bitkit/Views/Transfer/FundManualConfirmView.swift
+++ b/Bitkit/Views/Transfer/FundManualConfirmView.swift
@@ -31,19 +31,19 @@ struct FundManualConfirmView: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
-                DisplayText(NSLocalizedString("lightning__transfer__confirm", comment: ""), accentColor: .purpleAccent)
+                DisplayText(t("lightning__transfer__confirm"), accentColor: .purpleAccent)
                     .padding(.top, 16)
 
                 VStack(spacing: 16) {
                     HStack {
                         FeeDisplayRow(
-                            label: NSLocalizedString("lightning__spending_confirm__network_fee", comment: ""),
+                            label: t("lightning__spending_confirm__network_fee"),
                             amount: networkFeeSat
                         )
                         .frame(maxWidth: .infinity)
 
                         FeeDisplayRow(
-                            label: NSLocalizedString("lightning__spending_confirm__lsp_fee", comment: ""),
+                            label: t("lightning__spending_confirm__lsp_fee"),
                             amount: 0
                         )
                         .frame(maxWidth: .infinity)
@@ -51,13 +51,13 @@ struct FundManualConfirmView: View {
 
                     HStack {
                         FeeDisplayRow(
-                            label: NSLocalizedString("lightning__spending_confirm__amount", comment: ""),
+                            label: t("lightning__spending_confirm__amount"),
                             amount: satsAmount
                         )
                         .frame(maxWidth: .infinity)
 
                         FeeDisplayRow(
-                            label: NSLocalizedString("lightning__spending_confirm__total", comment: ""),
+                            label: t("lightning__spending_confirm__total"),
                             amount: satsAmount + networkFeeSat
                         )
                         .frame(maxWidth: .infinity)
@@ -69,7 +69,7 @@ struct FundManualConfirmView: View {
 
                 if !hideSwipeButton {
                     SwipeButton(
-                        title: NSLocalizedString("lightning__transfer__swipe", comment: ""),
+                        title: t("lightning__transfer__swipe"),
                         accentColor: .purpleAccent
                     ) {
                         do {
@@ -103,7 +103,7 @@ struct FundManualConfirmView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(NSLocalizedString("lightning__connections", comment: ""))
+        .navigationTitle(t("lightning__connections"))
         .backToWalletButton()
         .background(Color.black)
         .task {

--- a/Bitkit/Views/Transfer/FundManualSetupView.swift
+++ b/Bitkit/Views/Transfer/FundManualSetupView.swift
@@ -21,8 +21,8 @@ struct FundManualSetupView: View {
     // Test URI: 028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc@34.65.86.104:9400
     func pasteLightningNodeUri() {
         guard let pastedText = UIPasteboard.general.string?.trimmingCharacters(in: .whitespacesAndNewlines) else {
-            alertTitle = localizedString("wallet__send_clipboard_empty_title", comment: "")
-            alertMessage = localizedString("wallet__send_clipboard_empty_text", comment: "")
+            alertTitle = t("wallet__send_clipboard_empty_title")
+            alertMessage = t("wallet__send_clipboard_empty_text")
             showAlert = true
             return
         }
@@ -49,36 +49,36 @@ struct FundManualSetupView: View {
                 ScrollView(showsIndicators: false) {
                     VStack(spacing: 16) {
                         DisplayText(
-                            localizedString("lightning__external_manual__title"),
+                            t("lightning__external_manual__title"),
                             accentColor: .purpleAccent
                         )
 
-                        BodyMText(localizedString("lightning__external_manual__text"))
+                        BodyMText(t("lightning__external_manual__text"))
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.bottom, 16)
 
                         // Node ID field
                         VStack(alignment: .leading, spacing: 8) {
-                            CaptionMText(localizedString("lightning__external_manual__node_id"))
+                            CaptionMText(t("lightning__external_manual__node_id"))
                             TextField("00000000000000000000000000000000000000000000000000000000000000", text: $nodeId)
                                 .lineLimit(2 ... 2)
                         }
 
                         // Host field
                         VStack(alignment: .leading, spacing: 8) {
-                            CaptionMText(localizedString("lightning__external_manual__host"))
+                            CaptionMText(t("lightning__external_manual__host"))
                             TextField("00.00.00.00", text: $host)
                         }
 
                         // Port field
                         VStack(alignment: .leading, spacing: 8) {
-                            CaptionMText(localizedString("lightning__external_manual__port"))
+                            CaptionMText(t("lightning__external_manual__port"))
                             TextField("9735", text: $port)
                         }
 
                         // Paste Node URI button
                         CustomButton(
-                            title: localizedString("lightning__external_manual__paste"),
+                            title: t("lightning__external_manual__paste"),
                             variant: .primary,
                             size: .small,
                             icon: Image("clipboard")
@@ -105,14 +105,14 @@ struct FundManualSetupView: View {
                 HStack {
                     // Scan QR button
                     CustomButton(
-                        title: localizedString("lightning__external_manual__scan", comment: ""),
+                        title: t("lightning__external_manual__scan"),
                         variant: .secondary,
                         destination: ScannerView()
                     )
 
                     // Continue button
                     CustomButton(
-                        title: localizedString("common__continue", comment: ""),
+                        title: t("common__continue"),
                         variant: .primary,
                         isDisabled: nodeId.isEmpty || host.isEmpty || port.isEmpty,
                         destination: FundManualAmountView(lnPeer: LnPeer(nodeId: nodeId, host: host, port: UInt16(port) ?? 0))
@@ -121,7 +121,7 @@ struct FundManualSetupView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__external__nav_title"))
+        .navigationTitle(t("lightning__external__nav_title"))
         .backToWalletButton()
         .padding(.top, 16)
         .padding(.horizontal, 16)
@@ -130,7 +130,7 @@ struct FundManualSetupView: View {
             Alert(
                 title: Text(alertTitle),
                 message: Text(alertMessage),
-                dismissButton: .default(Text(localizedString("common__ok", comment: "")))
+                dismissButton: .default(Text(t("common__ok")))
             )
         }
         .onAppear {

--- a/Bitkit/Views/Transfer/FundManualSuccessView.swift
+++ b/Bitkit/Views/Transfer/FundManualSuccessView.swift
@@ -5,19 +5,19 @@ struct FundManualSuccessView: View {
     @EnvironmentObject var navigation: NavigationViewModel
 
     // Keep in state so we don't get a new random text on each render
-    @State private var randomOkText: String = localizedRandom("common__ok_random", comment: "")
+    @State private var randomOkText: String = localizedRandom("common__ok_random")
 
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
                 DisplayText(
-                    NSLocalizedString("lightning__external_success__title", comment: ""),
+                    t("lightning__external_success__title"),
                     accentColor: .purpleAccent
                 )
                 .padding(.top, 16)
 
                 BodyMText(
-                    NSLocalizedString("lightning__external_success__text", comment: ""),
+                    t("lightning__external_success__text"),
                     textColor: .textSecondary, accentColor: .white, accentFont: Fonts.bold
                 )
 
@@ -44,7 +44,7 @@ struct FundManualSuccessView: View {
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled()
-        .navigationTitle(NSLocalizedString("lightning__transfer_success__nav_title", comment: ""))
+        .navigationTitle(t("lightning__transfer_success__nav_title"))
         .backToWalletButton()
     }
 }

--- a/Bitkit/Views/Transfer/FundingOptions.swift
+++ b/Bitkit/Views/Transfer/FundingOptions.swift
@@ -8,16 +8,16 @@ struct FundingOptions: View {
 
     var text: String {
         if app.isGeoBlocked == true {
-            return localizedString("lightning__funding__text_blocked")
+            return t("lightning__funding__text_blocked")
         } else {
-            return localizedString("lightning__funding__text")
+            return t("lightning__funding__text")
         }
     }
 
     var body: some View {
         VStack(spacing: 0) {
             DisplayText(
-                localizedString("lightning__funding__title"),
+                t("lightning__funding__title"),
                 accentColor: .purpleAccent
             )
             .padding(.bottom, 8)
@@ -29,7 +29,7 @@ struct FundingOptions: View {
             VStack(spacing: 8) {
                 RectangleButton(
                     icon: Image("transfer").foregroundColor(.purpleAccent).frame(width: 32, height: 32),
-                    title: localizedString("lightning__funding__button1"),
+                    title: t("lightning__funding__button1"),
                     isDisabled: wallet.totalOnchainSats == 0 || app.isGeoBlocked == true
                 ) {
                     navigation.navigate(.spendingIntro)
@@ -37,7 +37,7 @@ struct FundingOptions: View {
 
                 RectangleButton(
                     icon: Image("qr").foregroundColor(.purpleAccent).frame(width: 32, height: 32),
-                    title: localizedString("lightning__funding__button2"),
+                    title: t("lightning__funding__button2"),
                     isDisabled: app.isGeoBlocked == true
                 ) {
                     navigation.reset()
@@ -46,7 +46,7 @@ struct FundingOptions: View {
 
                 RectangleButton(
                     icon: Image("external").foregroundColor(.purpleAccent).frame(width: 32, height: 32),
-                    title: localizedString("lightning__funding__button3")
+                    title: t("lightning__funding__button3")
                 ) {
                     navigation.navigate(.fundingAdvanced)
                 }
@@ -55,7 +55,7 @@ struct FundingOptions: View {
             Spacer()
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Transfer/LnurlChannel.swift
+++ b/Bitkit/Views/Transfer/LnurlChannel.swift
@@ -33,11 +33,11 @@ struct LnurlChannel: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            DisplayText(localizedString("other__lnurl_channel_title"), accentColor: .purpleAccent)
+            DisplayText(t("other__lnurl_channel_title"), accentColor: .purpleAccent)
                 .padding(.top, 32)
                 .padding(.bottom, 8)
 
-            BodyMText(localizedString("other__lnurl_channel_message"))
+            BodyMText(t("other__lnurl_channel_message"))
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             if isLoadingChannelInfo {
@@ -48,7 +48,7 @@ struct LnurlChannel: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if channelInfo != nil {
-                CaptionMText(localizedString("other__lnurl_channel_lsp"))
+                CaptionMText(t("other__lnurl_channel_lsp"))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.top, 48)
                     .padding(.bottom, 16)
@@ -56,7 +56,7 @@ struct LnurlChannel: View {
                 // Node
                 VStack(spacing: 0) {
                     HStack(alignment: .center) {
-                        CaptionBText(localizedString("other__lnurl_channel_node"), textColor: .textPrimary)
+                        CaptionBText(t("other__lnurl_channel_node"), textColor: .textPrimary)
                         Spacer()
                         CaptionBText(parsedUri.nodeId.ellipsis(maxLength: 16), textColor: .textPrimary)
                     }
@@ -68,7 +68,7 @@ struct LnurlChannel: View {
                 // Host
                 VStack(spacing: 0) {
                     HStack(alignment: .center) {
-                        CaptionBText(localizedString("other__lnurl_channel_host"), textColor: .textPrimary)
+                        CaptionBText(t("other__lnurl_channel_host"), textColor: .textPrimary)
                         Spacer()
                         CaptionBText(parsedUri.host, textColor: .textPrimary)
                     }
@@ -80,7 +80,7 @@ struct LnurlChannel: View {
                 // Port
                 VStack(spacing: 0) {
                     HStack(alignment: .center) {
-                        CaptionBText(localizedString("other__lnurl_channel_port"), textColor: .textPrimary)
+                        CaptionBText(t("other__lnurl_channel_port"), textColor: .textPrimary)
                         Spacer()
                         CaptionBText(String(parsedUri.port), textColor: .textPrimary)
                     }
@@ -102,7 +102,7 @@ struct LnurlChannel: View {
 
             HStack(spacing: 16) {
                 CustomButton(
-                    title: localizedString("common__cancel"),
+                    title: t("common__cancel"),
                     variant: .secondary,
                     size: .large
                 ) {
@@ -110,7 +110,7 @@ struct LnurlChannel: View {
                 }
 
                 CustomButton(
-                    title: localizedString("common__connect"),
+                    title: t("common__connect"),
                     variant: .primary,
                     size: .large,
                     isDisabled: channelInfo == nil || isLoadingChannelInfo,
@@ -124,7 +124,7 @@ struct LnurlChannel: View {
         }
         .padding(.horizontal, 16)
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("other__lnurl_channel_header"))
+        .navigationTitle(t("other__lnurl_channel_header"))
         .backToWalletButton()
         .task {
             await fetchChannelInfo()

--- a/Bitkit/Views/Transfer/SavingsAdvancedView.swift
+++ b/Bitkit/Views/Transfer/SavingsAdvancedView.swift
@@ -22,10 +22,10 @@ struct SavingsAdvancedView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            DisplayText(localizedString("lightning__savings_advanced__title"), accentColor: .brandAccent)
+            DisplayText(t("lightning__savings_advanced__title"), accentColor: .brandAccent)
                 .padding(.bottom, 16)
 
-            BodyMText(localizedString("lightning__savings_advanced__text"))
+            BodyMText(t("lightning__savings_advanced__text"))
                 .padding(.bottom, 16)
 
             if let channels = wallet.channels {
@@ -36,21 +36,21 @@ struct SavingsAdvancedView: View {
 
             Spacer()
 
-            CaptionMText(localizedString("lightning__savings_advanced__total"))
+            CaptionMText(t("lightning__savings_advanced__total"))
                 .padding(.bottom, 16)
 
             MoneyText(sats: Int(totalSelectedBalance), size: .display, symbol: true)
                 .padding(.bottom, 32)
 
             CustomButton(
-                title: localizedString("common__continue"),
+                title: t("common__continue"),
                 isDisabled: transfer.selectedChannelIds.isEmpty
             ) {
                 dismiss()
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
         .padding(.horizontal, 16)
         .padding(.top, 16)
@@ -69,7 +69,7 @@ struct SavingsAdvancedView: View {
         VStack(spacing: 16) {
             HStack {
                 VStack(alignment: .leading, spacing: 8) {
-                    CaptionMText(localizedString("lightning__connection") + " \(index + 1)")
+                    CaptionMText(t("lightning__connection") + " \(index + 1)")
                     MoneyText(sats: Int(balance), size: .bodySSB, symbol: true)
                 }
 

--- a/Bitkit/Views/Transfer/SavingsAvailabilityView.swift
+++ b/Bitkit/Views/Transfer/SavingsAvailabilityView.swift
@@ -5,9 +5,9 @@ struct SavingsAvailabilityView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            DisplayText(localizedString("lightning__availability__title"), accentColor: .brandAccent)
+            DisplayText(t("lightning__availability__title"), accentColor: .brandAccent)
 
-            BodyMText(localizedString("lightning__availability__text"), accentFont: Fonts.bold)
+            BodyMText(t("lightning__availability__text"), accentFont: Fonts.bold)
                 .padding(.top, 16)
 
             Spacer()
@@ -23,17 +23,17 @@ struct SavingsAvailabilityView: View {
             Spacer()
 
             HStack(spacing: 16) {
-                CustomButton(title: localizedString("common__cancel"), variant: .secondary) {
+                CustomButton(title: t("common__cancel"), variant: .secondary) {
                     navigation.reset()
                 }
 
-                CustomButton(title: localizedString("common__continue")) {
+                CustomButton(title: t("common__continue")) {
                     navigation.navigate(.savingsConfirm)
                 }
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Transfer/SavingsConfirmView.swift
+++ b/Bitkit/Views/Transfer/SavingsConfirmView.swift
@@ -36,9 +36,9 @@ struct SavingsConfirmView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            DisplayText(localizedString("lightning__transfer__confirm"), accentColor: .brandAccent)
+            DisplayText(t("lightning__transfer__confirm"), accentColor: .brandAccent)
 
-            CaptionMText(localizedString("lightning__savings_confirm__label"))
+            CaptionMText(t("lightning__savings_confirm__label"))
                 .padding(.top, 32)
 
             MoneyText(sats: Int(totalSats), size: .display, symbol: true)
@@ -46,11 +46,11 @@ struct SavingsConfirmView: View {
             if hasMultipleChannels {
                 HStack(spacing: 16) {
                     if hasSelectedChannels {
-                        CustomButton(title: localizedString("lightning__savings_confirm__transfer_all"), size: .small) {
+                        CustomButton(title: t("lightning__savings_confirm__transfer_all"), size: .small) {
                             transfer.setSelectedChannelIds([])
                         }
                     } else {
-                        CustomButton(title: localizedString("common__advanced"), size: .small) {
+                        CustomButton(title: t("common__advanced"), size: .small) {
                             navigation.navigate(.savingsAdvanced)
                         }
                     }
@@ -72,7 +72,7 @@ struct SavingsConfirmView: View {
 
             if !hideSwipeButton {
                 SwipeButton(
-                    title: localizedString("lightning__transfer__swipe"),
+                    title: t("lightning__transfer__swipe"),
                     accentColor: .brandAccent
                 ) {
                     do {
@@ -93,7 +93,7 @@ struct SavingsConfirmView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
         .padding(.horizontal, 16)
         .padding(.top, 16)

--- a/Bitkit/Views/Transfer/SavingsIntroView.swift
+++ b/Bitkit/Views/Transfer/SavingsIntroView.swift
@@ -6,10 +6,10 @@ struct SavingsIntroView: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("lightning__savings_intro__title"),
-            description: localizedString("lightning__savings_intro__text"),
+            title: t("lightning__savings_intro__title"),
+            description: t("lightning__savings_intro__text"),
             imageName: "piggybank-right",
-            buttonText: localizedString("lightning__savings_intro__button"),
+            buttonText: t("lightning__savings_intro__button"),
             onButtonPress: {
                 app.hasSeenTransferToSavingsIntro = true
                 navigation.navigate(.savingsAvailability)
@@ -18,7 +18,7 @@ struct SavingsIntroView: View {
             testID: "SavingsIntro"
         )
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
     }
 }

--- a/Bitkit/Views/Transfer/SavingsProgressView.swift
+++ b/Bitkit/Views/Transfer/SavingsProgressView.swift
@@ -18,25 +18,25 @@ struct SavingsProgressContentView: View {
 
     var navTitle: String {
         switch progressState {
-        case .inProgress: return localizedString("lightning__transfer__nav_title")
-        case .failed: return localizedString("lightning__savings_interrupted__nav_title")
-        case .success: return localizedString("lightning__transfer__nav_title")
+        case .inProgress: return t("lightning__transfer__nav_title")
+        case .failed: return t("lightning__savings_interrupted__nav_title")
+        case .success: return t("lightning__transfer__nav_title")
         }
     }
 
     var title: String {
         switch progressState {
-        case .inProgress: return localizedString("lightning__savings_progress__title")
-        case .failed: return localizedString("lightning__savings_interrupted__title")
-        case .success: return localizedString("lightning__transfer_success__title_savings")
+        case .inProgress: return t("lightning__savings_progress__title")
+        case .failed: return t("lightning__savings_interrupted__title")
+        case .success: return t("lightning__transfer_success__title_savings")
         }
     }
 
     var text: String {
         switch progressState {
-        case .inProgress: return localizedString("lightning__savings_progress__text")
-        case .failed: return localizedString("lightning__savings_interrupted__text")
-        case .success: return localizedString("lightning__transfer_success__text_savings")
+        case .inProgress: return t("lightning__savings_progress__text")
+        case .failed: return t("lightning__savings_interrupted__text")
+        case .success: return t("lightning__transfer_success__text_savings")
         }
     }
 
@@ -101,7 +101,7 @@ struct SavingsProgressContentView: View {
             Spacer()
 
             CustomButton(
-                title: localizedString("common__ok"),
+                title: t("common__ok"),
                 isLoading: progressState == .inProgress
             ) {
                 navigation.reset()

--- a/Bitkit/Views/Transfer/SettingUpView.swift
+++ b/Bitkit/Views/Transfer/SettingUpView.swift
@@ -77,33 +77,33 @@ struct SettingUpView: View {
     @State private var innerRotation: Double = 0
     @State private var transferRotation: Double = 0
     // Keep in state so we don't get a new random text on each render
-    @State private var randomOkText: String = localizedRandom("common__ok_random", comment: "")
+    @State private var randomOkText: String = localizedRandom("common__ok_random")
 
     var isTransferring: Bool {
         return transfer.lightningSetupStep < 3
     }
 
     var navTitle: String {
-        return isTransferring ? localizedString("lightning__transfer__nav_title") : localizedString("lightning__transfer_success__nav_title")
+        return isTransferring ? t("lightning__transfer__nav_title") : t("lightning__transfer_success__nav_title")
     }
 
     var title: String {
-        return isTransferring ? localizedString("lightning__savings_progress__title") : localizedString("lightning__transfer_success__title_spending")
+        return isTransferring ? t("lightning__savings_progress__title") : t("lightning__transfer_success__title_spending")
     }
 
     var text: String {
-        return isTransferring ? localizedString("lightning__setting_up_text") : localizedString("lightning__transfer_success__text_spending")
+        return isTransferring ? t("lightning__setting_up_text") : t("lightning__transfer_success__text_spending")
     }
 
     var buttonTitle: String {
-        return isTransferring ? localizedString("lightning__setting_up_button") : randomOkText
+        return isTransferring ? t("lightning__setting_up_button") : randomOkText
     }
 
     let steps = [
-        localizedString("lightning__setting_up_step1"), // Processing Payment
-        localizedString("lightning__setting_up_step2"), // Payment Successful
-        localizedString("lightning__setting_up_step3"), // Queued For Opening
-        localizedString("lightning__setting_up_step4"), // Opening Connection
+        t("lightning__setting_up_step1"), // Processing Payment
+        t("lightning__setting_up_step2"), // Payment Successful
+        t("lightning__setting_up_step3"), // Queued For Opening
+        t("lightning__setting_up_step4"), // Opening Connection
     ]
 
     var body: some View {

--- a/Bitkit/Views/Transfer/SpendingAdvancedView.swift
+++ b/Bitkit/Views/Transfer/SpendingAdvancedView.swift
@@ -33,7 +33,7 @@ struct SpendingAdvancedView: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
-                DisplayText(localizedString("lightning__spending_advanced__title"), accentColor: .purpleAccent)
+                DisplayText(t("lightning__spending_advanced__title"), accentColor: .purpleAccent)
 
                 // Receiving capacity input
                 AmountInput(primaryDisplay: $currency.primaryDisplay, overrideSats: $overrideSats) { newSats in
@@ -45,7 +45,7 @@ struct SpendingAdvancedView: View {
 
                 // Fee estimate
                 HStack(spacing: 4) {
-                    CaptionMText(localizedString("lightning__spending_advanced__fee"))
+                    CaptionMText(t("lightning__spending_advanced__fee"))
 
                     if let feeEstimate {
                         MoneyText(sats: Int(feeEstimate), size: .bodySSB, symbol: true)
@@ -72,7 +72,7 @@ struct SpendingAdvancedView: View {
             Spacer()
 
             CustomButton(
-                title: localizedString("common__continue"),
+                title: t("common__continue"),
                 isDisabled: !isValid
             ) {
                 do {
@@ -91,7 +91,7 @@ struct SpendingAdvancedView: View {
             .padding(.vertical, 16)
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .padding(.top, 16)
         .padding(.horizontal, 16)
         .bottomSafeAreaPadding()
@@ -113,21 +113,21 @@ struct SpendingAdvancedView: View {
 
     private var actionButtons: some View {
         HStack(spacing: 16) {
-            NumberPadActionButton(text: localizedString("common__min")) {
+            NumberPadActionButton(text: t("common__min")) {
                 Logger.debug("Min button pressed, setting to: \(transfer.transferValues.minLspBalance)")
                 overrideSats = transfer.transferValues.minLspBalance
             }
 
             Spacer()
 
-            NumberPadActionButton(text: localizedString("common__default")) {
+            NumberPadActionButton(text: t("common__default")) {
                 Logger.debug("Default button pressed, setting to: \(transfer.transferValues.defaultLspBalance)")
                 overrideSats = transfer.transferValues.defaultLspBalance
             }
 
             Spacer()
 
-            NumberPadActionButton(text: localizedString("common__max")) {
+            NumberPadActionButton(text: t("common__max")) {
                 Logger.debug("Max button pressed, setting to: \(transfer.transferValues.maxLspBalance)")
                 overrideSats = transfer.transferValues.maxLspBalance
             }

--- a/Bitkit/Views/Transfer/SpendingAmount.swift
+++ b/Bitkit/Views/Transfer/SpendingAmount.swift
@@ -16,7 +16,7 @@ struct SpendingAmount: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            DisplayText(localizedString("lightning__spending_amount__title"), accentColor: .purpleAccent)
+            DisplayText(t("lightning__spending_amount__title"), accentColor: .purpleAccent)
 
             AmountInput(primaryDisplay: $currency.primaryDisplay, overrideSats: $overrideSats) { newSats in
                 satsAmount = newSats
@@ -27,7 +27,7 @@ struct SpendingAmount: View {
             Spacer()
 
             HStack(alignment: .bottom) {
-                AvailableAmount(label: localizedString("wallet__send_available"), amount: wallet.totalBalanceSats)
+                AvailableAmount(label: t("wallet__send_available"), amount: wallet.totalBalanceSats)
                 Spacer()
                 actionButtons
             }
@@ -35,7 +35,7 @@ struct SpendingAmount: View {
 
             Divider()
 
-            CustomButton(title: localizedString("common__continue"), isDisabled: satsAmount == 0) {
+            CustomButton(title: t("common__continue"), isDisabled: satsAmount == 0) {
                 do {
                     let newOrder = try await blocktank.createOrder(spendingBalanceSats: satsAmount)
                     transfer.onOrderCreated(order: newOrder)
@@ -47,7 +47,7 @@ struct SpendingAmount: View {
             .padding(.top, 16)
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
         .padding(.top, 16)
         .padding(.horizontal, 16)
@@ -65,11 +65,11 @@ struct SpendingAmount: View {
                 }
             }
 
-            NumberPadActionButton(text: localizedString("lightning__spending_amount__quarter")) {
+            NumberPadActionButton(text: t("lightning__spending_amount__quarter")) {
                 overrideSats = UInt64(wallet.totalBalanceSats) / 4
             }
 
-            NumberPadActionButton(text: localizedString("common__max")) {
+            NumberPadActionButton(text: t("common__max")) {
                 overrideSats = UInt64(Double(wallet.totalBalanceSats) * 0.9) // TODO: can't actually use max, need to estimate fees
             }
         }

--- a/Bitkit/Views/Transfer/SpendingConfirm.swift
+++ b/Bitkit/Views/Transfer/SpendingConfirm.swift
@@ -12,19 +12,19 @@ struct SpendingConfirm: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            DisplayText(localizedString("lightning__transfer__confirm"), accentColor: .purpleAccent)
+            DisplayText(t("lightning__transfer__confirm"), accentColor: .purpleAccent)
 
             if let order = transfer.uiState.order {
                 VStack(spacing: 24) {
                     HStack {
                         FeeDisplayRow(
-                            label: localizedString("lightning__spending_confirm__network_fee"),
+                            label: t("lightning__spending_confirm__network_fee"),
                             amount: order.networkFeeSat
                         )
                         .frame(maxWidth: .infinity)
 
                         FeeDisplayRow(
-                            label: localizedString("lightning__spending_confirm__lsp_fee"),
+                            label: t("lightning__spending_confirm__lsp_fee"),
                             amount: order.serviceFeeSat
                         )
                         .frame(maxWidth: .infinity)
@@ -32,13 +32,13 @@ struct SpendingConfirm: View {
 
                     HStack {
                         FeeDisplayRow(
-                            label: localizedString("lightning__spending_confirm__amount"),
+                            label: t("lightning__spending_confirm__amount"),
                             amount: order.clientBalanceSat
                         )
                         .frame(maxWidth: .infinity)
 
                         FeeDisplayRow(
-                            label: localizedString("lightning__spending_confirm__total"),
+                            label: t("lightning__spending_confirm__total"),
                             amount: order.feeSat
                         )
                         .frame(maxWidth: .infinity)
@@ -59,16 +59,16 @@ struct SpendingConfirm: View {
                 }
 
                 HStack(spacing: 16) {
-                    CustomButton(title: localizedString("common__learn_more"), size: .small) {
+                    CustomButton(title: t("common__learn_more"), size: .small) {
                         navigation.navigate(.transferLearnMore(order: order))
                     }
 
                     if transfer.uiState.isAdvanced {
-                        CustomButton(title: localizedString("lightning__spending_confirm__default"), size: .small) {
+                        CustomButton(title: t("lightning__spending_confirm__default"), size: .small) {
                             transfer.onDefaultClick()
                         }
                     } else {
-                        CustomButton(title: localizedString("common__advanced"), size: .small) {
+                        CustomButton(title: t("common__advanced"), size: .small) {
                             navigation.navigate(.spendingAdvanced(order: order))
                         }
                     }
@@ -79,7 +79,7 @@ struct SpendingConfirm: View {
 
                 if !hideSwipeButton {
                     SwipeButton(
-                        title: localizedString("lightning__transfer__swipe"),
+                        title: t("lightning__transfer__swipe"),
                         accentColor: .purpleAccent
                     ) {
                         isPaying = true
@@ -104,7 +104,7 @@ struct SpendingConfirm: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
         .padding(.top, 16)
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Transfer/SpendingIntroView.swift
+++ b/Bitkit/Views/Transfer/SpendingIntroView.swift
@@ -5,10 +5,10 @@ struct SpendingIntroView: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("lightning__spending_intro__title"),
-            description: localizedString("lightning__spending_intro__text"),
+            title: t("lightning__spending_intro__title"),
+            description: t("lightning__spending_intro__text"),
             imageName: "coin-stack-x",
-            buttonText: localizedString("lightning__spending_intro__button"),
+            buttonText: t("lightning__spending_intro__button"),
             onButtonPress: {
                 navigation.navigate(.spendingAmount)
             },
@@ -17,7 +17,7 @@ struct SpendingIntroView: View {
             testID: "SpendingIntro"
         )
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .backToWalletButton()
     }
 }

--- a/Bitkit/Views/Transfer/TransferIntroView.swift
+++ b/Bitkit/Views/Transfer/TransferIntroView.swift
@@ -6,10 +6,10 @@ struct TransferIntroView: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("lightning__transfer_intro__title"),
-            description: localizedString("lightning__transfer_intro__text"),
+            title: t("lightning__transfer_intro__title"),
+            description: t("lightning__transfer_intro__text"),
             imageName: "lightning",
-            buttonText: localizedString("lightning__transfer_intro__button"),
+            buttonText: t("lightning__transfer_intro__button"),
             onButtonPress: {
                 app.hasSeenTransferToSpendingIntro = true
                 navigation.navigate(.fundingOptions)

--- a/Bitkit/Views/Transfer/TransferLearnMoreView.swift
+++ b/Bitkit/Views/Transfer/TransferLearnMoreView.swift
@@ -11,15 +11,15 @@ struct TransferLearnMoreView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            DisplayText(localizedString("lightning__liquidity__title"), accentColor: .purpleAccent)
+            DisplayText(t("lightning__liquidity__title"), accentColor: .purpleAccent)
                 .padding(.bottom, 16)
 
-            BodyMText(localizedString("lightning__liquidity__text"))
+            BodyMText(t("lightning__liquidity__text"))
 
             Spacer()
 
             VStack(alignment: .leading, spacing: 16) {
-                SubtitleText(localizedString("lightning__liquidity__label"))
+                SubtitleText(t("lightning__liquidity__label"))
                 LightningChannel(
                     capacity: order.lspBalanceSat + order.clientBalanceSat,
                     localBalance: order.clientBalanceSat,
@@ -29,13 +29,13 @@ struct TransferLearnMoreView: View {
                 )
             }
 
-            CustomButton(title: localizedString("common__understood")) {
+            CustomButton(title: t("common__understood")) {
                 dismiss()
             }
             .padding(.top, 32)
         }
         .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(localizedString("lightning__transfer__nav_title"))
+        .navigationTitle(t("lightning__transfer__nav_title"))
         .padding(.top, 16)
         .padding(.horizontal, 16)
         .bottomSafeAreaPadding()

--- a/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
@@ -55,7 +55,7 @@ struct ActivityExplorerView: View {
         var body: some View {
             Button {
                 UIPasteboard.general.string = content
-                app.toast(type: .success, title: localizedString("common__copied"), description: content)
+                app.toast(type: .success, title: t("common__copied"), description: content)
             } label: {
                 VStack(alignment: .leading, spacing: 0) {
                     CaptionText(title)
@@ -84,7 +84,7 @@ struct ActivityExplorerView: View {
 
             if let onchain {
                 InfoSection(
-                    title: localizedString("wallet__activity_tx_id"),
+                    title: t("wallet__activity_tx_id"),
                     content: onchain.txId,
                 )
 
@@ -110,20 +110,20 @@ struct ActivityExplorerView: View {
             } else if let lightning {
                 if let preimage = lightning.preimage {
                     InfoSection(
-                        title: localizedString("wallet__activity_preimage"),
+                        title: t("wallet__activity_preimage"),
                         content: preimage,
                     )
                 }
 
                 if let paymentHash {
                     InfoSection(
-                        title: localizedString("wallet__activity_payment_hash"),
+                        title: t("wallet__activity_payment_hash"),
                         content: paymentHash,
                     )
                 }
 
                 InfoSection(
-                    title: localizedString("wallet__activity_invoice"),
+                    title: t("wallet__activity_invoice"),
                     content: lightning.invoice,
                 )
             }
@@ -131,7 +131,7 @@ struct ActivityExplorerView: View {
             Spacer()
 
             if onchain != nil {
-                CustomButton(title: localizedString("common__open_block_explorer"), shouldExpand: true) {
+                CustomButton(title: t("common__open_block_explorer"), shouldExpand: true) {
                     if let onchain,
                        let url = getBlockExplorerUrl(txId: onchain.txId)
                     {
@@ -140,7 +140,7 @@ struct ActivityExplorerView: View {
                 }
             }
         }
-        .navigationTitle(localizedString("wallet__activity_bitcoin_received"))
+        .navigationTitle(t("wallet__activity_bitcoin_received"))
         .navigationBarTitleDisplayMode(.inline)
         .backToWalletButton()
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
@@ -62,13 +62,13 @@ struct ActivityItemView: View {
     private var navigationTitle: String {
         if isTransfer {
             return isSent
-                ? localizedString("wallet__activity_transfer_spending_done")
-                : localizedString("wallet__activity_transfer_savings_done")
+                ? t("wallet__activity_transfer_spending_done")
+                : t("wallet__activity_transfer_savings_done")
         }
 
         return isSent
-            ? localizedString("wallet__activity_bitcoin_sent")
-            : localizedString("wallet__activity_bitcoin_received")
+            ? t("wallet__activity_bitcoin_sent")
+            : t("wallet__activity_bitcoin_received")
     }
 
     private var formattedDateTime: (date: String, time: String) {
@@ -144,7 +144,7 @@ struct ActivityItemView: View {
     @ViewBuilder
     private var statusSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            CaptionText(localizedString("wallet__activity_status"))
+            CaptionText(t("wallet__activity_status"))
                 .textCase(.uppercase)
                 .padding(.bottom, 8)
 
@@ -156,38 +156,38 @@ struct ActivityItemView: View {
                         Image("hourglass-simple")
                             .foregroundColor(.purpleAccent)
                             .frame(width: 16, height: 16)
-                        BodySSBText(localizedString("wallet__activity_pending"), textColor: .purpleAccent)
+                        BodySSBText(t("wallet__activity_pending"), textColor: .purpleAccent)
                     case .succeeded:
                         Image("bolt")
                             .foregroundColor(.purpleAccent)
                             .frame(width: 16, height: 16)
-                        BodySSBText(localizedString("wallet__activity_successful"), textColor: .purpleAccent)
+                        BodySSBText(t("wallet__activity_successful"), textColor: .purpleAccent)
                     case .failed:
                         Image("x-circle")
                             .foregroundColor(.purpleAccent)
                             .frame(width: 16, height: 16)
-                        BodySSBText(localizedString("wallet__activity_failed"), textColor: .purpleAccent)
+                        BodySSBText(t("wallet__activity_failed"), textColor: .purpleAccent)
                     }
                 case let .onchain(activity):
                     if activity.confirmed == true {
                         Image("check-circle")
                             .foregroundColor(.greenAccent)
                             .frame(width: 16, height: 16)
-                        BodySSBText(localizedString("wallet__activity_confirmed"), textColor: .greenAccent)
+                        BodySSBText(t("wallet__activity_confirmed"), textColor: .greenAccent)
                     } else if activity.isBoosted {
                         Image("hourglass-simple")
                             .foregroundColor(.yellowAccent)
                             .frame(width: 16, height: 16)
                         BodySSBText(
-                            localizedString("wallet__activity_confirms_in_boosted",
-                                            variables: ["feeRateDescription": localizedString("fee__fast__shortDescription")]),
+                            t("wallet__activity_confirms_in_boosted",
+                              variables: ["feeRateDescription": t("fee__fast__shortDescription")]),
                             textColor: .yellowAccent
                         )
                     } else {
                         Image("hourglass-simple")
                             .foregroundColor(.brandAccent)
                             .frame(width: 16, height: 16)
-                        BodySSBText(localizedString("wallet__activity_confirming"), textColor: .brandAccent)
+                        BodySSBText(t("wallet__activity_confirming"), textColor: .brandAccent)
                     }
                 }
             }
@@ -201,7 +201,7 @@ struct ActivityItemView: View {
     private var timestampSection: some View {
         HStack(spacing: 16) {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(localizedString("wallet__activity_date"))
+                CaptionText(t("wallet__activity_date"))
                     .textCase(.uppercase)
                     .padding(.bottom, 8)
 
@@ -218,7 +218,7 @@ struct ActivityItemView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(localizedString("wallet__activity_time"))
+                CaptionText(t("wallet__activity_time"))
                     .textCase(.uppercase)
                     .padding(.bottom, 8)
 
@@ -241,7 +241,7 @@ struct ActivityItemView: View {
         if isSent {
             HStack(spacing: 16) {
                 VStack(alignment: .leading, spacing: 0) {
-                    CaptionText(localizedString("wallet__activity_payment"))
+                    CaptionText(t("wallet__activity_payment"))
                         .textCase(.uppercase)
                         .padding(.bottom, 8)
 
@@ -259,7 +259,7 @@ struct ActivityItemView: View {
 
                 if let fee = activity.fee {
                     VStack(alignment: .leading, spacing: 0) {
-                        CaptionText(localizedString("wallet__activity_fee"))
+                        CaptionText(t("wallet__activity_fee"))
                             .textCase(.uppercase)
                             .padding(.bottom, 8)
 
@@ -283,7 +283,7 @@ struct ActivityItemView: View {
     private var tagsSection: some View {
         if !viewModel.tags.isEmpty {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(localizedString("wallet__tags"))
+                CaptionText(t("wallet__tags"))
                     .textCase(.uppercase)
                     .padding(.bottom, 8)
 
@@ -311,7 +311,7 @@ struct ActivityItemView: View {
         if case let .lightning(activity) = viewModel.activity {
             if !activity.message.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
-                    CaptionText(localizedString("wallet__activity_invoice_note"))
+                    CaptionText(t("wallet__activity_invoice_note"))
                         .textCase(.uppercase)
                         .padding(.bottom, 8)
 
@@ -334,14 +334,14 @@ struct ActivityItemView: View {
         VStack(spacing: 16) {
             HStack(spacing: 16) {
                 CustomButton(
-                    title: localizedString("wallet__activity_assign"), size: .small,
+                    title: t("wallet__activity_assign"), size: .small,
                     icon: Image("user-plus")
                         .foregroundColor(accentColor),
                     shouldExpand: true
                 )
 
                 CustomButton(
-                    title: localizedString("wallet__activity_tag"), size: .small,
+                    title: t("wallet__activity_tag"), size: .small,
                     icon: Image("tag")
                         .foregroundColor(accentColor),
                     shouldExpand: true
@@ -359,7 +359,7 @@ struct ActivityItemView: View {
 
             HStack(spacing: 16) {
                 CustomButton(
-                    title: localizedString("wallet__activity_boost"), size: .small,
+                    title: t("wallet__activity_boost"), size: .small,
                     icon: Image("timer-alt")
                         .foregroundColor(accentColor),
                     isDisabled: shouldDisableBoostButton,
@@ -372,7 +372,7 @@ struct ActivityItemView: View {
                 }
 
                 CustomButton(
-                    title: localizedString("wallet__activity_explore"), size: .small,
+                    title: t("wallet__activity_explore"), size: .small,
                     icon: Image("branch")
                         .foregroundColor(accentColor),
                     shouldExpand: true

--- a/Bitkit/Views/Wallets/Activity/ActivityLatest.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityLatest.swift
@@ -8,7 +8,7 @@ struct ActivityLatest: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            CaptionMText(localizedString("wallet__activity"))
+            CaptionMText(t("wallet__activity"))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, 16)
                 .padding(.top, 32)
@@ -35,7 +35,7 @@ struct ActivityLatest: View {
                             }
                         )
                     } else {
-                        CustomButton(title: localizedString("wallet__activity_show_all"), variant: .tertiary) {
+                        CustomButton(title: t("wallet__activity_show_all"), variant: .tertiary) {
                             navigation.navigate(.activityList)
                         }
                     }

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -34,22 +34,22 @@ private struct TransactionStatusText: View {
         if txType == .sent {
             switch status {
             case .failed:
-                BodyMSBText(localizedString("wallet__activity_failed"), textColor: .textPrimary)
+                BodyMSBText(t("wallet__activity_failed"), textColor: .textPrimary)
             case .pending:
-                BodyMSBText(localizedString("wallet__activity_pending"), textColor: .textPrimary)
+                BodyMSBText(t("wallet__activity_pending"), textColor: .textPrimary)
             case .succeeded:
-                BodyMSBText(localizedString("wallet__activity_sent"), textColor: .textPrimary)
+                BodyMSBText(t("wallet__activity_sent"), textColor: .textPrimary)
             case .none:
                 EmptyView()
             }
         } else {
             switch status {
             case .failed:
-                BodyMSBText(localizedString("wallet__activity_failed"), textColor: .textPrimary)
+                BodyMSBText(t("wallet__activity_failed"), textColor: .textPrimary)
             case .pending:
-                BodyMSBText(localizedString("wallet__activity_pending"), textColor: .textPrimary)
+                BodyMSBText(t("wallet__activity_pending"), textColor: .textPrimary)
             case .succeeded:
-                BodyMSBText(localizedString("wallet__activity_received"), textColor: .textPrimary)
+                BodyMSBText(t("wallet__activity_received"), textColor: .textPrimary)
             case .none:
                 EmptyView()
             }
@@ -59,9 +59,9 @@ private struct TransactionStatusText: View {
     @ViewBuilder
     private var onchainStatus: some View {
         if txType == .sent {
-            BodyMSBText(localizedString("wallet__activity_sent"), textColor: .textPrimary)
+            BodyMSBText(t("wallet__activity_sent"), textColor: .textPrimary)
         } else {
-            BodyMSBText(localizedString("wallet__activity_received"), textColor: .textPrimary)
+            BodyMSBText(t("wallet__activity_received"), textColor: .textPrimary)
         }
     }
 }

--- a/Bitkit/Views/Wallets/Activity/AllActivityView.swift
+++ b/Bitkit/Views/Wallets/Activity/AllActivityView.swift
@@ -15,13 +15,13 @@ struct AllActivityView: View {
         var description: String {
             switch self {
             case .all:
-                return localizedString("wallet__activity_tabs__all")
+                return t("wallet__activity_tabs__all")
             case .sent:
-                return localizedString("wallet__activity_tabs__sent")
+                return t("wallet__activity_tabs__sent")
             case .received:
-                return localizedString("wallet__activity_tabs__received")
+                return t("wallet__activity_tabs__received")
             case .other:
-                return localizedString("wallet__activity_tabs__other")
+                return t("wallet__activity_tabs__other")
             }
         }
     }

--- a/Bitkit/Views/Wallets/Activity/EmptyActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/EmptyActivityRow.swift
@@ -10,8 +10,8 @@ struct EmptyActivityRow: View {
             )
 
             VStack(alignment: .leading, spacing: 4) {
-                BodyMSBText(localizedString("wallet__activity_no"))
-                CaptionBText(localizedString("wallet__activity_no_explain"))
+                BodyMSBText(t("wallet__activity_no"))
+                CaptionBText(t("wallet__activity_no_explain"))
             }
 
             Spacer()

--- a/Bitkit/Views/Wallets/HomeView.swift
+++ b/Bitkit/Views/Wallets/HomeView.swift
@@ -140,7 +140,7 @@ struct HomeView: View {
                     .foregroundColor(.secondary)
                     .frame(width: 32, height: 32)
 
-                TitleText(localizedString("slashtags__your_name_capital"))
+                TitleText(t("slashtags__your_name_capital"))
             }
             .frame(height: 46)
         }

--- a/Bitkit/Views/Wallets/LnurlWithdraw/LnurlWithdrawAmount.swift
+++ b/Bitkit/Views/Wallets/LnurlWithdraw/LnurlWithdrawAmount.swift
@@ -23,7 +23,7 @@ struct LnurlWithdrawAmount: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("wallet__lnurl_w_title"), showBackButton: true)
+            SheetHeader(title: t("wallet__lnurl_w_title"), showBackButton: true)
 
             VStack(alignment: .leading, spacing: 16) {
                 AmountInput(primaryDisplay: $currency.primaryDisplay, overrideSats: $overrideSats, showConversion: true) { newAmount in
@@ -34,7 +34,7 @@ struct LnurlWithdrawAmount: View {
                 Spacer()
 
                 HStack(alignment: .bottom) {
-                    AvailableAmount(label: localizedString("wallet__lnurl_w_max"), amount: maxAmount)
+                    AvailableAmount(label: t("wallet__lnurl_w_max"), amount: maxAmount)
                         .onTapGesture {
                             overrideSats = UInt64(maxAmount)
                         }
@@ -58,7 +58,7 @@ struct LnurlWithdrawAmount: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("common__continue"), isDisabled: !isValid) {
+            CustomButton(title: t("common__continue"), isDisabled: !isValid) {
                 onContinue()
             }
             .padding(.top, 16)

--- a/Bitkit/Views/Wallets/LnurlWithdraw/LnurlWithdrawConfirm.swift
+++ b/Bitkit/Views/Wallets/LnurlWithdraw/LnurlWithdrawConfirm.swift
@@ -20,13 +20,13 @@ struct LnurlWithdrawConfirm: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("wallet__lnurl_w_title"), showBackButton: true)
+            SheetHeader(title: t("wallet__lnurl_w_title"), showBackButton: true)
 
             MoneyStack(sats: Int(amount), showSymbol: true)
                 .padding(.top, 16)
                 .padding(.bottom, 42)
 
-            BodyMText(localizedString("wallet__lnurl_w_text"))
+            BodyMText(t("wallet__lnurl_w_text"))
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()
@@ -39,7 +39,7 @@ struct LnurlWithdrawConfirm: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("wallet__lnurl_w_button"), isLoading: isLoading) {
+            CustomButton(title: t("wallet__lnurl_w_button"), isLoading: isLoading) {
                 performWithdraw()
             }
         }
@@ -73,8 +73,8 @@ struct LnurlWithdrawConfirm: View {
                 await MainActor.run {
                     app.toast(
                         type: .info,
-                        title: localizedString("other__lnurl_withdr_success_title"),
-                        description: localizedString("other__lnurl_withdr_success_msg")
+                        title: t("other__lnurl_withdr_success_title"),
+                        description: t("other__lnurl_withdr_success_msg")
                     )
                     isLoading = false
                     sheets.hideSheet()

--- a/Bitkit/Views/Wallets/Receive/QrArea.swift
+++ b/Bitkit/Views/Wallets/Receive/QrArea.swift
@@ -22,7 +22,7 @@ struct QrArea: View {
             QR(content: uri, imageAsset: imageAsset)
 
             if showCopyTooltip {
-                Tooltip(text: localizedString("wallet__receive_copied"))
+                Tooltip(text: t("wallet__receive_copied"))
                     .transition(.opacity.combined(with: .scale(scale: 0.8)))
                     .offset(y: 80)
                     .allowsHitTesting(false)
@@ -32,7 +32,7 @@ struct QrArea: View {
 
         HStack {
             CustomButton(
-                title: localizedString("common__edit"),
+                title: t("common__edit"),
                 size: .small,
                 icon: Image("pencil").foregroundColor(accentColor),
                 shouldExpand: true
@@ -41,7 +41,7 @@ struct QrArea: View {
             }
 
             CustomButton(
-                title: localizedString("common__copy"),
+                title: t("common__copy"),
                 size: .small,
                 icon: Image("copy").foregroundColor(accentColor),
                 shouldExpand: true
@@ -50,7 +50,7 @@ struct QrArea: View {
             }
 
             CustomButton(
-                title: localizedString("common__share"),
+                title: t("common__share"),
                 size: .small,
                 icon: Image("share").foregroundColor(accentColor),
                 shouldExpand: true

--- a/Bitkit/Views/Wallets/Receive/ReceiveCjitAmount.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveCjitAmount.swift
@@ -18,7 +18,7 @@ struct ReceiveCjitAmount: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("wallet__receive_bitcoin"), showBackButton: true)
+            SheetHeader(title: t("wallet__receive_bitcoin"), showBackButton: true)
 
             VStack(alignment: .leading, spacing: 16) {
                 AmountInput(primaryDisplay: $currency.primaryDisplay, overrideSats: $overrideSats, showConversion: true) { newSats in
@@ -31,7 +31,7 @@ struct ReceiveCjitAmount: View {
 
                 HStack(alignment: .bottom) {
                     AvailableAmount(
-                        label: localizedString("fee__minimum__title"),
+                        label: t("fee__minimum__title"),
                         amount: Int(minimumAmount)
                     )
                     .onTapGesture {
@@ -57,7 +57,7 @@ struct ReceiveCjitAmount: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("common__continue"), isDisabled: amountSats < minimumAmount) {
+            CustomButton(title: t("common__continue"), isDisabled: amountSats < minimumAmount) {
                 // Wait until node is running if it's in starting state
                 if await wallet.waitForNodeToRun() {
                     // Only proceed if node is running

--- a/Bitkit/Views/Wallets/Receive/ReceiveCjitConfirmation.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveCjitConfirmation.swift
@@ -28,14 +28,14 @@ struct ReceiveCjitConfirmation: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("wallet__receive_bitcoin"), showBackButton: true)
+            SheetHeader(title: t("wallet__receive_bitcoin"), showBackButton: true)
 
             VStack(alignment: .leading, spacing: 0) {
                 MoneyStack(sats: Int(receiveAmountSats), showSymbol: true)
                     .padding(.bottom, 32)
 
                 BodyMText(
-                    localizedString(
+                    t(
                         "wallet__receive_connect_initial",
                         variables: [
                             "networkFee": formattedNetworkFee(),
@@ -48,7 +48,7 @@ struct ReceiveCjitConfirmation: View {
                 .padding(.bottom, 32)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    CaptionMText(localizedString("wallet__receive_will"))
+                    CaptionMText(t("wallet__receive_will"))
                     MoneyText(sats: receiveAmount, size: .title, symbol: true)
                 }
             }
@@ -63,11 +63,11 @@ struct ReceiveCjitConfirmation: View {
             Spacer(minLength: 0)
 
             HStack(spacing: 16) {
-                CustomButton(title: localizedString("common__learn_more"), variant: .secondary) {
+                CustomButton(title: t("common__learn_more"), variant: .secondary) {
                     navigationPath.append(.cjitLearnMore(entry: entry, receiveAmountSats: receiveAmountSats))
                 }
 
-                CustomButton(title: localizedString("common__continue")) {
+                CustomButton(title: t("common__continue")) {
                     navigationPath.append(.qr(cjitInvoice: entry.invoice.request, tab: .spending))
                 }
             }

--- a/Bitkit/Views/Wallets/Receive/ReceiveCjitLearnMore.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveCjitLearnMore.swift
@@ -12,19 +12,19 @@ struct ReceiveCjitLearnMore: View {
 
     var text: String {
         isAdditional
-            ? localizedString("wallet__receive_liquidity__text_additional")
-            : localizedString("wallet__receive_liquidity__text")
+            ? t("wallet__receive_liquidity__text_additional")
+            : t("wallet__receive_liquidity__text")
     }
 
     var label: String {
         isAdditional
-            ? localizedString("wallet__receive_liquidity__label_additional")
-            : localizedString("wallet__receive_liquidity__label")
+            ? t("wallet__receive_liquidity__label_additional")
+            : t("wallet__receive_liquidity__label")
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("wallet__receive_liquidity__nav_title"), showBackButton: true)
+            SheetHeader(title: t("wallet__receive_liquidity__nav_title"), showBackButton: true)
 
             BodyMText(text)
 
@@ -42,7 +42,7 @@ struct ReceiveCjitLearnMore: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("common__understood")) {
+            CustomButton(title: t("common__understood")) {
                 dismiss()
             }
         }

--- a/Bitkit/Views/Wallets/Receive/ReceiveEdit.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveEdit.swift
@@ -14,7 +14,7 @@ struct ReceiveEdit: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("wallet__receive_specify"))
+            SheetHeader(title: t("wallet__receive_specify"))
 
             VStack(alignment: .leading, spacing: 0) {
                 AmountInput(primaryDisplay: $currency.primaryDisplay, overrideSats: $overrideSats, showConversion: true, shouldAutoFocus: false) {
@@ -26,12 +26,12 @@ struct ReceiveEdit: View {
                 .focused($isAmountInputFocused)
                 .padding(.bottom, 32)
 
-                CaptionMText(localizedString("wallet__note"))
+                CaptionMText(t("wallet__note"))
                     .padding(.bottom, 8)
 
                 ZStack(alignment: .topLeading) {
                     if noteText.isEmpty {
-                        BodySSBText(localizedString("wallet__receive_note_placeholder"), textColor: .textSecondary)
+                        BodySSBText(t("wallet__receive_note_placeholder"), textColor: .textSecondary)
                             .padding(16)
                     }
 
@@ -49,12 +49,12 @@ struct ReceiveEdit: View {
                 .background(Color.white06)
                 .cornerRadius(8)
 
-                CaptionMText(localizedString("wallet__tags"))
+                CaptionMText(t("wallet__tags"))
                     .padding(.top, 16)
                     .padding(.bottom, 8)
 
                 CustomButton(
-                    title: localizedString("wallet__tags_add"),
+                    title: t("wallet__tags_add"),
                     size: .small,
                     icon: Image("tag").foregroundColor(.brandAccent),
                 ) {
@@ -78,7 +78,7 @@ struct ReceiveEdit: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("wallet__receive_show_qr")) {
+            CustomButton(title: t("wallet__receive_show_qr")) {
                 // Wait until node is running if it's in starting state
                 if await wallet.waitForNodeToRun() {
                     do {

--- a/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
@@ -33,11 +33,11 @@ struct ReceiveQr: View {
         var description: String {
             switch self {
             case .savings:
-                return localizedString("lightning__savings")
+                return t("lightning__savings")
             case .unified:
                 return "Auto"
             case .spending:
-                return localizedString("lightning__spending")
+                return t("lightning__spending")
             }
         }
     }
@@ -68,7 +68,7 @@ struct ReceiveQr: View {
 
             VStack(spacing: 0) {
                 SheetHeader(
-                    title: localizedString("wallet__receive_bitcoin"),
+                    title: t("wallet__receive_bitcoin"),
                     action:
                     AnyView(
                         Button(action: {
@@ -215,7 +215,7 @@ struct ReceiveQr: View {
                     if !wallet.onchainAddress.isEmpty {
                         pairs.append(
                             CopyAddressPair(
-                                title: localizedString("wallet__receive_bitcoin_invoice"),
+                                title: t("wallet__receive_bitcoin_invoice"),
                                 address: wallet.onchainAddress,
                                 type: .onchain
                             )
@@ -226,7 +226,7 @@ struct ReceiveQr: View {
                     if let cjitInvoice {
                         pairs.append(
                             CopyAddressPair(
-                                title: localizedString("wallet__receive_lightning_invoice"),
+                                title: t("wallet__receive_lightning_invoice"),
                                 address: cjitInvoice,
                                 type: .lightning
                             )
@@ -237,7 +237,7 @@ struct ReceiveQr: View {
                     if !wallet.bolt11.isEmpty {
                         pairs.append(
                             CopyAddressPair(
-                                title: localizedString("wallet__receive_lightning_invoice"),
+                                title: t("wallet__receive_lightning_invoice"),
                                 address: wallet.bolt11,
                                 type: .lightning
                             )
@@ -248,7 +248,7 @@ struct ReceiveQr: View {
                     if !wallet.onchainAddress.isEmpty {
                         pairs.append(
                             CopyAddressPair(
-                                title: localizedString("wallet__receive_bitcoin_invoice"),
+                                title: t("wallet__receive_bitcoin_invoice"),
                                 address: wallet.onchainAddress,
                                 type: .onchain
                             )
@@ -258,7 +258,7 @@ struct ReceiveQr: View {
                     if !wallet.bolt11.isEmpty {
                         pairs.append(
                             CopyAddressPair(
-                                title: localizedString("wallet__receive_lightning_invoice"),
+                                title: t("wallet__receive_lightning_invoice"),
                                 address: wallet.bolt11,
                                 type: .lightning
                             )
@@ -283,7 +283,7 @@ struct ReceiveQr: View {
         VStack(spacing: 0) {
             if showingCjitOnboarding {
                 CustomButton(
-                    title: localizedString("wallet__receive_spending"),
+                    title: t("wallet__receive_spending"),
                     icon: Image("bolt").foregroundColor(.purpleAccent),
                     isDisabled: wallet.nodeLifecycleState != .running
                 ) {

--- a/Bitkit/Views/Wallets/Receive/ReceiveTag.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveTag.swift
@@ -11,12 +11,12 @@ struct ReceiveTag: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: localizedString("wallet__tags_add"), showBackButton: true)
+            SheetHeader(title: t("wallet__tags_add"), showBackButton: true)
 
             let tagsToShow = activityListViewModel.recentlyUsedTags
 
             if !tagsToShow.isEmpty {
-                CaptionMText(localizedString("wallet__tags_previously"))
+                CaptionMText(t("wallet__tags_previously"))
                     .padding(.bottom, 16)
 
                 WrappingHStack(spacing: 8) {
@@ -31,11 +31,11 @@ struct ReceiveTag: View {
                 }
             }
 
-            CaptionMText(localizedString("wallet__tags_new"))
+            CaptionMText(t("wallet__tags_new"))
                 .padding(.top, 28)
                 .padding(.bottom, 8)
 
-            TextField(localizedString("wallet__tags_new_enter"), text: $newTag, backgroundColor: .white06)
+            TextField(t("wallet__tags_new_enter"), text: $newTag, backgroundColor: .white06)
                 .focused($isTextFieldFocused)
                 .disabled(isLoading)
                 .autocapitalization(.none)
@@ -45,7 +45,7 @@ struct ReceiveTag: View {
             Spacer()
 
             CustomButton(
-                title: localizedString("wallet__tags_add_button"),
+                title: t("wallet__tags_add_button"),
                 isDisabled: newTag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                 isLoading: isLoading
             ) {

--- a/Bitkit/Views/Wallets/SavingsWalletView.swift
+++ b/Bitkit/Views/Wallets/SavingsWalletView.swift
@@ -28,7 +28,7 @@ struct SavingsWalletView: View {
                 ScrollView(showsIndicators: false) {
                     ActivityList(viewType: .onchain)
 
-                    CustomButton(title: localizedString("wallet__activity_show_all"), variant: .tertiary) {
+                    CustomButton(title: t("wallet__activity_show_all"), variant: .tertiary) {
                         navigation.navigate(.activityList)
                     }
                     /// Leave some space for TabBar
@@ -46,7 +46,7 @@ struct SavingsWalletView: View {
                 .transition(.move(edge: .leading).combined(with: .opacity))
             }
         }
-        .navigationTitle(localizedString("wallet__savings__title"))
+        .navigationTitle(t("wallet__savings__title"))
         .padding(.horizontal)
         .frame(maxHeight: .infinity, alignment: .top)
         .overlay(alignment: .topTrailing) {

--- a/Bitkit/Views/Wallets/Send/LnurlPayAmount.swift
+++ b/Bitkit/Views/Wallets/Send/LnurlPayAmount.swift
@@ -20,7 +20,7 @@ struct LnurlPayAmount: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("wallet__lnurl_p_title"), showBackButton: true)
+            SheetHeader(title: t("wallet__lnurl_p_title"), showBackButton: true)
 
             VStack(alignment: .leading, spacing: 16) {
                 AmountInput(primaryDisplay: $currency.primaryDisplay, overrideSats: $overrideSats, showConversion: true) { newAmount in
@@ -31,14 +31,14 @@ struct LnurlPayAmount: View {
                 Spacer()
 
                 HStack(alignment: .bottom) {
-                    AvailableAmount(label: localizedString("wallet__send_available_spending"), amount: wallet.totalLightningSats)
+                    AvailableAmount(label: t("wallet__send_available_spending"), amount: wallet.totalLightningSats)
                         .onTapGesture {
                             overrideSats = UInt64(wallet.totalLightningSats)
                         }
 
                     Spacer()
 
-                    NumberPadActionButton(text: localizedString("common__max"), color: .brandAccent) {
+                    NumberPadActionButton(text: t("common__max"), color: .brandAccent) {
                         overrideSats = maxAmount
                     }
 
@@ -59,7 +59,7 @@ struct LnurlPayAmount: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("common__continue"), isDisabled: !isValid) {
+            CustomButton(title: t("common__continue"), isDisabled: !isValid) {
                 onContinue()
             }
             .padding(.top, 16)
@@ -74,8 +74,8 @@ struct LnurlPayAmount: View {
 
         if amount < minSendable {
             app.toast(
-                type: .error, title: localizedString("wallet__lnurl_pay__error_min__title"),
-                description: localizedString("wallet__lnurl_pay__error_min__description", variables: ["amount": "\(minSendable)"])
+                type: .error, title: t("wallet__lnurl_pay__error_min__title"),
+                description: t("wallet__lnurl_pay__error_min__description", variables: ["amount": "\(minSendable)"])
             )
             return
         }

--- a/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
+++ b/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
@@ -20,11 +20,11 @@ struct LnurlPayConfirm: View {
     private var biometryTypeName: String {
         switch Env.biometryType {
         case .touchID:
-            return localizedString("security__bio_touch_id")
+            return t("security__bio_touch_id")
         case .faceID:
-            return localizedString("security__bio_face_id")
+            return t("security__bio_face_id")
         default:
-            return localizedString("security__bio_face_id") // Default to Face ID
+            return t("security__bio_face_id") // Default to Face ID
         }
     }
 
@@ -40,7 +40,7 @@ struct LnurlPayConfirm: View {
 
     var body: some View {
         VStack {
-            SheetHeader(title: localizedString("wallet__lnurl_p_title"), showBackButton: true)
+            SheetHeader(title: t("wallet__lnurl_p_title"), showBackButton: true)
 
             VStack(alignment: .leading) {
                 MoneyStack(sats: Int(wallet.sendAmountSats ?? app.lnurlPayData!.minSendable), showSymbol: true)
@@ -48,7 +48,7 @@ struct LnurlPayConfirm: View {
 
                 VStack(spacing: 0) {
                     VStack(alignment: .leading) {
-                        CaptionMText(localizedString("wallet__send_invoice"))
+                        CaptionMText(t("wallet__send_invoice"))
                             .padding(.bottom, 8)
                         BodySSBText(uri)
                             .lineLimit(1)
@@ -60,7 +60,7 @@ struct LnurlPayConfirm: View {
                     Divider()
 
                     VStack(alignment: .leading) {
-                        CaptionMText(localizedString("wallet__send_fee_and_speed"))
+                        CaptionMText(t("wallet__send_fee_and_speed"))
                             .padding(.bottom, 8)
                         HStack(spacing: 0) {
                             Image("bolt-hollow")
@@ -79,10 +79,10 @@ struct LnurlPayConfirm: View {
 
                     if let commentAllowed = app.lnurlPayData?.commentAllowed {
                         VStack(alignment: .leading) {
-                            CaptionMText(localizedString("wallet__lnurl_pay_confirm__comment"))
+                            CaptionMText(t("wallet__lnurl_pay_confirm__comment"))
                                 .padding(.bottom, 8)
 
-                            TextField(localizedString("wallet__lnurl_pay_confirm__comment_placeholder"), text: $comment)
+                            TextField(t("wallet__lnurl_pay_confirm__comment_placeholder"), text: $comment)
                                 .lineLimit(3 ... 3)
                                 .onChange(of: comment) { newValue in
                                     let maxLength = Int(commentAllowed)
@@ -100,7 +100,7 @@ struct LnurlPayConfirm: View {
             Spacer()
 
             SwipeButton(
-                title: localizedString("wallet__send_swipe"),
+                title: t("wallet__send_swipe"),
                 accentColor: .greenAccent
             ) {
                 // Check if we need to show warning for amounts over $100 USD
@@ -155,23 +155,23 @@ struct LnurlPayConfirm: View {
         .navigationBarHidden(true)
         .padding(.horizontal, 16)
         .sheetBackground()
-        .alert(localizedString("common__are_you_sure"), isPresented: $showWarningAlert) {
-            Button(localizedString("common__dialog_cancel"), role: .cancel) {
+        .alert(t("common__are_you_sure"), isPresented: $showWarningAlert) {
+            Button(t("common__dialog_cancel"), role: .cancel) {
                 alertContinuation?.resume(returning: false)
                 alertContinuation = nil
             }
-            Button(localizedString("wallet__send_yes")) {
+            Button(t("wallet__send_yes")) {
                 alertContinuation?.resume(returning: true)
                 alertContinuation = nil
             }
         } message: {
-            Text(localizedString("wallet__send_dialog1"))
+            Text(t("wallet__send_dialog1"))
         }
         .alert(
-            localizedString("security__bio_error_title"),
+            t("security__bio_error_title"),
             isPresented: $showingBiometricError
         ) {
-            Button(localizedString("common__ok")) {
+            Button(t("common__ok")) {
                 // Error handled, user acknowledged
             }
         } message: {
@@ -179,8 +179,8 @@ struct LnurlPayConfirm: View {
         }
         .navigationDestination(isPresented: $showPinCheck) {
             PinCheckView(
-                title: localizedString("security__pin_send_title"),
-                explanation: localizedString("security__pin_send"),
+                title: t("security__pin_send_title"),
+                explanation: t("security__pin_send"),
                 onCancel: {
                     pinCheckContinuation?.resume(returning: false)
                     pinCheckContinuation = nil
@@ -218,7 +218,7 @@ struct LnurlPayConfirm: View {
             }
 
             // Request biometric authentication
-            let reason = localizedString(
+            let reason = t(
                 "security__bio_confirm",
                 variables: ["biometricsName": biometryTypeName]
             )
@@ -246,16 +246,16 @@ struct LnurlPayConfirm: View {
 
         switch nsError.code {
         case LAError.biometryNotAvailable.rawValue:
-            biometricErrorMessage = localizedString("security__bio_not_available")
+            biometricErrorMessage = t("security__bio_not_available")
             showingBiometricError = true
         case LAError.biometryNotEnrolled.rawValue:
-            biometricErrorMessage = localizedString("security__bio_not_available")
+            biometricErrorMessage = t("security__bio_not_available")
             showingBiometricError = true
         case LAError.userCancel.rawValue, LAError.userFallback.rawValue:
             // User cancelled - don't show error, just keep current state
             return
         default:
-            biometricErrorMessage = localizedString(
+            biometricErrorMessage = t(
                 "security__bio_error_message",
                 variables: ["type": biometryTypeName]
             )

--- a/Bitkit/Views/Wallets/Send/SendAmountView.swift
+++ b/Bitkit/Views/Wallets/Send/SendAmountView.swift
@@ -16,7 +16,7 @@ struct SendAmountView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("wallet__send_amount"), showBackButton: true)
+            SheetHeader(title: t("wallet__send_amount"), showBackButton: true)
 
             VStack(alignment: .leading, spacing: 16) {
                 // Use AmountInput component instead of TextField
@@ -31,7 +31,7 @@ struct SendAmountView: View {
                 // Available balance section
                 HStack(alignment: .bottom) {
                     AvailableAmount(
-                        label: localizedString("wallet__send_available"),
+                        label: t("wallet__send_available"),
                         amount: Int(availableAmount)
                     )
                     .onTapGesture {
@@ -43,8 +43,8 @@ struct SendAmountView: View {
                     // No specific invoice, show toggle button based on selected wallet type
                     NumberPadActionButton(
                         text: app.selectedWalletToPayFrom == .lightning
-                            ? NSLocalizedString("wallet__spending__title", comment: "").uppercased()
-                            : NSLocalizedString("wallet__savings__title", comment: "").uppercased(),
+                            ? t("wallet__spending__title").uppercased()
+                            : t("wallet__savings__title").uppercased(),
                         color: app.selectedWalletToPayFrom == .lightning ? .purpleAccent : .brandAccent,
                         variant: .secondary
                     ) {
@@ -73,7 +73,7 @@ struct SendAmountView: View {
 
             Spacer()
 
-            CustomButton(title: localizedString("common__continue"), isDisabled: satsAmount == 0) {
+            CustomButton(title: t("common__continue"), isDisabled: satsAmount == 0) {
                 do {
                     if satsAmount > 0 {
                         wallet.sendAmountSats = satsAmount

--- a/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
+++ b/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
@@ -20,11 +20,11 @@ struct SendConfirmationView: View {
     private var biometryTypeName: String {
         switch Env.biometryType {
         case .touchID:
-            return NSLocalizedString("security__bio_touch_id", comment: "")
+            return t("security__bio_touch_id")
         case .faceID:
-            return NSLocalizedString("security__bio_face_id", comment: "")
+            return t("security__bio_face_id")
         default:
-            return NSLocalizedString("security__bio_face_id", comment: "") // Default to Face ID
+            return t("security__bio_face_id") // Default to Face ID
         }
     }
 
@@ -36,7 +36,7 @@ struct SendConfirmationView: View {
 
     var body: some View {
         VStack {
-            SheetHeader(title: localizedString("wallet__send_review"), showBackButton: true)
+            SheetHeader(title: t("wallet__send_review"), showBackButton: true)
 
             VStack(alignment: .leading) {
                 if app.selectedWalletToPayFrom == .lightning, let invoice = app.scannedLightningInvoice {
@@ -55,7 +55,7 @@ struct SendConfirmationView: View {
             Spacer()
 
             SwipeButton(
-                title: NSLocalizedString("wallet__send_swipe", comment: ""),
+                title: t("wallet__send_swipe"),
                 accentColor: .greenAccent
             ) {
                 // Check if we need to show warning for amounts over $100 USD
@@ -114,23 +114,23 @@ struct SendConfirmationView: View {
         .padding(.horizontal, 16)
         .sheetBackground()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .alert(NSLocalizedString("common__are_you_sure", comment: ""), isPresented: $showWarningAlert) {
-            Button(NSLocalizedString("common__dialog_cancel", comment: ""), role: .cancel) {
+        .alert(t("common__are_you_sure"), isPresented: $showWarningAlert) {
+            Button(t("common__dialog_cancel"), role: .cancel) {
                 alertContinuation?.resume(returning: false)
                 alertContinuation = nil
             }
-            Button(NSLocalizedString("wallet__send_yes", comment: "")) {
+            Button(t("wallet__send_yes")) {
                 alertContinuation?.resume(returning: true)
                 alertContinuation = nil
             }
         } message: {
-            Text(NSLocalizedString("wallet__send_dialog1", comment: ""))
+            Text(t("wallet__send_dialog1"))
         }
         .alert(
-            NSLocalizedString("security__bio_error_title", comment: ""),
+            t("security__bio_error_title"),
             isPresented: $showingBiometricError
         ) {
-            Button(NSLocalizedString("common__ok", comment: "")) {
+            Button(t("common__ok")) {
                 // Error handled, user acknowledged
             }
         } message: {
@@ -138,8 +138,8 @@ struct SendConfirmationView: View {
         }
         .navigationDestination(isPresented: $showPinCheck) {
             PinCheckView(
-                title: NSLocalizedString("security__pin_send_title", comment: ""),
-                explanation: NSLocalizedString("security__pin_send", comment: ""),
+                title: t("security__pin_send_title"),
+                explanation: t("security__pin_send"),
                 onCancel: {
                     pinCheckContinuation?.resume(returning: false)
                     pinCheckContinuation = nil
@@ -177,8 +177,8 @@ struct SendConfirmationView: View {
             }
 
             // Request biometric authentication
-            let reason = localizedString(
-                "security__bio_confirm", comment: "",
+            let reason = t(
+                "security__bio_confirm",
                 variables: ["biometricsName": biometryTypeName]
             )
 
@@ -205,17 +205,17 @@ struct SendConfirmationView: View {
 
         switch nsError.code {
         case LAError.biometryNotAvailable.rawValue:
-            biometricErrorMessage = NSLocalizedString("security__bio_not_available", comment: "")
+            biometricErrorMessage = t("security__bio_not_available")
             showingBiometricError = true
         case LAError.biometryNotEnrolled.rawValue:
-            biometricErrorMessage = NSLocalizedString("security__bio_not_available", comment: "")
+            biometricErrorMessage = t("security__bio_not_available")
             showingBiometricError = true
         case LAError.userCancel.rawValue, LAError.userFallback.rawValue:
             // User cancelled - don't show error, just keep current state
             return
         default:
-            biometricErrorMessage = localizedString(
-                "security__bio_error_message", comment: "",
+            biometricErrorMessage = t(
+                "security__bio_error_message",
                 variables: ["type": biometryTypeName]
             )
             showingBiometricError = true
@@ -279,7 +279,7 @@ struct SendConfirmationView: View {
     @ViewBuilder
     func toView(_ address: String) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            CaptionMText(localizedString("wallet__send_to"))
+            CaptionMText(t("wallet__send_to"))
             BodyMBoldText(address.ellipsis(maxLength: 20), textColor: .textPrimary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -323,7 +323,7 @@ struct SendConfirmationView: View {
 
             HStack {
                 VStack(alignment: .leading) {
-                    Text(NSLocalizedString("wallet__send_fee_and_speed", comment: ""))
+                    Text(t("wallet__send_fee_and_speed"))
                         .foregroundColor(.secondary)
                         .font(.caption)
                     Text("1")

--- a/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
+++ b/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
@@ -10,15 +10,15 @@ struct SendEnterManuallyView: View {
 
     var body: some View {
         VStack {
-            SheetHeader(title: localizedString("wallet__send_bitcoin"), showBackButton: true)
+            SheetHeader(title: t("wallet__send_bitcoin"), showBackButton: true)
 
-            CaptionText(NSLocalizedString("wallet__send_to", comment: "").uppercased())
+            CaptionText(t("wallet__send_to").uppercased())
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal)
 
             ZStack(alignment: .topLeading) {
                 if text.isEmpty {
-                    TitleText(NSLocalizedString("wallet__send_address_placeholder", comment: ""), textColor: .textSecondary)
+                    TitleText(t("wallet__send_address_placeholder"), textColor: .textSecondary)
                         .padding(20)
                 }
 

--- a/Bitkit/Views/Wallets/Send/SendOptionsView.swift
+++ b/Bitkit/Views/Wallets/Send/SendOptionsView.swift
@@ -38,36 +38,36 @@ struct SendOptionsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: localizedString("wallet__send_bitcoin"))
+            SheetHeader(title: t("wallet__send_bitcoin"))
 
             VStack(alignment: .leading, spacing: 0) {
-                CaptionMText(localizedString("wallet__send_to"))
+                CaptionMText(t("wallet__send_to"))
                     .padding(.bottom, 8)
 
                 VStack(spacing: 8) {
                     SendOptionCard(
-                        title: localizedString("wallet__recipient_contact"),
+                        title: t("wallet__recipient_contact"),
                         action: handleContact,
                         iconName: "users",
                         testID: "RecipientContact"
                     )
 
                     SendOptionCard(
-                        title: localizedString("wallet__recipient_invoice"),
+                        title: t("wallet__recipient_invoice"),
                         action: handlePaste,
                         iconName: "clipboard",
                         testID: "RecipientInvoice"
                     )
 
                     SendOptionCard(
-                        title: localizedString("wallet__recipient_manual"),
+                        title: t("wallet__recipient_manual"),
                         action: { navigationPath.append(.manual) },
                         iconName: "pencil",
                         testID: "RecipientManual"
                     )
 
                     SendOptionCard(
-                        title: localizedString("wallet__recipient_scan"),
+                        title: t("wallet__recipient_scan"),
                         action: { navigationPath.append(.scan) },
                         iconName: "scan-brand",
                         testID: "RecipientScan"
@@ -104,8 +104,8 @@ struct SendOptionsView: View {
         guard let uri = UIPasteboard.general.string else {
             app.toast(
                 type: .warning,
-                title: localizedString("wallet__send_clipboard_empty_title"),
-                description: localizedString("wallet__send_clipboard_empty_text")
+                title: t("wallet__send_clipboard_empty_title"),
+                description: t("wallet__send_clipboard_empty_text")
             )
             return
         }

--- a/Bitkit/Views/Wallets/Send/SendQuickpay.swift
+++ b/Bitkit/Views/Wallets/Send/SendQuickpay.swift
@@ -56,7 +56,7 @@ struct SendQuickpay: View {
 
     var body: some View {
         VStack {
-            SheetHeader(title: localizedString("wallet__send_quickpay__nav_title"))
+            SheetHeader(title: t("wallet__send_quickpay__nav_title"))
 
             if let invoice = app.scannedLightningInvoice {
                 MoneyStack(sats: Int(invoice.amountSatoshis))
@@ -68,7 +68,7 @@ struct SendQuickpay: View {
 
             Spacer()
 
-            DisplayText(localizedString("wallet__send_quickpay__title"), accentColor: .purpleAccent)
+            DisplayText(t("wallet__send_quickpay__title"), accentColor: .purpleAccent)
         }
         .padding(.horizontal)
         .onAppear {

--- a/Bitkit/Views/Wallets/Send/SendSuccess.swift
+++ b/Bitkit/Views/Wallets/Send/SendSuccess.swift
@@ -32,7 +32,7 @@ struct SendSuccess: View {
                 }
 
                 VStack(alignment: .leading, spacing: 0) {
-                    SheetHeader(title: localizedString("wallet__send_sent"), showBackButton: false)
+                    SheetHeader(title: t("wallet__send_sent"), showBackButton: false)
 
                     if let sendAmountSats = wallet.sendAmountSats {
                         MoneyStack(sats: Int(sendAmountSats), showSymbol: true)
@@ -50,11 +50,11 @@ struct SendSuccess: View {
                     Spacer()
 
                     HStack(spacing: 16) {
-                        CustomButton(title: localizedString("wallet__send_details"), variant: .secondary) {
+                        CustomButton(title: t("wallet__send_details"), variant: .secondary) {
                             // TODO: navigate to activity details screen
                         }
 
-                        CustomButton(title: localizedString("common__close")) {
+                        CustomButton(title: t("common__close")) {
                             sheets.hideSheet()
                         }
                     }

--- a/Bitkit/Views/Wallets/Send/SendUtxoSelectionView.swift
+++ b/Bitkit/Views/Wallets/Send/SendUtxoSelectionView.swift
@@ -24,7 +24,7 @@ struct SendUtxoSelectionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SheetHeader(title: NSLocalizedString("wallet__selection_title", comment: ""), showBackButton: true)
+            SheetHeader(title: t("wallet__selection_title"), showBackButton: true)
 
             ScrollView {
                 LazyVStack(spacing: 0) {
@@ -50,7 +50,7 @@ struct SendUtxoSelectionView: View {
             // Bottom summary
             VStack(spacing: 8) {
                 HStack {
-                    BodyMText(NSLocalizedString("wallet__selection_total_required", comment: "").uppercased(), textColor: .textSecondary)
+                    BodyMText(t("wallet__selection_total_required").uppercased(), textColor: .textSecondary)
                     Spacer()
                     BodyMSBText("\(formatSats(totalRequiredSats))", textColor: .textPrimary)
                 }
@@ -59,14 +59,14 @@ struct SendUtxoSelectionView: View {
                 Divider()
 
                 HStack {
-                    BodyMText(NSLocalizedString("wallet__selection_total_selected", comment: "").uppercased(), textColor: .textSecondary)
+                    BodyMText(t("wallet__selection_total_selected").uppercased(), textColor: .textSecondary)
                     Spacer()
                     BodyMSBText("\(formatSats(totalSelectedSats))", textColor: totalSelectedSats >= totalRequiredSats ? .greenAccent : .redAccent)
                 }
             }
             .padding(.bottom, 16)
 
-            CustomButton(title: localizedString("common__continue"), isDisabled: selectedUtxos.isEmpty || totalSelectedSats < totalRequiredSats) {
+            CustomButton(title: t("common__continue"), isDisabled: selectedUtxos.isEmpty || totalSelectedSats < totalRequiredSats) {
                 do {
                     wallet.selectedUtxo = wallet.availableUtxos.filter { selectedUtxos.contains($0.outpoint.txid) }
 

--- a/Bitkit/Views/Wallets/Sheets/AddTagSheet.swift
+++ b/Bitkit/Views/Wallets/Sheets/AddTagSheet.swift
@@ -35,12 +35,12 @@ struct AddTagSheet: View {
     var body: some View {
         Sheet(id: .addTag) {
             VStack(alignment: .leading, spacing: 0) {
-                SheetHeader(title: localizedString("wallet__tags_add"))
+                SheetHeader(title: t("wallet__tags_add"))
 
                 let tagsToShow = previewTags ?? activityListViewModel.recentlyUsedTags
 
                 if !tagsToShow.isEmpty {
-                    CaptionMText(localizedString("wallet__tags_previously"))
+                    CaptionMText(t("wallet__tags_previously"))
                         .padding(.bottom, 16)
 
                     WrappingHStack(spacing: 8) {
@@ -55,18 +55,18 @@ struct AddTagSheet: View {
                     }
                 }
 
-                CaptionMText(localizedString("wallet__tags_new"))
+                CaptionMText(t("wallet__tags_new"))
                     .padding(.top, 28)
                     .padding(.bottom, 8)
 
-                TextField(localizedString("wallet__tags_new_enter"), text: $newTag, backgroundColor: .white08)
+                TextField(t("wallet__tags_new_enter"), text: $newTag, backgroundColor: .white08)
                     .disabled(isLoading)
                     .padding(.top, 8)
 
                 Spacer()
 
                 CustomButton(
-                    title: localizedString("wallet__tags_add_button"),
+                    title: t("wallet__tags_add_button"),
                     isDisabled: newTag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                     isLoading: isLoading
                 ) {

--- a/Bitkit/Views/Wallets/Sheets/BoostSheet.swift
+++ b/Bitkit/Views/Wallets/Sheets/BoostSheet.swift
@@ -87,11 +87,11 @@ struct BoostSheet: View {
     var body: some View {
         Sheet(id: .boost, data: config) {
             VStack(alignment: .leading, spacing: 0) {
-                SheetHeader(title: localizedString("wallet__boost_title"))
+                SheetHeader(title: t("wallet__boost_title"))
 
                 VStack(spacing: 16) {
                     BodyMText(
-                        localizedString("wallet__boost_fee_recomended"),
+                        t("wallet__boost_fee_recomended"),
                         textColor: .textSecondary
                     )
                     .multilineTextAlignment(.center)
@@ -164,12 +164,12 @@ struct BoostSheet: View {
 
                             VStack(alignment: .leading, spacing: 2) {
                                 BodyMSBText(
-                                    localizedString("wallet__boost"),
+                                    t("wallet__boost"),
                                     textColor: .white
                                 )
 
                                 FootnoteText(
-                                    "\(localizedString("settings__fee__fast__description"))",
+                                    "\(t("settings__fee__fast__description"))",
                                     textColor: .textSecondary
                                 )
                             }
@@ -216,7 +216,7 @@ struct BoostSheet: View {
                 Spacer()
 
                 SwipeButton(
-                    title: localizedString("wallet__boost_swipe"),
+                    title: t("wallet__boost_swipe"),
                     accentColor: .yellowAccent
                 ) {
                     try await performBoost()
@@ -325,8 +325,8 @@ struct BoostSheet: View {
                     fetchingFees = false
                     app.toast(
                         type: .error,
-                        title: localizedString("common__error"),
-                        description: localizedString("wallet__boost_fee_error")
+                        title: t("common__error"),
+                        description: t("wallet__boost_fee_error")
                     )
                 }
             }
@@ -345,8 +345,8 @@ struct BoostSheet: View {
             Logger.error("Fee rate not set or invalid when attempting boost: \(feeRateToUse)", context: "BoostSheet.performBoost")
             app.toast(
                 type: .error,
-                title: localizedString("common__error"),
-                description: localizedString("wallet__boost_fee_not_set")
+                title: t("common__error"),
+                description: t("wallet__boost_fee_not_set")
             )
             throw AppError(message: "Fee rate not set", debugMessage: "Fee rate not set or invalid when attempting boost: \(feeRateToUse)")
         }
@@ -356,8 +356,8 @@ struct BoostSheet: View {
             Logger.error("Fee rate too low for boost: \(feeRateToUse) < \(minFeeRate) sat/vbyte", context: "BoostSheet.performBoost")
             app.toast(
                 type: .error,
-                title: localizedString("common__error"),
-                description: localizedString("wallet__min_possible_fee_rate_msg")
+                title: t("common__error"),
+                description: t("wallet__min_possible_fee_rate_msg")
             )
             throw AppError(message: "Fee rate too low", debugMessage: "Fee rate \(feeRateToUse) is below minimum \(minFeeRate) sat/vbyte")
         }
@@ -389,8 +389,8 @@ struct BoostSheet: View {
             // Show success message after everything is synced
             app.toast(
                 type: .success,
-                title: localizedString("wallet__boost_success_title"),
-                description: localizedString("wallet__boost_success_msg")
+                title: t("wallet__boost_success_title"),
+                description: t("wallet__boost_success_msg")
             )
 
             Logger.info("Boost transaction completed successfully, hiding sheet", context: "BoostSheet.performBoost")
@@ -408,7 +408,7 @@ struct BoostSheet: View {
 
             app.toast(
                 type: .error,
-                title: localizedString("wallet__boost_error"),
+                title: t("wallet__boost_error"),
                 description: error.localizedDescription
             )
 

--- a/Bitkit/Views/Wallets/Sheets/ReceivedTx.swift
+++ b/Bitkit/Views/Wallets/Sheets/ReceivedTx.swift
@@ -30,7 +30,7 @@ struct ReceivedTx: View {
 
     var body: some View {
         let isOnchain = config.details.type == .onchain
-        let title = isOnchain ? localizedString("wallet__payment_received") : localizedString("wallet__instant_payment_received")
+        let title = isOnchain ? t("wallet__payment_received") : t("wallet__instant_payment_received")
 
         Sheet(id: .receivedTx, data: config) {
             ZStack {

--- a/Bitkit/Views/Wallets/SpendingWalletView.swift
+++ b/Bitkit/Views/Wallets/SpendingWalletView.swift
@@ -28,7 +28,7 @@ struct SpendingWalletView: View {
                 ScrollView(showsIndicators: false) {
                     ActivityList(viewType: .lightning)
 
-                    CustomButton(title: localizedString("wallet__activity_show_all"), variant: .tertiary) {
+                    CustomButton(title: t("wallet__activity_show_all"), variant: .tertiary) {
                         navigation.navigate(.activityList)
                     }
                     /// Leave some space for TabBar
@@ -46,7 +46,7 @@ struct SpendingWalletView: View {
                 .transition(.move(edge: .leading).combined(with: .opacity))
             }
         }
-        .navigationTitle(localizedString("wallet__spending__title"))
+        .navigationTitle(t("wallet__spending__title"))
         .padding(.horizontal)
         .frame(maxHeight: .infinity, alignment: .top)
         .overlay(alignment: .topTrailing) {

--- a/Bitkit/Views/Widgets/WidgetDetailView.swift
+++ b/Bitkit/Views/Widgets/WidgetDetailView.swift
@@ -12,11 +12,11 @@ struct WidgetDetailView: View {
 
     // Widget data computed from the ID
     private var widget: (name: String, description: String, icon: String) {
-        let name = localizedString("widgets__\(id.rawValue)__name")
+        let name = t("widgets__\(id.rawValue)__name")
 
         // Get fiat symbol from currency conversion
         let fiatSymbol = currency.symbol
-        let description = localizedString("widgets__\(id.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
+        let description = t("widgets__\(id.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
         let icon = "\(id.rawValue)-widget"
 
         return (name: name, description: description, icon: icon)
@@ -81,14 +81,14 @@ struct WidgetDetailView: View {
                     navigation.navigate(.widgetEdit(id))
                 }) {
                     HStack(alignment: .center, spacing: 0) {
-                        BodyMText(localizedString("widgets__widget__edit"), textColor: .textPrimary)
+                        BodyMText(t("widgets__widget__edit"), textColor: .textPrimary)
 
                         Spacer()
 
                         BodyMText(
                             hasCustomOptions
-                                ? localizedString("widgets__widget__edit_custom")
-                                : localizedString("widgets__widget__edit_default"),
+                                ? t("widgets__widget__edit_custom")
+                                : t("widgets__widget__edit_default"),
                             textColor: .textPrimary
                         )
 
@@ -119,7 +119,7 @@ struct WidgetDetailView: View {
             Spacer()
 
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(localizedString("common__preview"))
+                CaptionText(t("common__preview"))
                     .textCase(.uppercase)
                     .padding(.top, 16)
                     .padding(.bottom, 16)
@@ -129,7 +129,7 @@ struct WidgetDetailView: View {
                 HStack(spacing: 16) {
                     if isWidgetSaved {
                         CustomButton(
-                            title: localizedString("common__delete"),
+                            title: t("common__delete"),
                             variant: .secondary,
                             size: .large,
                             shouldExpand: true
@@ -140,7 +140,7 @@ struct WidgetDetailView: View {
                     }
 
                     CustomButton(
-                        title: localizedString("common__save"),
+                        title: t("common__save"),
                         variant: .primary,
                         size: .large,
                         shouldExpand: true,
@@ -154,23 +154,23 @@ struct WidgetDetailView: View {
         .padding(.top)
         .padding(.horizontal, 16)
         .frame(maxHeight: .infinity)
-        .navigationTitle(localizedString("widgets__widget__nav_title"))
+        .navigationTitle(t("widgets__widget__nav_title"))
         .navigationBarTitleDisplayMode(.inline)
         .backToWalletButton()
         .alert(
-            localizedString("widgets__delete__title"),
+            t("widgets__delete__title"),
             isPresented: $showDeleteAlert,
             actions: {
-                Button(localizedString("common__cancel"), role: .cancel) {
+                Button(t("common__cancel"), role: .cancel) {
                     showDeleteAlert = false
                 }
 
-                Button(localizedString("common__delete_yes"), role: .destructive) {
+                Button(t("common__delete_yes"), role: .destructive) {
                     onDelete()
                 }
             },
             message: {
-                Text(localizedString("widgets__delete__description", variables: ["name": widget.name]))
+                Text(t("widgets__delete__description", variables: ["name": widget.name]))
             }
         )
     }

--- a/Bitkit/Views/Widgets/WidgetEditModels.swift
+++ b/Bitkit/Views/Widgets/WidgetEditModels.swift
@@ -146,7 +146,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showSource",
                     type: .toggleItem,
-                    title: localizedString("widgets__widget__source"),
+                    title: t("widgets__widget__source"),
                     valueView: AnyView(BodySSBText("mempool.space", textColor: .textSecondary)),
                     isChecked: blocksOptions.showSource
                 )
@@ -247,7 +247,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showSource",
                     type: .toggleItem,
-                    title: localizedString("widgets__widget__source"),
+                    title: t("widgets__widget__source"),
                     valueView: AnyView(BodySSBText("mempool.space", textColor: .textSecondary)),
                     isChecked: blocksOptions.showSource
                 )
@@ -274,7 +274,7 @@ enum WidgetEditItemFactory {
             WidgetEditItem(
                 key: "showSource",
                 type: .toggleItem,
-                title: localizedString("widgets__widget__source"),
+                title: t("widgets__widget__source"),
                 valueView: AnyView(BodySSBText("mempool.space", textColor: .textSecondary)),
                 isChecked: factsOptions.showSource
             )
@@ -315,7 +315,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showSource",
                     type: .toggleItem,
-                    title: localizedString("widgets__widget__source"),
+                    title: t("widgets__widget__source"),
                     valueView: AnyView(BodySSBText(data.publisher, textColor: .textSecondary)),
                     isChecked: newsOptions.showSource
                 )
@@ -346,7 +346,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showSource",
                     type: .toggleItem,
-                    title: localizedString("widgets__widget__source"),
+                    title: t("widgets__widget__source"),
                     valueView: AnyView(BodySSBText("Bitcoin Magazine", textColor: .textSecondary)),
                     isChecked: newsOptions.showSource
                 )
@@ -410,7 +410,7 @@ enum WidgetEditItemFactory {
             WidgetEditItem(
                 key: "showSource",
                 type: .toggleItem,
-                title: localizedString("widgets__widget__source"),
+                title: t("widgets__widget__source"),
                 valueView: AnyView(BodySSBText("Bitfinex.com", textColor: .textSecondary)),
                 isChecked: priceOptions.showSource
             )
@@ -451,7 +451,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showMedian",
                     type: .toggleItem,
-                    title: localizedString("widgets__weather__current_fee"),
+                    title: t("widgets__weather__current_fee"),
                     value: data.currentFee,
                     isChecked: weatherOptions.showMedian
                 )
@@ -461,7 +461,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showNextBlockFee",
                     type: .toggleItem,
-                    title: localizedString("widgets__weather__next_block"),
+                    title: t("widgets__weather__next_block"),
                     value: "\(data.nextBlockFee) ₿/vByte",
                     isChecked: weatherOptions.showNextBlockFee
                 )
@@ -492,7 +492,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showMedian",
                     type: .toggleItem,
-                    title: localizedString("widgets__weather__current_fee"),
+                    title: t("widgets__weather__current_fee"),
                     value: "$0.50",
                     isChecked: weatherOptions.showMedian
                 )
@@ -502,7 +502,7 @@ enum WidgetEditItemFactory {
                 WidgetEditItem(
                     key: "showNextBlockFee",
                     type: .toggleItem,
-                    title: localizedString("widgets__weather__next_block"),
+                    title: t("widgets__weather__next_block"),
                     value: "15 ₿/vByte",
                     isChecked: weatherOptions.showNextBlockFee
                 )

--- a/Bitkit/Views/Widgets/WidgetEditView.swift
+++ b/Bitkit/Views/Widgets/WidgetEditView.swift
@@ -22,9 +22,9 @@ struct WidgetEditView: View {
 
     // Widget data computed from the ID
     private var widget: (name: String, description: String, icon: String) {
-        let name = localizedString("widgets__\(id.rawValue)__name")
+        let name = t("widgets__\(id.rawValue)__name")
         let fiatSymbol = currency.symbol
-        let description = localizedString("widgets__\(id.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
+        let description = t("widgets__\(id.rawValue)__description", variables: ["fiatSymbol": fiatSymbol])
         let icon = "\(id.rawValue)-widget"
         return (name: name, description: description, icon: icon)
     }
@@ -58,7 +58,7 @@ struct WidgetEditView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             BodyMText(
-                localizedString("widgets__widget__edit_description", variables: ["name": widget.name]),
+                t("widgets__widget__edit_description", variables: ["name": widget.name]),
                 textColor: .textSecondary
             )
             .padding(.vertical)
@@ -80,7 +80,7 @@ struct WidgetEditView: View {
 
             HStack(spacing: 16) {
                 CustomButton(
-                    title: localizedString("common__reset"),
+                    title: t("common__reset"),
                     variant: .secondary,
                     size: .large,
                     isDisabled: !(editLogic?.hasEdited ?? false),
@@ -91,7 +91,7 @@ struct WidgetEditView: View {
                 .accessibilityIdentifier("WidgetEditReset")
 
                 CustomButton(
-                    title: localizedString("common__preview"),
+                    title: t("common__preview"),
                     variant: .primary,
                     size: .large,
                     isDisabled: !(editLogic?.hasEnabledOption ?? false),
@@ -102,7 +102,7 @@ struct WidgetEditView: View {
             }
             .padding(.top, 16)
         }
-        .navigationTitle(localizedString("widgets__widget__edit"))
+        .navigationTitle(t("widgets__widget__edit"))
         .navigationBarTitleDisplayMode(.inline)
         .backToWalletButton()
         .padding(.horizontal, 16)

--- a/Bitkit/Views/Widgets/WidgetsIntroView.swift
+++ b/Bitkit/Views/Widgets/WidgetsIntroView.swift
@@ -6,10 +6,10 @@ struct WidgetsIntroView: View {
 
     var body: some View {
         OnboardingView(
-            title: localizedString("widgets__onboarding__title"),
-            description: localizedString("widgets__onboarding__description"),
+            title: t("widgets__onboarding__title"),
+            description: t("widgets__onboarding__description"),
             imageName: "puzzle",
-            buttonText: localizedString("common__continue"),
+            buttonText: t("common__continue"),
             onButtonPress: {
                 app.hasSeenWidgetsIntro = true
                 navigation.navigate(.widgetsList)

--- a/Bitkit/Views/Widgets/WidgetsListView.swift
+++ b/Bitkit/Views/Widgets/WidgetsListView.swift
@@ -15,7 +15,7 @@ struct WidgetsListView: View {
             .padding(.top)
             .padding(.horizontal)
         }
-        .navigationTitle(localizedString("widgets__add"))
+        .navigationTitle(t("widgets__add"))
         .navigationBarTitleDisplayMode(.inline)
         .backToWalletButton()
     }


### PR DESCRIPTION
### Description

Renames `NSLocalizedString()` and `localizedString()` to `t()` (naming taken from `react-i18n`). Since this function is used a lot it makes sense for it to have a concise name. It also doesn't have the required `comment` parameter which we don't need since translations are coming from Transifex.