### PR TITLE
feat(activity): add tab filter

### DIFF
--- a/Bitkit/Components/Activity/ActivityList.swift
+++ b/Bitkit/Components/Activity/ActivityList.swift
@@ -18,18 +18,17 @@ struct ActivityList: View {
         let groupedItems = activity.groupActivities(activities)
 
         if !groupedItems.isEmpty {
-            LazyVStack(alignment: .leading, spacing: 0) {
+            LazyVStack(alignment: .leading, spacing: 16) {
                 ForEach(groupedItems, id: \.self) { groupItem in
                     switch groupItem {
                     case let .header(title):
                         CaptionMText(title)
-                            .padding(.top)
+                            .padding(.top, 16)
 
                     case let .activity(item):
                         NavigationLink(value: Route.activityDetail(item)) {
-                            ActivityRow(item: item)
+                            ActivityRow(item: item, feeEstimates: activity.feeEstimates)
                         }
-                        .padding(.top)
                         .disabled(isHorizontalSwipe)
                     }
                 }

--- a/Bitkit/Components/MoneyCell.swift
+++ b/Bitkit/Components/MoneyCell.swift
@@ -13,7 +13,7 @@ struct MoneyCell: View {
                 size: .bodyMSB,
                 prefix: prefix,
                 color: .textPrimary,
-                symbolColor: .textPrimary
+                symbolColor: .textSecondary
             )
 
             MoneyText(

--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -33,7 +33,6 @@ enum Env {
     // MARK: wallet services
 
     static let network: LDKNode.Network = .regtest
-    static let defaultWalletWordCount = 12
     static let walletSyncIntervalSecs: UInt64 = 10 // TODO: play around with this
 
     /// Converts the LDKNode.Network to BitkitCore.Network for use with bitkitcore functions
@@ -204,7 +203,7 @@ enum Env {
     static var vssServerUrl: String {
         switch network {
         case .regtest:
-            return "https://bitkit.stag0.blocktank.to/vss"
+            return "https://bitkit.stag0.blocktank.to/vss_rs"
         case .bitcoin:
             fatalError("Bitcoin network not implemented")
         case .testnet:

--- a/Bitkit/Models/TransactionSpeed.swift
+++ b/Bitkit/Models/TransactionSpeed.swift
@@ -134,6 +134,39 @@ public extension TransactionSpeed {
         guard case let .custom(rate) = self else { return true }
         return rate >= minRate && rate <= maxRate
     }
+
+    /// Determines the appropriate fee description for a given fee rate
+    /// - Parameters:
+    ///   - feeRate: The fee rate in satoshis per virtual byte
+    ///   - feeEstimates: Current network fee estimates
+    /// - Returns: Localized fee description string
+    static func getFeeDescription(feeRate: UInt64, feeEstimates: FeeRates) -> String {
+        // Check against fee estimates in order of priority (highest to lowest)
+        if feeRate >= UInt64(feeEstimates.fast) {
+            return t("fee__fast__shortDescription")
+        } else if feeRate >= UInt64(feeEstimates.mid) {
+            return t("fee__normal__shortDescription")
+        } else if feeRate >= UInt64(feeEstimates.slow) {
+            return t("fee__slow__shortDescription")
+        } else {
+            // For rates below slow, use minimum
+            return t("fee__minimum__shortDescription")
+        }
+    }
+
+    /// Determines the appropriate fee description for a given fee rate with fallback
+    /// - Parameters:
+    ///   - feeRate: The fee rate in satoshis per virtual byte
+    ///   - feeEstimates: Current network fee estimates (optional)
+    /// - Returns: Localized fee description string with fallback
+    static func getFeeDescription(feeRate: UInt64, feeEstimates: FeeRates?) -> String {
+        guard let estimates = feeEstimates else {
+            // Fallback when no fee estimates are available
+            return t("fee__normal__shortDescription")
+        }
+
+        return getFeeDescription(feeRate: feeRate, feeEstimates: estimates)
+    }
 }
 
 // MARK: - Equatable Implementation

--- a/Bitkit/Utilities/DateFormatterHelpers.swift
+++ b/Bitkit/Utilities/DateFormatterHelpers.swift
@@ -101,6 +101,57 @@ enum DateFormatterHelpers {
         return dateFormatter.string(from: date)
     }
 
+    /// Formats a date for activity item display with relative formatting
+    /// Matches the behavior of the React Native app's getActivityItemDate function
+    /// - Parameter timestamp: Unix timestamp
+    /// - Returns: Localized date string with relative formatting
+    static func getActivityItemDate(_ timestamp: UInt64) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let calendar = Calendar.current
+        let now = Date()
+
+        let beginningOfYear = calendar.dateInterval(of: .year, for: now)?.start ?? now
+
+        if calendar.isDateInToday(date) {
+            // Today, format as time only (e.g., "22:40")
+            let formatter = DateFormatter()
+            formatter.locale = Locale.current
+            formatter.dateFormat = "HH:mm"
+            return formatter.string(from: date)
+        }
+
+        if calendar.isDateInYesterday(date) {
+            // Yesterday, format as "Yesterday, 13:37"
+            let formatter = DateFormatter()
+            formatter.locale = Locale.current
+            formatter.doesRelativeDateFormatting = true
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            let dateString = formatter.string(from: date) // This will be localized "Yesterday"
+
+            let timeFormatter = DateFormatter()
+            timeFormatter.locale = Locale.current
+            timeFormatter.dateFormat = "HH:mm"
+            let timeString = timeFormatter.string(from: date)
+
+            return "\(dateString), \(timeString)"
+        }
+
+        if timestamp >= UInt64(beginningOfYear.timeIntervalSince1970) {
+            // Current year, format as "April 4, 08:29"
+            let formatter = DateFormatter()
+            formatter.locale = Locale.current
+            formatter.dateFormat = "MMMM d, HH:mm"
+            return formatter.string(from: date)
+        }
+
+        // Before current year, format as "February 2, 2021"
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "MMMM d, yyyy"
+        return formatter.string(from: date)
+    }
+
     /// Gets a localized relative date group header for activity grouping
     /// - Parameter date: The date to get the group header for
     /// - Returns: Localized group header string (e.g., "Today", "Yesterday", "This Month", etc.)
@@ -136,16 +187,13 @@ enum DateFormatterHelpers {
 
         if date >= beginningOfWeek {
             // This week - return localized "This week"
-            return t("wallet__activity_group_week", comment: "Activity group header for current week")
+            return t("wallet__activity_group_week")
         } else if date >= beginningOfMonth {
             // This month - return localized "This month"
-            return t("wallet__activity_group_month", comment: "Activity group header for current month")
+            return t("wallet__activity_group_month")
         } else if date >= beginningOfYear {
-            // This year - use month and year
-            let monthYearFormatter = DateFormatter()
-            monthYearFormatter.locale = Locale.current
-            monthYearFormatter.dateFormat = "MMMM yyyy"
-            return monthYearFormatter.string(from: date)
+            // This year - return localized "This year"
+            return t("wallet__activity_group_year")
         } else {
             // Earlier - use year only
             let yearFormatter = DateFormatter()

--- a/Bitkit/Views/Settings/AppStatusView.swift
+++ b/Bitkit/Views/Settings/AppStatusView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct AppStatusView: View {
-    @EnvironmentObject private var app: AppViewModel
     @EnvironmentObject private var navigation: NavigationViewModel
     @EnvironmentObject private var network: NetworkMonitor
     @EnvironmentObject private var wallet: WalletViewModel

--- a/Bitkit/Views/Settings/DevSettingsView.swift
+++ b/Bitkit/Views/Settings/DevSettingsView.swift
@@ -22,6 +22,20 @@ struct DevSettingsView: View {
                     Button {
                         Task {
                             do {
+                                try await CoreService.shared.activity.generateRandomTestData()
+                                await activity.syncState()
+                                app.toast(type: .success, title: "Success", description: "Generated test activities")
+                            } catch {
+                                app.toast(type: .error, title: "Error", description: "Failed to generate activities: \(error.localizedDescription)")
+                            }
+                        }
+                    } label: {
+                        SettingsListLabel(title: "Generate Test Activities", rightIcon: nil)
+                    }
+
+                    Button {
+                        Task {
+                            do {
                                 try await CoreService.shared.activity.removeAll()
                                 await activity.syncState()
                                 app.toast(type: .success, title: "Success", description: "All activities removed")
@@ -30,27 +44,7 @@ struct DevSettingsView: View {
                             }
                         }
                     } label: {
-                        SettingsListLabel(
-                            title: "Reset All Activities",
-                            rightIcon: nil
-                        )
-                    }
-
-                    Button {
-                        Task {
-                            do {
-                                try await CoreService.shared.activity.generateRandomTestData(count: 100)
-                                await activity.syncState()
-                                app.toast(type: .success, title: "Success", description: "Generated 100 random activities")
-                            } catch {
-                                app.toast(type: .error, title: "Error", description: "Failed to generate activities: \(error.localizedDescription)")
-                            }
-                        }
-                    } label: {
-                        SettingsListLabel(
-                            title: "Generate Test Activities",
-                            rightIcon: nil
-                        )
+                        SettingsListLabel(title: "Reset All Activities", rightIcon: nil)
                     }
 
                     NavigationLink(value: Route.logs) {

--- a/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityExplorerView.swift
@@ -84,8 +84,7 @@ struct ActivityExplorerView: View {
                 app.toast(type: .success, title: t("common__copied"), description: content)
             } label: {
                 VStack(alignment: .leading, spacing: 0) {
-                    CaptionText(title)
-                        .textCase(.uppercase)
+                    CaptionMText(title)
                         .padding(.bottom, 8)
                     BodySSBText(content)
                         .padding(.bottom, 16)
@@ -108,7 +107,7 @@ struct ActivityExplorerView: View {
                 Spacer()
                 ActivityIcon(activity: item, size: 48)
             }
-            .padding(.bottom, 16)
+            .padding(.bottom, 32)
 
             if let onchain {
                 InfoSection(
@@ -117,8 +116,7 @@ struct ActivityExplorerView: View {
                 )
 
                 if let txDetails {
-                    CaptionText(tPlural("wallet__activity_input", arguments: ["count": txDetails.vin.count]))
-                        .textCase(.uppercase)
+                    CaptionMText(tPlural("wallet__activity_input", arguments: ["count": txDetails.vin.count]))
                         .padding(.bottom, 8)
                     VStack(alignment: .leading, spacing: 4) {
                         ForEach(Array(txDetails.vin.enumerated()), id: \.offset) { _, input in
@@ -133,8 +131,7 @@ struct ActivityExplorerView: View {
                     Divider()
                         .padding(.vertical, 16)
 
-                    CaptionText(tPlural("wallet__activity_output", arguments: ["count": txDetails.vout.count]))
-                        .textCase(.uppercase)
+                    CaptionMText(tPlural("wallet__activity_output", arguments: ["count": txDetails.vout.count]))
                         .padding(.bottom, 8)
                     VStack(alignment: .leading, spacing: 4) {
                         ForEach(txDetails.vout.indices, id: \.self) { i in

--- a/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
@@ -4,10 +4,11 @@ import SwiftUI
 
 struct ActivityItemView: View {
     let item: Activity
+    @EnvironmentObject var activityList: ActivityListViewModel
     @EnvironmentObject var app: AppViewModel
+    @EnvironmentObject var currency: CurrencyViewModel
     @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var sheets: SheetViewModel
-    @EnvironmentObject var currency: CurrencyViewModel
     @StateObject private var viewModel: ActivityItemViewModel
 
     init(item: Activity) {
@@ -44,6 +45,11 @@ struct ActivityItemView: View {
 
     private var amountPrefix: String {
         isSent ? "-" : "+"
+    }
+
+    private var feeDescription: String {
+        guard case let .onchain(activity) = item else { return "" }
+        return TransactionSpeed.getFeeDescription(feeRate: activity.feeRate, feeEstimates: activityList.feeEstimates)
     }
 
     private var activity: (timestamp: UInt64, fee: UInt64?, value: UInt64, txType: PaymentType) {
@@ -138,8 +144,7 @@ struct ActivityItemView: View {
     @ViewBuilder
     private var statusSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            CaptionText(t("wallet__activity_status"))
-                .textCase(.uppercase)
+            CaptionMText(t("wallet__activity_status"))
                 .padding(.bottom, 8)
 
             HStack(spacing: 4) {
@@ -173,8 +178,7 @@ struct ActivityItemView: View {
                             .foregroundColor(.yellowAccent)
                             .frame(width: 16, height: 16)
                         BodySSBText(
-                            t("wallet__activity_confirms_in_boosted",
-                              variables: ["feeRateDescription": t("fee__fast__shortDescription")]),
+                            t("wallet__activity_confirms_in_boosted", variables: ["feeRateDescription": feeDescription]),
                             textColor: .yellowAccent
                         )
                     } else {
@@ -195,8 +199,7 @@ struct ActivityItemView: View {
     private var timestampSection: some View {
         HStack(spacing: 16) {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(t("wallet__activity_date"))
-                    .textCase(.uppercase)
+                CaptionMText(t("wallet__activity_date"))
                     .padding(.bottom, 8)
 
                 HStack(spacing: 4) {
@@ -212,8 +215,7 @@ struct ActivityItemView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(t("wallet__activity_time"))
-                    .textCase(.uppercase)
+                CaptionMText(t("wallet__activity_time"))
                     .padding(.bottom, 8)
 
                 HStack(spacing: 4) {
@@ -235,8 +237,7 @@ struct ActivityItemView: View {
         if isSent {
             HStack(spacing: 16) {
                 VStack(alignment: .leading, spacing: 0) {
-                    CaptionText(t("wallet__activity_payment"))
-                        .textCase(.uppercase)
+                    CaptionMText(t("wallet__activity_payment"))
                         .padding(.bottom, 8)
 
                     HStack(spacing: 4) {
@@ -253,8 +254,7 @@ struct ActivityItemView: View {
 
                 if let fee = activity.fee {
                     VStack(alignment: .leading, spacing: 0) {
-                        CaptionText(t("wallet__activity_fee"))
-                            .textCase(.uppercase)
+                        CaptionMText(t("wallet__activity_fee"))
                             .padding(.bottom, 8)
 
                         HStack(spacing: 4) {
@@ -277,8 +277,7 @@ struct ActivityItemView: View {
     private var tagsSection: some View {
         if !viewModel.tags.isEmpty {
             VStack(alignment: .leading, spacing: 0) {
-                CaptionText(t("wallet__tags"))
-                    .textCase(.uppercase)
+                CaptionMText(t("wallet__tags"))
                     .padding(.bottom, 8)
 
                 WrappingHStack(spacing: 8) {
@@ -305,8 +304,7 @@ struct ActivityItemView: View {
         if case let .lightning(activity) = viewModel.activity {
             if !activity.message.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
-                    CaptionText(t("wallet__activity_invoice_note"))
-                        .textCase(.uppercase)
+                    CaptionMText(t("wallet__activity_invoice_note"))
                         .padding(.bottom, 8)
 
                     VStack(alignment: .leading, spacing: 0) {

--- a/Bitkit/Views/Wallets/Activity/ActivityLatest.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityLatest.swift
@@ -15,7 +15,7 @@ struct ActivityLatest: View {
                 LazyVStack(alignment: .leading, spacing: 16) {
                     ForEach(items, id: \.self) { item in
                         NavigationLink(value: Route.activityDetail(item)) {
-                            ActivityRow(item: item)
+                            ActivityRow(item: item, feeEstimates: activity.feeEstimates)
                         }
                     }
                 }

--- a/Bitkit/Views/Wallets/Activity/ActivityRow.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRow.swift
@@ -1,176 +1,18 @@
 import BitkitCore
 import SwiftUI
 
-private struct TransactionStatusText: View {
-    let txType: PaymentType
-    let isLightning: Bool
-    let status: PaymentState?
-    let confirmed: Bool?
-    let isTransfer: Bool
-
-    init(txType: PaymentType, activity: Activity) {
-        self.txType = txType
-        switch activity {
-        case let .lightning(ln):
-            isLightning = true
-            status = ln.status
-            confirmed = nil
-            isTransfer = false
-        case let .onchain(onchain):
-            isLightning = false
-            status = nil
-            confirmed = onchain.confirmed
-            isTransfer = onchain.isTransfer
-        }
-    }
-
-    var body: some View {
-        if isTransfer {
-            BodyMSBText(t("wallet__activity_transfer"), textColor: .textPrimary)
-        } else if isLightning {
-            lightningStatus
-        } else {
-            onchainStatus
-        }
-    }
-
-    @ViewBuilder
-    private var lightningStatus: some View {
-        if txType == .sent {
-            switch status {
-            case .failed:
-                BodyMSBText(t("wallet__activity_failed"), textColor: .textPrimary)
-            case .pending:
-                BodyMSBText(t("wallet__activity_pending"), textColor: .textPrimary)
-            case .succeeded:
-                BodyMSBText(t("wallet__activity_sent"), textColor: .textPrimary)
-            case .none:
-                EmptyView()
-            }
-        } else {
-            switch status {
-            case .failed:
-                BodyMSBText(t("wallet__activity_failed"), textColor: .textPrimary)
-            case .pending:
-                BodyMSBText(t("wallet__activity_pending"), textColor: .textPrimary)
-            case .succeeded:
-                BodyMSBText(t("wallet__activity_received"), textColor: .textPrimary)
-            case .none:
-                EmptyView()
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var onchainStatus: some View {
-        if txType == .sent {
-            BodyMSBText(t("wallet__activity_sent"), textColor: .textPrimary)
-        } else {
-            BodyMSBText(t("wallet__activity_received"), textColor: .textPrimary)
-        }
-    }
-}
-
 struct ActivityRow: View {
     let item: Activity
-    @EnvironmentObject var currency: CurrencyViewModel
-
-    private var formattedTime: String {
-        let timestamp = switch item {
-        case let .lightning(activity):
-            TimeInterval(activity.timestamp)
-        case let .onchain(activity):
-            TimeInterval(activity.timestamp)
-        }
-
-        return DateFormatterHelpers.formatActivityTime(UInt64(timestamp))
-    }
-
-    private var amountPrefix: String {
-        switch item {
-        case let .lightning(activity):
-            return activity.txType == .sent ? "-" : "+"
-        case let .onchain(activity):
-            return activity.txType == .sent ? "-" : "+"
-        }
-    }
-
-    private var amount: Int {
-        switch item {
-        case let .lightning(activity):
-            if activity.txType == .sent {
-                return Int(activity.value + (activity.fee ?? 0))
-            } else {
-                return Int(activity.value)
-            }
-        case let .onchain(activity):
-            if activity.txType == .sent {
-                return Int(activity.value + activity.fee)
-            } else {
-                return Int(activity.value)
-            }
-        }
-    }
+    let feeEstimates: FeeRates?
 
     var body: some View {
-        HStack(spacing: 16) {
-            ActivityIcon(activity: item, size: 40)
-
-            VStack(alignment: .leading, spacing: 4) {
-                switch item {
-                case let .lightning(activity):
-                    TransactionStatusText(txType: activity.txType, activity: item)
-                case let .onchain(activity):
-                    TransactionStatusText(txType: activity.txType, activity: item)
-                }
-
-                // Show message if available, otherwise show time
-                switch item {
-                case let .lightning(activity):
-                    if !activity.message.isEmpty {
-                        CaptionBText(activity.message)
-                    } else {
-                        CaptionBText(formattedTime)
-                    }
-                case let .onchain(activity):
-                    if activity.isTransfer {
-                        switch activity.txType {
-                        case .sent:
-                            let captionText = if activity.confirmed {
-                                "wallet__activity_transfer_spending_done"
-                            } else {
-                                t(
-                                    "wallet__activity_transfer_spending_pending",
-                                    variables: [
-                                        "duration": formattedTime,
-                                    ]
-                                )
-                            }
-
-                            CaptionBText(captionText)
-                        case .received:
-                            let captionText = if activity.confirmed {
-                                "wallet__activity_transfer_savings_done"
-                            } else {
-                                t(
-                                    "wallet__activity_transfer_savings_pending",
-                                    variables: [
-                                        "duration": formattedTime,
-                                    ]
-                                )
-                            }
-
-                            CaptionBText(captionText)
-                        }
-                    } else {
-                        CaptionBText(formattedTime)
-                    }
-                }
+        Group {
+            switch item {
+            case let .lightning(activity):
+                ActivityRowLightning(item: activity)
+            case let .onchain(activity):
+                ActivityRowOnchain(item: activity, feeEstimates: feeEstimates)
             }
-
-            Spacer()
-
-            MoneyCell(sats: amount, prefix: amountPrefix)
         }
         .padding(16)
         .background(Color.gray6)

--- a/Bitkit/Views/Wallets/Activity/ActivityRowLightning.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRowLightning.swift
@@ -1,0 +1,57 @@
+import BitkitCore
+import SwiftUI
+
+private struct ActivityStatus: View {
+    let txType: PaymentType
+    let status: PaymentState
+
+    var body: some View {
+        switch status {
+        case .failed:
+            BodyMSBText(t("wallet__activity_failed"))
+        case .pending:
+            BodyMSBText(t("wallet__activity_pending"))
+        case .succeeded:
+            if txType == .sent {
+                BodyMSBText(t("wallet__activity_sent"))
+            } else {
+                BodyMSBText(t("wallet__activity_received"))
+            }
+        }
+    }
+}
+
+struct ActivityRowLightning: View {
+    let item: LightningActivity
+
+    private var amountPrefix: String {
+        return item.txType == .sent ? "-" : "+"
+    }
+
+    private var amount: Int {
+        if item.txType == .sent {
+            return Int(item.value + (item.fee ?? 0))
+        } else {
+            return Int(item.value)
+        }
+    }
+
+    private var formattedTime: String {
+        return DateFormatterHelpers.getActivityItemDate(item.timestamp)
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ActivityIcon(activity: .lightning(item), size: 40)
+
+            VStack(alignment: .leading, spacing: 2) {
+                ActivityStatus(txType: item.txType, status: item.status)
+                CaptionBText(item.message.isEmpty ? formattedTime : item.message)
+            }
+
+            Spacer()
+
+            MoneyCell(sats: amount, prefix: amountPrefix)
+        }
+    }
+}

--- a/Bitkit/Views/Wallets/Activity/ActivityRowOnchain.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityRowOnchain.swift
@@ -1,0 +1,78 @@
+import BitkitCore
+import SwiftUI
+
+private struct ActivityStatus: View {
+    let txType: PaymentType
+    let confirmed: Bool
+    let isTransfer: Bool
+
+    var body: some View {
+        if isTransfer {
+            BodyMSBText(t("wallet__activity_transfer"))
+        } else {
+            if txType == .sent {
+                BodyMSBText(t("wallet__activity_sent"))
+            } else {
+                BodyMSBText(t("wallet__activity_received"))
+            }
+        }
+    }
+}
+
+struct ActivityRowOnchain: View {
+    let item: OnchainActivity
+    let feeEstimates: FeeRates?
+
+    private var amountPrefix: String {
+        return item.txType == .sent ? "-" : "+"
+    }
+
+    private var amount: Int {
+        if item.txType == .sent {
+            return Int(item.value + item.fee)
+        } else {
+            return Int(item.value)
+        }
+    }
+
+    private var formattedTime: String {
+        return DateFormatterHelpers.getActivityItemDate(item.timestamp)
+    }
+
+    private var description: String {
+        if item.isTransfer {
+            switch item.txType {
+            case .sent:
+                return item.confirmed ?
+                    t("wallet__activity_transfer_spending_done") :
+                    t("wallet__activity_transfer_spending_pending", variables: ["duration": "TODO"])
+            case .received:
+                return item.confirmed ?
+                    t("wallet__activity_transfer_savings_done") :
+                    t("wallet__activity_transfer_savings_pending", variables: ["duration": "TODO"])
+            }
+        } else {
+            if item.confirmed {
+                return formattedTime
+            } else {
+                let feeDescription = TransactionSpeed.getFeeDescription(feeRate: item.feeRate, feeEstimates: feeEstimates)
+                return t("wallet__activity_confirms_in", variables: ["feeRateDescription": feeDescription])
+            }
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ActivityIcon(activity: .onchain(item), size: 40)
+
+            VStack(alignment: .leading, spacing: 2) {
+                ActivityStatus(txType: item.txType, confirmed: item.confirmed, isTransfer: item.isTransfer)
+                CaptionBText(description)
+            }
+
+            Spacer()
+
+            MoneyCell(sats: amount, prefix: amountPrefix)
+        }
+    }
+}

--- a/Bitkit/Views/Wallets/Activity/AllActivityView.swift
+++ b/Bitkit/Views/Wallets/Activity/AllActivityView.swift
@@ -5,26 +5,8 @@ struct AllActivityView: View {
     @EnvironmentObject private var activity: ActivityListViewModel
     @EnvironmentObject private var wallet: WalletViewModel
 
-    @State private var selectedTab = ActivityTab.all
     @State private var isHorizontalSwipe = false
     @State private var dragOffset: CGFloat = 0
-
-    enum ActivityTab: CaseIterable, CustomStringConvertible {
-        case all, sent, received, other
-
-        var description: String {
-            switch self {
-            case .all:
-                return t("wallet__activity_tabs__all")
-            case .sent:
-                return t("wallet__activity_tabs__sent")
-            case .received:
-                return t("wallet__activity_tabs__received")
-            case .other:
-                return t("wallet__activity_tabs__other")
-            }
-        }
-    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -35,7 +17,7 @@ struct AllActivityView: View {
                 ActivityListFilter(viewModel: activity)
                     .padding(.bottom, 16)
 
-                SegmentedControl<ActivityTab>(selectedTab: $selectedTab, tabs: ActivityTab.allCases)
+                SegmentedControl<ActivityTab>(selectedTab: $activity.selectedTab, tabs: ActivityTab.allCases)
                     .padding(.bottom, 8)
             }
 
@@ -62,20 +44,20 @@ struct AllActivityView: View {
                                 if abs(horizontalAmount) > abs(verticalAmount) {
                                     if horizontalAmount < -50 {
                                         // Swipe left - move to next tab
-                                        if let currentIndex = ActivityTab.allCases.firstIndex(of: selectedTab),
+                                        if let currentIndex = ActivityTab.allCases.firstIndex(of: activity.selectedTab),
                                            currentIndex < ActivityTab.allCases.count - 1
                                         {
                                             withAnimation(.easeInOut(duration: 0.2)) {
-                                                selectedTab = ActivityTab.allCases[currentIndex + 1]
+                                                activity.selectedTab = ActivityTab.allCases[currentIndex + 1]
                                             }
                                         }
                                     } else if horizontalAmount > 50 {
                                         // Swipe right - move to previous tab
-                                        if let currentIndex = ActivityTab.allCases.firstIndex(of: selectedTab),
+                                        if let currentIndex = ActivityTab.allCases.firstIndex(of: activity.selectedTab),
                                            currentIndex > 0
                                         {
                                             withAnimation(.easeInOut(duration: 0.2)) {
-                                                selectedTab = ActivityTab.allCases[currentIndex - 1]
+                                                activity.selectedTab = ActivityTab.allCases[currentIndex - 1]
                                             }
                                         }
                                     }

--- a/Bitkit/Views/Wallets/Sheets/AddTagSheet.swift
+++ b/Bitkit/Views/Wallets/Sheets/AddTagSheet.swift
@@ -19,19 +19,16 @@ struct AddTagSheetItem: SheetItem, Equatable {
 }
 
 struct AddTagSheet: View {
+    @EnvironmentObject private var activityListViewModel: ActivityListViewModel
     @EnvironmentObject private var app: AppViewModel
     @EnvironmentObject private var sheets: SheetViewModel
-    @EnvironmentObject private var activityListViewModel: ActivityListViewModel
     @EnvironmentObject private var tagManager: TagManager
 
     let config: AddTagSheetItem
 
-    private var activityId: String {
-        config.activityId
-    }
-
     @State private var newTag: String = ""
     @State private var isLoading: Bool = false
+    @FocusState private var isTextFieldFocused: Bool
 
     var body: some View {
         Sheet(id: .addTag) {
@@ -52,13 +49,14 @@ struct AddTagSheet: View {
                             )
                         }
                     }
+                    .padding(.bottom, 28)
                 }
 
                 CaptionMText(t("wallet__tags_new"))
-                    .padding(.top, 28)
                     .padding(.bottom, 8)
 
                 TextField(t("wallet__tags_new_enter"), text: $newTag, backgroundColor: .white08)
+                    .focused($isTextFieldFocused)
                     .disabled(isLoading)
                     .padding(.top, 8)
 
@@ -73,7 +71,7 @@ struct AddTagSheet: View {
                         await appendTagAndClose(newTag.trimmingCharacters(in: .whitespacesAndNewlines))
                     }
                 }
-                .padding(.top, 16)
+                .buttonBottomPadding(isFocused: isTextFieldFocused)
             }
             .padding(.horizontal)
         }
@@ -84,7 +82,7 @@ struct AddTagSheet: View {
         isLoading = true
         do {
             tagManager.addToLastUsedTags(tag)
-            try await activityListViewModel.appendTags(toActivity: activityId, tags: [tag])
+            try await activityListViewModel.appendTags(toActivity: config.activityId, tags: [tag])
             sheets.hideSheet()
         } catch {
             app.toast(type: .error, title: "Failed to add tag", description: error.localizedDescription)


### PR DESCRIPTION
### Description

- add tab filter for AllActivity screen
- add relative dates for activity items
- add "Confirms in ..." for activity items
- use new staging VSS
- update dummy activity items
- polishing

### Notes

I split up `ActivityRow` into separate onchain and lightning views, some duplication but easier to read.

### Screenshot / Video


https://github.com/user-attachments/assets/18c55088-26a2-4eec-8a94-07d97b8b7c22

