### PR TITLE
feat: electrum settings

### DIFF
--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -1,3 +1,4 @@
+import LDKNode
 import SwiftUI
 
 struct AppScene: View {
@@ -14,6 +15,7 @@ struct AppScene: View {
     @StateObject private var transfer = TransferViewModel()
     @StateObject private var widgets = WidgetsViewModel()
     @StateObject private var settings = SettingsViewModel()
+    @StateObject private var suggestionsManager = SuggestionsManager()
 
     @State private var hideSplash = false
     @State private var removeSplash = false
@@ -62,6 +64,7 @@ struct AppScene: View {
             .environmentObject(transfer)
             .environmentObject(widgets)
             .environmentObject(settings)
+            .environmentObject(suggestionsManager)
             .onAppear {
                 if !settings.requirePinOnLaunch {
                     isPinVerified = true
@@ -173,7 +176,7 @@ struct AppScene: View {
             app?.handleLdkNodeEvent(lightningEvent)
         }
 
-        wallet.addOnEvent(id: "activity-sync") { [weak activity] _ in
+        wallet.addOnEvent(id: "activity-sync") { [weak activity] (_: Event) in
             // TODO: this might not be the best for performace to sync all payments on every event. Could switch to habdling the specific event.
             Task { try? await activity?.syncLdkNodePayments() }
         }

--- a/Bitkit/Components/Home/Suggestions.swift
+++ b/Bitkit/Components/Home/Suggestions.swift
@@ -110,7 +110,7 @@ struct Suggestions: View {
     @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var sheets: SheetViewModel
     @EnvironmentObject var settings: SettingsViewModel
-    @StateObject private var suggestionsManager = SuggestionsManager.shared
+    @EnvironmentObject var suggestionsManager: SuggestionsManager
 
     @State private var showShareSheet = false
     // Prevent duplicate item taps when the card is dismissed

--- a/Bitkit/Components/RadioGroup.swift
+++ b/Bitkit/Components/RadioGroup.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct RadioGroup<T: Hashable>: View {
+    let options: [RadioOption<T>]
+    @Binding var selectedValue: T
+
+    init(options: [RadioOption<T>], selectedValue: Binding<T>) {
+        self.options = options
+        _selectedValue = selectedValue
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(options.enumerated()), id: \.element.value) { _, option in
+                    RadioButton(
+                        title: option.title,
+                        isSelected: selectedValue == option.value,
+                    ) {
+                        selectedValue = option.value
+                    }
+
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+struct RadioOption<T: Hashable> {
+    let title: String
+    let value: T
+
+    init(title: String, value: T) {
+        self.title = title
+        self.value = value
+    }
+}
+
+private struct RadioButton: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                BodyMText(title, textColor: .textPrimary)
+
+                Spacer()
+
+                if isSelected {
+                    Image("checkmark")
+                        .resizable()
+                        .foregroundColor(.brandAccent)
+                        .frame(width: 32, height: 32)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 51)
+        }
+    }
+}

--- a/Bitkit/Components/TextField.swift
+++ b/Bitkit/Components/TextField.swift
@@ -4,12 +4,20 @@ struct TextField: View {
     let placeholder: String
     let backgroundColor: Color
     let font: Font
+    let axis: Axis
     @Binding var text: String
 
-    init(_ placeholder: String, text: Binding<String>, backgroundColor: Color = .white10, font: Font = .custom(Fonts.semiBold, size: 15)) {
+    init(
+        _ placeholder: String,
+        text: Binding<String>,
+        backgroundColor: Color = .white10,
+        font: Font = .custom(Fonts.semiBold, size: 15),
+        axis: Axis = .horizontal,
+    ) {
         self.placeholder = placeholder
         self.backgroundColor = backgroundColor
         self.font = font
+        self.axis = axis
         _text = text
     }
 
@@ -21,7 +29,7 @@ struct TextField: View {
                     .font(font)
             }
 
-            SwiftUI.TextField("", text: $text, axis: .vertical)
+            SwiftUI.TextField("", text: $text, axis: axis)
                 .accentColor(.brandAccent)
                 .font(font)
         }

--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -106,7 +106,7 @@ enum Env {
             return
                 appStorageUrl
                     .appendingPathComponent("bitcoin")
-                    .appendingPathComponent("wallet\(walletIndex)/electrs")
+                    .appendingPathComponent("wallet\(walletIndex)/ldk")
         case .testnet:
             fatalError("Testnet network not implemented")
         case .signet:

--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -273,6 +273,8 @@ struct MainNavView: View {
                     .backToWalletButton()
             case .profileIntro:
                 ProfileIntroView()
+            case .scanner:
+                ScannerScreen()
 
             // Shop
             case .shopIntro:
@@ -358,8 +360,7 @@ struct MainNavView: View {
             case .node:
                 NodeStateView()
             case .electrumSettings:
-                Text("Coming Soon")
-                    .backToWalletButton()
+                ElectrumSettingsScreen()
             case .addressViewer:
                 AddressViewer()
 

--- a/Bitkit/Managers/SuggestionsManager.swift
+++ b/Bitkit/Managers/SuggestionsManager.swift
@@ -3,13 +3,11 @@ import SwiftUI
 
 @MainActor
 final class SuggestionsManager: ObservableObject {
-    static let shared = SuggestionsManager()
-
     @Published private(set) var dismissedIds: Set<String> = []
 
     private let userDefaultsKey = "dismissedSuggestions"
 
-    private init() {
+    init() {
         loadDismissed()
     }
 

--- a/Bitkit/Models/ElectrumServer.swift
+++ b/Bitkit/Models/ElectrumServer.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum ElectrumProtocol: String, Codable {
+    case tcp
+    case ssl
+}
+
+struct ElectrumServer: Equatable, Codable {
+    let host: String
+    let port: Int
+    let protocolType: ElectrumProtocol
+
+    var url: String {
+        return "\(host):\(port)"
+    }
+
+    var portString: String {
+        return String(port)
+    }
+
+    // Convenience initializer for string port
+    init(host: String, portString: String, protocolType: ElectrumProtocol) {
+        self.host = host
+        port = Int(portString) ?? 50001
+        self.protocolType = protocolType
+    }
+
+    init(host: String, port: Int, protocolType: ElectrumProtocol) {
+        self.host = host
+        self.port = port
+        self.protocolType = protocolType
+    }
+}

--- a/Bitkit/Services/ElectrumConfigService.swift
+++ b/Bitkit/Services/ElectrumConfigService.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftUI
+
+/// Service responsible for managing Electrum server configuration
+class ElectrumConfigService {
+    @AppStorage("electrumServer") private var electrumServerData = Data()
+
+    init() {}
+
+    /// Gets the current Electrum server URL that should be used for connections
+    func getCurrentServer() -> ElectrumServer {
+        let storedServer = getStoredServer()
+        return storedServer ?? getDefaultServer()
+    }
+
+    /// Gets the stored server configuration, if any
+    func getStoredServer() -> ElectrumServer? {
+        guard !electrumServerData.isEmpty else { return nil }
+
+        do {
+            return try JSONDecoder().decode(ElectrumServer.self, from: electrumServerData)
+        } catch {
+            Logger.error(error, context: "Failed to decode Electrum server config")
+            return nil
+        }
+    }
+
+    /// Gets the default server parsed from Env.electrumServerUrl
+    func getDefaultServer() -> ElectrumServer {
+        let defaultServerUrl = Env.electrumServerUrl
+        let components = defaultServerUrl.split(separator: ":")
+
+        guard components.count >= 2 else {
+            fatalError("Invalid default Electrum server URL: \(defaultServerUrl)")
+        }
+
+        let host = String(components[0])
+        let port = String(components[1])
+        let protocolType = getProtocolForPort(port)
+
+        return ElectrumServer(host: host, portString: port, protocolType: protocolType)
+    }
+
+    /// Saves Electrum server configuration
+    func saveServerConfig(_ server: ElectrumServer) {
+        do {
+            electrumServerData = try JSONEncoder().encode(server)
+            Logger.info("Saved Electrum server config: \(server.url) (\(server.protocolType.rawValue))")
+        } catch {
+            Logger.error(error, context: "Failed to encode Electrum server config")
+        }
+    }
+
+    /// Gets the protocol for a given port
+    func getProtocolForPort(_ port: String) -> ElectrumProtocol {
+        if port == "443" {
+            return .ssl
+        }
+
+        if Env.network == .testnet {
+            return port == "51002" ? .ssl : .tcp
+        }
+
+        return port == "50002" ? .ssl : .tcp
+    }
+}

--- a/Bitkit/ViewModels/Extensions/SettingsViewModel+Electrum.swift
+++ b/Bitkit/ViewModels/Extensions/SettingsViewModel+Electrum.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+// MARK: - Electrum Server Management
+
+extension SettingsViewModel {
+    func loadElectrumSettings() {
+        // Check connection status first
+        let isRunning = lightningService.status?.isRunning == true
+        electrumIsConnected = isRunning
+
+        // Update form with current server (stored or default)
+        let currentServer = electrumConfigService.getCurrentServer()
+        updateForm(with: currentServer)
+    }
+
+    func resetElectrumToDefault() async -> (success: Bool, host: String, port: String, errorMessage: String?) {
+        let defaultServer = electrumConfigService.getDefaultServer()
+        updateForm(with: defaultServer)
+
+        return await connectToElectrumServer()
+    }
+
+    func connectToElectrumServer() async -> (success: Bool, host: String, port: String, errorMessage: String?) {
+        electrumIsLoading = true
+
+        let host = electrumHost.trimmingCharacters(in: .whitespaces)
+        let port = electrumPort.trimmingCharacters(in: .whitespaces)
+
+        // Validate input first
+        if let validationError = validateElectrumInput(host: host, port: port) {
+            electrumIsLoading = false
+            return (success: false, host: host, port: port, errorMessage: validationError)
+        }
+
+        // Update current server config immediately after validation
+        electrumCurrentServer = ElectrumServer(
+            host: host,
+            portString: port,
+            protocolType: electrumSelectedProtocol
+        )
+
+        do {
+            // Save the configuration to settings
+            electrumConfigService.saveServerConfig(electrumCurrentServer)
+
+            // Restart the Lightning node with the new Electrum server
+            try await lightningService.restartWithElectrumServer(electrumCurrentServer.url)
+
+            electrumIsConnected = true
+            electrumIsLoading = false
+
+            Logger.info("Successfully connected to Electrum server: \(electrumCurrentServer.url)")
+
+            return (success: true, host: host, port: port, errorMessage: nil)
+        } catch {
+            electrumIsConnected = false
+            electrumIsLoading = false
+
+            Logger.error(error, context: "Failed to connect to Electrum server")
+
+            return (success: false, host: host, port: port, errorMessage: nil)
+        }
+    }
+
+    func onElectrumScan(_ data: String) async -> (success: Bool, host: String, port: String, errorMessage: String?)? {
+        let parseResult = parseElectrumScanData(data)
+
+        guard let serverPeer = parseResult else {
+            // Return nil for invalid scan data
+            return nil
+        }
+
+        updateForm(with: serverPeer)
+
+        // Try to connect
+        return await connectToElectrumServer()
+    }
+
+    private func updateForm(with server: ElectrumServer) {
+        electrumHost = server.host
+        electrumPort = server.portString
+        electrumSelectedProtocol = server.protocolType
+    }
+
+    private func validateElectrumInput(host: String, port: String) -> String? {
+        // Check if both host and port are empty
+        if host.isEmpty && port.isEmpty {
+            return t("settings__es__error_host_port")
+        }
+
+        // Check if host is empty
+        if host.isEmpty {
+            return t("settings__es__error_host")
+        }
+
+        // Check if port is empty
+        if port.isEmpty {
+            return t("settings__es__error_port")
+        }
+
+        // Check if port is a valid number
+        guard let portInt = Int(port) else {
+            return t("settings__es__error_port_invalid")
+        }
+
+        // Check port range
+        guard portInt > 0 && portInt <= 65535 else {
+            return t("settings__es__error_port_invalid")
+        }
+
+        // Check URL format
+        let url = "\(host):\(port)"
+        if !isValidElectrumURL(url) {
+            return t("settings__es__error_invalid_http")
+        }
+
+        return nil // No validation errors
+    }
+
+    private func isValidElectrumURL(_ data: String) -> Bool {
+        // Add 'http://' if the protocol is missing to enable URL parsing
+        let normalizedData = data.hasPrefix("http://") || data.hasPrefix("https://") ? data : "http://\(data)"
+
+        guard let url = URL(string: normalizedData) else {
+            return false
+        }
+
+        let hostname = url.host ?? ""
+
+        // Allow standard domains, custom TLDs like .local, and IPv4 addresses
+        let isValidDomainOrIP =
+            hostname.range(
+                of: #"^([a-z\d]([a-z\d-]*[a-z\d])*\.)+[a-z\d-]+|(\d{1,3}\.){3}\d{1,3}$"#, options: .regularExpression, range: nil, locale: nil
+            ) != nil
+
+        // Always allow .local domains
+        if hostname.hasSuffix(".local") {
+            return true
+        }
+
+        // Allow localhost in development mode
+        if Env.isDebug && data.contains("localhost") {
+            return true
+        }
+
+        return isValidDomainOrIP
+    }
+
+    private func parseElectrumScanData(_ data: String) -> ElectrumServer? {
+        // Handle plain format: host:port or host:port:s (Umbrel format)
+        if !data.hasPrefix("http://") && !data.hasPrefix("https://") {
+            let parts = data.split(separator: ":")
+            guard parts.count >= 2 else { return nil }
+
+            let host = String(parts[0])
+            let port = String(parts[1])
+            let shortProtocol = parts.count > 2 ? String(parts[2]) : nil
+
+            let protocolType: ElectrumProtocol = if let shortProtocol {
+                // Support Umbrel connection URL format
+                shortProtocol == "s" ? .ssl : .tcp
+            } else {
+                // Prefix protocol for common ports if missing
+                electrumConfigService.getProtocolForPort(port)
+            }
+
+            return ElectrumServer(host: host, portString: port, protocolType: protocolType)
+        }
+
+        // Handle URLs with http:// or https:// prefix
+        guard let url = URL(string: data) else { return nil }
+
+        let host = url.host ?? ""
+        let port = (url.port ?? 0) > 0 ? String(url.port ?? 0) : (url.scheme == "https" ? "443" : "80")
+        let protocolType: ElectrumProtocol = url.scheme == "https" ? .ssl : .tcp
+
+        return ElectrumServer(host: host, portString: port, protocolType: protocolType)
+    }
+}

--- a/Bitkit/ViewModels/Extensions/SettingsViewModel+Notifications.swift
+++ b/Bitkit/ViewModels/Extensions/SettingsViewModel+Notifications.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftUI
+import UserNotifications
+
+// MARK: - Notification Management
+
+extension SettingsViewModel {
+    func checkNotificationPermission() {
+        NotificationService.shared.checkNotificationPermission { status in
+            self.notificationAuthorizationStatus = status
+        }
+    }
+}

--- a/Bitkit/ViewModels/Extensions/SettingsViewModel+PIN.swift
+++ b/Bitkit/ViewModels/Extensions/SettingsViewModel+PIN.swift
@@ -1,0 +1,91 @@
+import Foundation
+import SwiftUI
+
+// MARK: - PIN Management
+
+extension SettingsViewModel {
+    func updatePinEnabledState() {
+        let newState = checkPinExists()
+        if pinEnabled != newState {
+            pinEnabled = newState
+            Logger.debug("PIN enabled state updated to \(newState)", context: "SettingsViewModel")
+        }
+    }
+
+    private func checkPinExists() -> Bool {
+        do {
+            return try Keychain.exists(key: .securityPin)
+        } catch {
+            Logger.error("Failed to check if PIN exists in keychain: \(error)", context: "SettingsViewModel")
+            return false
+        }
+    }
+
+    func setPin(_ pin: String) throws {
+        try Keychain.saveString(key: .securityPin, str: pin)
+        updatePinEnabledState()
+    }
+
+    func pinCheck(pin: String) -> Bool {
+        do {
+            guard let storedPin = try Keychain.loadString(key: .securityPin) else {
+                return false
+            }
+
+            let isCorrect = storedPin == pin
+
+            if isCorrect {
+                // Reset failed attempts on successful PIN entry
+                pinFailedAttempts = 0
+            } else {
+                // Increment failed attempts
+                pinFailedAttempts += 1
+            }
+
+            return isCorrect
+        } catch {
+            Logger.error("Failed to check PIN from keychain: \(error)", context: "SettingsViewModel")
+            return false
+        }
+    }
+
+    func getRemainingPinAttempts() -> Int {
+        return max(0, Env.pinAttempts - pinFailedAttempts)
+    }
+
+    func hasExceededPinAttempts() -> Bool {
+        return pinFailedAttempts >= Env.pinAttempts
+    }
+
+    func resetPinAttempts() {
+        pinFailedAttempts = 0
+    }
+
+    func resetPinSettings() {
+        pinEnabled = false
+        pinFailedAttempts = 0
+        requirePinOnLaunch = true
+        requirePinWhenIdle = false
+        requirePinForPayments = false
+        useBiometrics = false
+        Logger.debug("PIN settings reset after app wipe", context: "SettingsViewModel")
+    }
+
+    func removePin(pin: String, resetSettings: Bool = true) throws {
+        guard pinCheck(pin: pin) else {
+            throw NSError(domain: "SettingsViewModel", code: 1, userInfo: [NSLocalizedDescriptionKey: "PIN does not match"])
+        }
+
+        try Keychain.delete(key: .securityPin)
+
+        if resetSettings {
+            // Reset all PIN-related settings when PIN is disabled
+            requirePinOnLaunch = true
+            requirePinWhenIdle = false
+            requirePinForPayments = false
+            useBiometrics = false
+        }
+
+        updatePinEnabledState()
+    }
+}

--- a/Bitkit/ViewModels/NavigationViewModel.swift
+++ b/Bitkit/ViewModels/NavigationViewModel.swift
@@ -29,6 +29,7 @@ enum Route: Hashable {
     case savingsConfirm
     case savingsAdvanced
     case savingsProgress
+    case scanner
 
     // Shop
     case shopIntro

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -40,12 +40,18 @@ class WalletViewModel: ObservableObject {
 
     private let lightningService: LightningService
     private let coreService: CoreService
+    private let electrumConfigService: ElectrumConfigService
 
     @Published var isRestoringWallet = false
 
-    init(lightningService: LightningService = .shared, coreService: CoreService = .shared) {
+    init(
+        lightningService: LightningService = .shared,
+        coreService: CoreService = .shared,
+        electrumConfigService: ElectrumConfigService = ElectrumConfigService()
+    ) {
         self.lightningService = lightningService
         self.coreService = coreService
+        self.electrumConfigService = electrumConfigService
     }
 
     deinit {
@@ -74,7 +80,8 @@ class WalletViewModel: ObservableObject {
 
         syncState()
         do {
-            try await lightningService.setup(walletIndex: walletIndex)
+            let electrumServerUrl = electrumConfigService.getCurrentServer().url
+            try await lightningService.setup(walletIndex: walletIndex, electrumServerUrl: electrumServerUrl)
             try await lightningService.start(onEvent: { event in
                 // On every lightning event just sync UI
                 Task { @MainActor in

--- a/Bitkit/Views/Scanner/ScannerScreen.swift
+++ b/Bitkit/Views/Scanner/ScannerScreen.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct ScannerScreen: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScannerView(isFullScreen: true)
+        }
+        .navigationTitle(t("other__qr_scan"))
+        .navigationBarTitleDisplayMode(.inline)
+        .backToWalletButton()
+        .bottomSafeAreaPadding()
+    }
+}

--- a/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
+++ b/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct AdvancedSettingsView: View {
-    @StateObject private var suggestionsManager = SuggestionsManager.shared
+    @EnvironmentObject var suggestionsManager: SuggestionsManager
     @State private var showingResetAlert = false
 
     var body: some View {

--- a/Bitkit/Views/Settings/Advanced/ElectrumSettingsScreen.swift
+++ b/Bitkit/Views/Settings/Advanced/ElectrumSettingsScreen.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct ElectrumSettingsScreen: View {
+    @EnvironmentObject var app: AppViewModel
+    @EnvironmentObject var navigation: NavigationViewModel
+    @EnvironmentObject var settings: SettingsViewModel
+
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    // Connection Status Section
+                    VStack(alignment: .leading, spacing: 4) {
+                        BodyMText(t("settings__es__connected_to"))
+
+                        if settings.electrumIsLoading {
+                            ProgressView()
+                        } else {
+                            if settings.electrumIsConnected {
+                                BodyMText(settings.electrumCurrentServer.url, textColor: .greenAccent)
+                            } else {
+                                BodyMText(t("settings__es__disconnected"), textColor: .redAccent)
+                            }
+                        }
+                    }
+                    .padding(.top, 16)
+                    .padding(.bottom, 32)
+
+                    // Host Input Section
+                    VStack(alignment: .leading, spacing: 8) {
+                        CaptionMText(t("settings__es__host"))
+                        TextField("127.0.0.1", text: $settings.electrumHost)
+                            .focused($isTextFieldFocused)
+                            .autocapitalization(.none)
+                            .autocorrectionDisabled(true)
+                            .submitLabel(.done)
+                            .onSubmit {
+                                isTextFieldFocused = false
+                            }
+                    }
+                    .padding(.bottom, 16)
+
+                    // Port Input Section
+                    VStack(alignment: .leading, spacing: 8) {
+                        CaptionMText(t("settings__es__port"))
+                        TextField("50001", text: $settings.electrumPort)
+                            .focused($isTextFieldFocused)
+                            .keyboardType(.numberPad)
+                    }
+                    .padding(.bottom, 27)
+
+                    // Protocol Selection Section
+                    VStack(alignment: .leading, spacing: 8) {
+                        CaptionMText(t("settings__es__protocol"))
+                        RadioGroup(
+                            options: [
+                                RadioOption(title: "TCP", value: ElectrumProtocol.tcp),
+                                RadioOption(title: "TLS", value: ElectrumProtocol.ssl),
+                            ],
+                            selectedValue: $settings.electrumSelectedProtocol,
+                        )
+                    }
+
+                    Spacer()
+
+                    HStack(spacing: 16) {
+                        CustomButton(title: t("settings__es__button_reset"), variant: .secondary) {
+                            onReset()
+                        }
+
+                        CustomButton(
+                            title: t("settings__es__button_connect"),
+                            isDisabled: !settings.electrumCanConnect,
+                            isLoading: settings.electrumIsLoading
+                        ) {
+                            onConnect()
+                        }
+                    }
+                    .padding(.bottom, isTextFieldFocused ? 16 : 0)
+                }
+                .frame(minHeight: geometry.size.height)
+                .padding(.horizontal, 16)
+                .bottomSafeAreaPadding()
+            }
+            .navigationTitle(t("settings__adv__electrum_server"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        navigation.navigate(.scanner)
+                    }) {
+                        Image("scan")
+                            .resizable()
+                            .foregroundColor(.textPrimary)
+                            .frame(width: 32, height: 32)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            settings.loadElectrumSettings()
+        }
+    }
+
+    private func onConnect() {
+        Task {
+            let result = await settings.connectToElectrumServer()
+            showToast(result.success, result.host, result.port, result.errorMessage)
+        }
+    }
+
+    private func onReset() {
+        Task {
+            let result = await settings.resetElectrumToDefault()
+            showToast(result.success, result.host, result.port, result.errorMessage)
+        }
+    }
+
+    private func showToast(_ success: Bool, _ host: String, _ port: String, _ errorMessage: String?) {
+        if success {
+            app.toast(
+                type: .success,
+                title: t("settings__es__server_updated_title"),
+                description: t("settings__es__server_updated_message", variables: ["host": host, "port": port])
+            )
+        } else {
+            app.toast(
+                type: .warning,
+                title: t("settings__es__error_peer"),
+                description: errorMessage ?? t("settings__es__server_error_description")
+            )
+        }
+    }
+}

--- a/Bitkit/Views/Transfer/FundAdvancedOptions.swift
+++ b/Bitkit/Views/Transfer/FundAdvancedOptions.swift
@@ -19,7 +19,7 @@ struct FundAdvancedOptions: View {
                         .padding(.bottom, 32)
 
                     VStack(spacing: 8) {
-                        NavigationLink(destination: ScannerView()) {
+                        NavigationLink(value: Route.scanner) {
                             RectangleButton(
                                 icon: Image("scan")
                                     .resizable()

--- a/Bitkit/Views/Transfer/FundManualSetupView.swift
+++ b/Bitkit/Views/Transfer/FundManualSetupView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct FundManualSetupView: View {
     @EnvironmentObject var app: AppViewModel
+    @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var wallet: WalletViewModel
     @Environment(\.dismiss) private var dismiss
 
@@ -103,14 +104,13 @@ struct FundManualSetupView: View {
                 Spacer()
 
                 HStack {
-                    // Scan QR button
                     CustomButton(
                         title: t("lightning__external_manual__scan"),
                         variant: .secondary,
-                        destination: ScannerView()
-                    )
+                    ) {
+                        navigation.navigate(.scanner)
+                    }
 
-                    // Continue button
                     CustomButton(
                         title: t("common__continue"),
                         variant: .primary,

--- a/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
+++ b/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
@@ -82,14 +82,18 @@ struct LnurlPayConfirm: View {
                             CaptionMText(t("wallet__lnurl_pay_confirm__comment"))
                                 .padding(.bottom, 8)
 
-                            TextField(t("wallet__lnurl_pay_confirm__comment_placeholder"), text: $comment)
-                                .lineLimit(3 ... 3)
-                                .onChange(of: comment) { newValue in
-                                    let maxLength = Int(commentAllowed)
-                                    if newValue.count > maxLength {
-                                        comment = String(newValue.prefix(maxLength))
-                                    }
+                            TextField(
+                                t("wallet__lnurl_pay_confirm__comment_placeholder"),
+                                text: $comment,
+                                axis: .vertical
+                            )
+                            .lineLimit(3 ... 3)
+                            .onChange(of: comment) { newValue in
+                                let maxLength = Int(commentAllowed)
+                                if newValue.count > maxLength {
+                                    comment = String(newValue.prefix(maxLength))
                                 }
+                            }
                         }
                         .padding(.vertical)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/BitkitNotification/NotificationService.swift
+++ b/BitkitNotification/NotificationService.swift
@@ -39,7 +39,9 @@ class NotificationService: UNNotificationServiceExtension {
             }
 
             do {
-                try await LightningService.shared.setup(walletIndex: self.walletIndex) // Assume first wallet for now
+                // TODO: For notification extension, use default Electrum server URL for now
+                let electrumServerUrl = Env.electrumServerUrl
+                try await LightningService.shared.setup(walletIndex: self.walletIndex, electrumServerUrl: electrumServerUrl)
                 try await LightningService.shared.start { event in
                     self.lightningEventTime = CFAbsoluteTimeGetCurrent()
                     self.handleLdkEvent(event: event)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bitkit iOS (Native)
 
 > [!CAUTION]
-> ⚠️This **NOT** the repository of the Bitkit app from the app stores!
+> ⚠️This is **NOT** the repository of the Bitkit app from the app stores!
 > ⚠️Work-in-progress
 > The live Bitkit app repository is here: **[github.com/synonymdev/bitkit](https://github.com/synonymdev/bitkit)**
 


### PR DESCRIPTION
### Description

- add electrum settings screen
- add (fullscreen) scanner screen
- revert convert SuggestionsManager to singleton
- Split SettingsViewModel into extensions

### Notes

NotificationService doesn't yet use the stored electrum server since it is a separate target. If needed we need to create an app group and share UserDefaults via app group identifier

### Screenshot / Video

https://github.com/user-attachments/assets/19cfcf23-cc2d-45a2-9a09-c46127eb23e9

