### PR TITLE
feat(send): navigate to details in success screen

### DIFF
--- a/Bitkit/Utilities/PaymentNavigationHelper.swift
+++ b/Bitkit/Utilities/PaymentNavigationHelper.swift
@@ -19,8 +19,8 @@ struct PaymentNavigationHelper {
             return false
         }
 
-        // Onchain invoices don't use quickpay
-        guard app.scannedOnchainInvoice == nil else {
+        // We need a lightning invoice to use quickpay
+        guard app.scannedLightningInvoice != nil else {
             return false
         }
 
@@ -37,11 +37,7 @@ struct PaymentNavigationHelper {
         }
 
         // Check regular lightning invoice
-        if let lightningInvoice = app.scannedLightningInvoice {
-            return lightningInvoice.amountSatoshis <= quickpayAmountSats
-        }
-
-        return false
+        return app.scannedLightningInvoice!.amountSatoshis <= quickpayAmountSats
     }
 
     /// Centralized method to open the appropriate sheet based on the current state

--- a/Bitkit/Utilities/RetryHelper.swift
+++ b/Bitkit/Utilities/RetryHelper.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Tries to execute a throwing async operation N times, with a delay between each attempt.
+/// - Parameters:
+///   - toTry: The async operation to try to execute
+///   - times: The maximum number of attempts (must be greater than 0)
+///   - interval: The interval of time between each attempt in seconds
+/// - Returns: The result of the successful operation
+/// - Throws: The error from the last failed attempt
+func tryNTimes<T>(
+    toTry: () async throws -> T,
+    times: Int = 5,
+    interval: UInt64 = 5
+) async throws -> T {
+    guard times > 0 else {
+        throw NSError(
+            domain: "RetryHelper",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "Bad argument: 'times' must be greater than 0, but \(times) was received."]
+        )
+    }
+
+    var attemptCount = 0
+
+    while true {
+        do {
+            return try await toTry()
+        } catch {
+            attemptCount += 1
+
+            if attemptCount >= times {
+                throw error
+            }
+
+            // Wait before next attempt
+            try await Task.sleep(nanoseconds: interval * 1_000_000_000)
+        }
+    }
+}

