### PR TITLE
Display outputs in transaction details

### DIFF
--- a/Bitkit/Utilities/AddressChecker.swift
+++ b/Bitkit/Utilities/AddressChecker.swift
@@ -14,6 +14,40 @@ struct AddressInfo: Codable {
     let mempool_stats: AddressStats
 }
 
+struct TxInput: Codable {
+    let txid: String?
+    let vout: Int?
+    let prevout: TxOutput?
+    let scriptsig: String?
+    let scriptsig_asm: String?
+    let witness: [String]?
+    let is_coinbase: Bool?
+    let sequence: Int64?
+}
+
+struct TxOutput: Codable {
+    let scriptpubkey: String
+    let scriptpubkey_asm: String?
+    let scriptpubkey_type: String?
+    let scriptpubkey_address: String?
+    let value: Int64
+    let n: Int?
+}
+
+struct TxStatus: Codable {
+    let confirmed: Bool
+    let block_height: Int?
+    let block_hash: String?
+    let block_time: Int64?
+}
+
+struct TxDetails: Codable {
+    let txid: String
+    let vin: [TxInput]
+    let vout: [TxOutput]
+    let status: TxStatus
+}
+
 enum AddressCheckerError: Error {
     case invalidUrl
     case networkError(Error)
@@ -41,6 +75,29 @@ class AddressChecker {
 
             let decoder = JSONDecoder()
             return try decoder.decode(AddressInfo.self, from: data)
+        } catch let error as DecodingError {
+            throw AddressCheckerError.invalidResponse
+        } catch {
+            throw AddressCheckerError.networkError(error)
+        }
+    }
+
+    static func getTransaction(txid: String) async throws -> TxDetails {
+        guard let url = URL(string: "\(Env.esploraServerUrl)/tx/\(txid)") else {
+            throw AddressCheckerError.invalidUrl
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200
+            else {
+                throw AddressCheckerError.invalidResponse
+            }
+
+            let decoder = JSONDecoder()
+            return try decoder.decode(TxDetails.self, from: data)
         } catch let error as DecodingError {
             throw AddressCheckerError.invalidResponse
         } catch {

--- a/Bitkit/Utilities/AddressChecker.swift
+++ b/Bitkit/Utilities/AddressChecker.swift
@@ -82,6 +82,8 @@ class AddressChecker {
         }
     }
 
+    /// Fetches full transaction details from the Esplora endpoint for the given txid.
+    /// - Parameter txid: Hex transaction identifier.
     static func getTransaction(txid: String) async throws -> TxDetails {
         guard let url = URL(string: "\(Env.esploraServerUrl)/tx/\(txid)") else {
             throw AddressCheckerError.invalidUrl
@@ -99,6 +101,7 @@ class AddressChecker {
             let decoder = JSONDecoder()
             return try decoder.decode(TxDetails.self, from: data)
         } catch let error as DecodingError {
+            Logger.error("decoding error \(error)")
             throw AddressCheckerError.invalidResponse
         } catch {
             throw AddressCheckerError.networkError(error)

--- a/Bitkit/Utilities/LocalizeHelpers.swift
+++ b/Bitkit/Utilities/LocalizeHelpers.swift
@@ -58,18 +58,6 @@ enum LocalizationHelper {
 
     /// Formats a string using ICU MessageFormat with pluralization support
     static func formatPlural(_ pattern: String, arguments: [String: Any], locale: Locale = Locale.current) -> String {
-        // Convert arguments dictionary to format expected by MessageFormatter
-        var formattedArgs: [String: Any] = [:]
-        var argumentArray: [Any] = []
-        var argumentNames: [String] = []
-
-        // Extract argument names and values, maintaining order
-        for (key, value) in arguments {
-            formattedArgs[key] = value
-            argumentNames.append(key)
-            argumentArray.append(value)
-        }
-
         return formatterPlural(pattern, arguments: arguments)
     }
 

--- a/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
@@ -37,8 +37,6 @@ struct ActivityExplorerView: View {
     private func loadTransactionDetails() async {
         guard let onchain else { return }
 
-        isLoadingTransaction = true
-
         do {
             let details = try await AddressChecker.getTransaction(txid: onchain.txId)
             await MainActor.run {
@@ -118,12 +116,23 @@ struct ActivityExplorerView: View {
                     content: onchain.txId,
                 )
 
-                InfoSection(
-                    title: "INPUT",
-                    content: "\(onchain.txId):0",
-                )
-
                 if let txDetails {
+                    CaptionText("Inputs (\(txDetails.vin.count))")
+                        .textCase(.uppercase)
+                        .padding(.bottom, 8)
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(Array(txDetails.vin.enumerated()), id: \.offset) { _, input in
+                            let txId = input.txid ?? ""
+                            let vout = input.vout ?? 0
+                            BodySSBText("\(txId):\(vout)")
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+
+                    Divider()
+                        .padding(.vertical, 16)
+
                     CaptionText("OUTPUTS (\(txDetails.vout.count))")
                         .textCase(.uppercase)
                         .padding(.bottom, 8)

--- a/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
@@ -43,7 +43,7 @@ struct ActivityExplorerView: View {
                 txDetails = details
             }
         } catch {
-            await MainActor.run {}
+            Logger.warn("Failed to load transaction details: \(error)")
         }
     }
 

--- a/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
@@ -117,7 +117,7 @@ struct ActivityExplorerView: View {
                 )
 
                 if let txDetails {
-                    CaptionText("Inputs (\(txDetails.vin.count))")
+                    CaptionText(tPlural("wallet__activity_input", arguments: ["count": txDetails.vin.count]))
                         .textCase(.uppercase)
                         .padding(.bottom, 8)
                     VStack(alignment: .leading, spacing: 4) {
@@ -133,7 +133,7 @@ struct ActivityExplorerView: View {
                     Divider()
                         .padding(.vertical, 16)
 
-                    CaptionText("OUTPUTS (\(txDetails.vout.count))")
+                    CaptionText(tPlural("wallet__activity_output", arguments: ["count": txDetails.vout.count]))
                         .textCase(.uppercase)
                         .padding(.bottom, 8)
                     VStack(alignment: .leading, spacing: 4) {

--- a/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
@@ -137,8 +137,8 @@ struct ActivityExplorerView: View {
                         .textCase(.uppercase)
                         .padding(.bottom, 8)
                     VStack(alignment: .leading, spacing: 4) {
-                        ForEach(Array(txDetails.vout.enumerated()), id: \.offset) { _, output in
-                            BodySSBText(output.scriptpubkey_address ?? "")
+                        ForEach(txDetails.vout.indices, id: \.self) { i in
+                            BodySSBText(txDetails.vout[i].scriptpubkey_address ?? "")
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                         }


### PR DESCRIPTION
### Description

This PR implements a temporary solution to display tx inputs and outputst in the transaction detail screen

### Linked Issues/Tasks

[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=36310-191375&t=zb0ppOIWQ0hvBRFw-4)

### Screenshot / Video

https://github.com/user-attachments/assets/5561c251-070f-427d-850f-2a0a19abda1f

