### PR TITLE
Missing Activity status home

### DIFF
--- a/Bitkit/Views/Wallets/Activity/ActivityIcon.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityIcon.swift
@@ -7,6 +7,7 @@ struct ActivityIcon: View {
     let confirmed: Bool?
     let txType: PaymentType
     let size: CGFloat
+    let isBoosted: Bool
 
     init(activity: Activity, size: CGFloat = 32) {
         self.size = size
@@ -16,11 +17,13 @@ struct ActivityIcon: View {
             status = ln.status
             confirmed = nil
             txType = ln.txType
+            isBoosted = false
         case let .onchain(onchain):
             isLightning = false
             status = nil
             confirmed = onchain.confirmed
             txType = onchain.txType
+            isBoosted = onchain.isBoosted
         }
     }
 
@@ -48,6 +51,13 @@ struct ActivityIcon: View {
                     size: size
                 )
             }
+        } else if isBoosted && !(confirmed ?? false) {
+            CircularIcon(
+                icon: "timer-alt",
+                iconColor: .yellow,
+                backgroundColor: .yellow16,
+                size: size
+            )
         } else {
             CircularIcon(
                 icon: txType == .sent ? "arrow-up" : "arrow-down",

--- a/Bitkit/Views/Wallets/Activity/ActivityIcon.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityIcon.swift
@@ -8,6 +8,7 @@ struct ActivityIcon: View {
     let txType: PaymentType
     let size: CGFloat
     let isBoosted: Bool
+    let isTransfer: Bool
 
     init(activity: Activity, size: CGFloat = 32) {
         self.size = size
@@ -18,12 +19,14 @@ struct ActivityIcon: View {
             confirmed = nil
             txType = ln.txType
             isBoosted = false
+            isTransfer = false
         case let .onchain(onchain):
             isLightning = false
             status = nil
             confirmed = onchain.confirmed
             txType = onchain.txType
             isBoosted = onchain.isBoosted
+            isTransfer = onchain.isTransfer
         }
     }
 
@@ -59,8 +62,9 @@ struct ActivityIcon: View {
                 size: size
             )
         } else {
+            let paymentIcon = txType == PaymentType.sent ? "arrow-up" : "arrow-down"
             CircularIcon(
-                icon: txType == .sent ? "arrow-up" : "arrow-down",
+                icon: isTransfer ? "arrow-up-down" : paymentIcon,
                 iconColor: .brandAccent,
                 backgroundColor: .brand16,
                 size: size

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -25,7 +25,9 @@ private struct TransactionStatusText: View {
     }
 
     var body: some View {
-        if isLightning {
+        if isTransfer {
+            BodyMSBText(t("wallet__activity_transfer"), textColor: .textPrimary)
+        } else if isLightning {
             lightningStatus
         } else {
             onchainStatus

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -115,7 +115,7 @@ struct ActivityRow: View {
     var body: some View {
         HStack(spacing: 16) {
             icon
-
+            
             VStack(alignment: .leading, spacing: 4) {
                 switch item {
                 case let .lightning(activity):
@@ -136,23 +136,45 @@ struct ActivityRow: View {
                     if activity.isTransfer {
                         switch activity.txType {
                         case .sent:
-                            CaptionBText("wallet__activity_transfer_spending_done")
+                            let captionText = if activity.confirmed {
+                                "wallet__activity_transfer_spending_done"
+                            } else {
+                                t(
+                                    "wallet__activity_transfer_spending_pending",
+                                    variables: [
+                                        "duration": formattedTime,
+                                    ]
+                                )
+                            }
+                            
+                            CaptionBText(captionText)
                         case .received:
-                            CaptionBText("wallet__activity_transfer_savings_done")
+                            let captionText = if activity.confirmed {
+                                "wallet__activity_transfer_savings_done"
+                            } else {
+                                t(
+                                    "wallet__activity_transfer_savings_pending",
+                                    variables: [
+                                        "duration": formattedTime,
+                                    ]
+                                )
+                            }
+                            
+                            CaptionBText(captionText)
                         }
                     } else {
                         CaptionBText(formattedTime)
                     }
                 }
             }
-
+            
             Spacer()
-
+            
             MoneyCell(sats: amount, prefix: amountPrefix)
         }
         .padding(.vertical, 8)
     }
-
+    
     @ViewBuilder
     var icon: some View {
         ActivityIcon(activity: item, size: 32)

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -6,6 +6,7 @@ private struct TransactionStatusText: View {
     let isLightning: Bool
     let status: PaymentState?
     let confirmed: Bool?
+    let isTransfer: Bool
 
     init(txType: PaymentType, activity: Activity) {
         self.txType = txType
@@ -14,10 +15,12 @@ private struct TransactionStatusText: View {
             isLightning = true
             status = ln.status
             confirmed = nil
+            isTransfer = false
         case let .onchain(onchain):
             isLightning = false
             status = nil
             confirmed = onchain.confirmed
+            isTransfer = onchain.isTransfer
         }
     }
 

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -115,7 +115,7 @@ struct ActivityRow: View {
     var body: some View {
         HStack(spacing: 16) {
             icon
-            
+
             VStack(alignment: .leading, spacing: 4) {
                 switch item {
                 case let .lightning(activity):
@@ -146,7 +146,7 @@ struct ActivityRow: View {
                                     ]
                                 )
                             }
-                            
+
                             CaptionBText(captionText)
                         case .received:
                             let captionText = if activity.confirmed {
@@ -159,7 +159,7 @@ struct ActivityRow: View {
                                     ]
                                 )
                             }
-                            
+
                             CaptionBText(captionText)
                         }
                     } else {
@@ -167,14 +167,14 @@ struct ActivityRow: View {
                     }
                 }
             }
-            
+
             Spacer()
-            
+
             MoneyCell(sats: amount, prefix: amountPrefix)
         }
         .padding(.vertical, 8)
     }
-    
+
     @ViewBuilder
     var icon: some View {
         ActivityIcon(activity: item, size: 32)

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -132,8 +132,17 @@ struct ActivityRow: View {
                     } else {
                         CaptionBText(formattedTime)
                     }
-                case .onchain:
-                    CaptionBText(formattedTime)
+                case let .onchain(activity):
+                    if activity.isTransfer {
+                        switch activity.txType {
+                        case .sent:
+                            CaptionBText("wallet__activity_transfer_spending_done")
+                        case .received:
+                            CaptionBText("wallet__activity_transfer_savings_done")
+                        }
+                    } else {
+                        CaptionBText(formattedTime)
+                    }
                 }
             }
 


### PR DESCRIPTION
[FIGMA - TRANFER](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=33495-110147&t=zBqiG26XotuNa2lv-4)

### Description

This PR adds missing status in the home Activities

- Implement boost and transfer icon
- Implement transfer status
- Implement transfer pending and confirmed caption

Tested:

- [x] RBF
- [x] CPFP
- [ ] Transfer

### Linked Issues/Tasks

`n/a`
### Screenshot / Video

https://github.com/user-attachments/assets/1fb5ec9e-8f70-40dc-b886-89cff5de0ef8

https://github.com/user-attachments/assets/c1827c15-7f1a-41a1-a4d9-2e2a0228e3ef