--- a/Bitkit/ViewModels/AppViewModel.swift
+++ b/Bitkit/ViewModels/AppViewModel.swift
@@ -5,12 +5,8 @@ import SwiftUI
 
 @MainActor
 class AppViewModel: ObservableObject {
-    // Decoded from bitkit-core
-    @Published var scannedLightningInvoice: LightningInvoice?
-    // Should be removed once we have the string on the above struct: https://github.com/synonymdev/bitkit-core/issues/4
-    @Published var scannedLightningBolt11Invoice: String?
-
     // Send flow
+    @Published var scannedLightningInvoice: LightningInvoice?
     @Published var scannedOnchainInvoice: OnChainInvoice?
     @Published var selectedWalletToPayFrom: WalletType = .onchain
 
@@ -238,7 +234,6 @@ extension AppViewModel {
 
     private func handleScannedLightningInvoice(_ invoice: LightningInvoice, bolt11: String, onchainInvoice: OnChainInvoice? = nil) {
         scannedLightningInvoice = invoice
-        scannedLightningBolt11Invoice = bolt11.trimmingCharacters(in: .whitespacesAndNewlines)
         scannedOnchainInvoice = onchainInvoice // Keep onchain invoice if provided
         selectedWalletToPayFrom = .lightning
 
@@ -356,7 +351,6 @@ extension AppViewModel {
         selectedWalletToPayFrom = .onchain // Reset to default
         lnurlPayData = nil
         lnurlWithdrawData = nil
-        scannedLightningBolt11Invoice = nil
     }
 }
 

--- a/Bitkit/ViewModels/SettingsViewModel.swift
+++ b/Bitkit/ViewModels/SettingsViewModel.swift
@@ -58,7 +58,6 @@ class SettingsViewModel: ObservableObject {
     @AppStorage("hideBalanceOnOpen") var hideBalanceOnOpen: Bool = false
     @AppStorage("readClipboard") var readClipboard: Bool = false
     @AppStorage("warnWhenSendingOver100") var warnWhenSendingOver100: Bool = false
-    @AppStorage("showRecentlyPaidContacts") var showRecentlyPaidContacts: Bool = true // TODO: probably not going to be in anytime soon
     @AppStorage("requirePinOnLaunch") var requirePinOnLaunch: Bool = true
     @AppStorage("requirePinWhenIdle") var requirePinWhenIdle: Bool = false
     @AppStorage("requirePinForPayments") var requirePinForPayments: Bool = false

--- a/Bitkit/Views/Wallets/Send/SendFailure.swift
+++ b/Bitkit/Views/Wallets/Send/SendFailure.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+// TODO: add error message and retry button
+
+struct SendFailure: View {
+    @EnvironmentObject var sheets: SheetViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ZStack {
+                VStack(alignment: .leading, spacing: 0) {
+                    SheetHeader(title: t("wallet__send_error_tx_failed"), showBackButton: false)
+
+                    Spacer()
+
+                    Image("cross")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 256, height: 256)
+                        .padding()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                    Spacer()
+
+                    HStack(spacing: 16) {
+                        CustomButton(title: t("common__close")) {
+                            sheets.hideSheet()
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+            .navigationBarHidden(true)
+            .sheetBackground()
+        }
+    }
+}

--- a/Bitkit/Views/Wallets/Send/SendSheet.swift
+++ b/Bitkit/Views/Wallets/Send/SendSheet.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum SendRoute {
+enum SendRoute: Hashable {
     case options
     case manual
     case scan
@@ -8,7 +8,7 @@ enum SendRoute {
     case utxoSelection
     case confirm
     case quickpay
-    case success
+    case success(String)
     case failure
     case lnurlPayAmount
     case lnurlPayConfirm
@@ -64,11 +64,10 @@ struct SendSheet: View {
             SendConfirmationView(navigationPath: $navigationPath)
         case .quickpay:
             SendQuickpay(navigationPath: $navigationPath)
-        case .success:
-            SendSuccess()
+        case let .success(paymentId):
+            SendSuccess(paymentId: paymentId)
         case .failure:
-            // SendFailure()
-            Text("Failure")
+            SendFailure()
         case .lnurlPayAmount:
             LnurlPayAmount(navigationPath: $navigationPath)
         case .lnurlPayConfirm:

--- a/Bitkit/Views/Wallets/Send/SendSuccess.swift
+++ b/Bitkit/Views/Wallets/Send/SendSuccess.swift
@@ -1,10 +1,17 @@
+import BitkitCore
 import Lottie
 import SwiftUI
 
 struct SendSuccess: View {
+    @EnvironmentObject var activityListViewModel: ActivityListViewModel
     @EnvironmentObject var app: AppViewModel
+    @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var sheets: SheetViewModel
     @EnvironmentObject var wallet: WalletViewModel
+
+    let paymentId: String // The payment hash or txid from the successful payment
+
+    @State private var foundActivity: Activity?
 
     // Load the confetti animation
     private var confettiAnimation: LottieAnimation? {
@@ -50,8 +57,13 @@ struct SendSuccess: View {
                     Spacer()
 
                     HStack(spacing: 16) {
-                        CustomButton(title: t("wallet__send_details"), variant: .secondary) {
-                            // TODO: navigate to activity details screen
+                        CustomButton(
+                            title: t("wallet__send_details"),
+                            variant: .secondary,
+                            isDisabled: foundActivity == nil
+                        ) {
+                            navigation.navigate(.activityDetail(foundActivity!))
+                            sheets.hideSheet()
                         }
 
                         CustomButton(title: t("common__close")) {
@@ -63,6 +75,25 @@ struct SendSuccess: View {
             }
             .navigationBarHidden(true)
             .sheetBackground()
+        }
+        .task {
+            await searchForActivity()
+        }
+    }
+
+    private func searchForActivity() async {
+        do {
+            let activity = try await tryNTimes(
+                toTry: {
+                    try await activityListViewModel.findActivity(byPaymentId: paymentId)
+                },
+                times: 12,
+                interval: 5
+            )
+
+            foundActivity = activity
+        } catch {
+            Logger.warn("Could not find activity for payment ID: \(paymentId) after 12 attempts")
         }
     }
 }


### PR DESCRIPTION
### Description

- enable navigation to activity details view on send success screen
- fix quickpay for unified invoice
- add some missing send flow UI
- clean up `wallet.send()` for LN payments

### Screenshot / Video

https://github.com/user-attachments/assets/c0949185-618b-4fb5-a4a1-25682823f7cb

