### PR TITLE
feat(settings): add pending connections

### DIFF
--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -219,6 +219,9 @@ struct AppScene: View {
         do {
             try await wallet.start()
             try await activity.syncLdkNodePayments()
+
+            // Start watching pending orders after wallet is ready
+            await blocktank.startWatchingPendingOrders(transferViewModel: transfer)
         } catch {
             Logger.error("Failed to start wallet")
             Haptics.notify(.error)

--- a/Bitkit/Components/LightningChannel.swift
+++ b/Bitkit/Components/LightningChannel.swift
@@ -101,7 +101,7 @@ struct LightningChannel: View {
                         .frame(width: 14, height: 14)
                         .foregroundColor(spendingAvailableColor)
 
-                    CaptionBText(formatNumber(localBalance), textColor: spendingAvailableColor)
+                    BodySSBText(formatNumber(localBalance), textColor: spendingAvailableColor)
                 }
 
                 Spacer()
@@ -112,7 +112,7 @@ struct LightningChannel: View {
                         .frame(width: 14, height: 14)
                         .foregroundColor(receivingAvailableColor)
 
-                    CaptionBText(formatNumber(remoteBalance), textColor: receivingAvailableColor)
+                    BodySSBText(formatNumber(remoteBalance), textColor: receivingAvailableColor)
                 }
             }
 
@@ -146,8 +146,8 @@ struct LightningChannel: View {
                 }
             }
             .frame(height: 16)
-            .opacity(status == .pending ? 0.5 : 1.0)
         }
+        .opacity(status == .pending ? 0.5 : 1.0)
     }
 }
 

--- a/Bitkit/Components/MoneyText.swift
+++ b/Bitkit/Components/MoneyText.swift
@@ -7,6 +7,7 @@ enum MoneySize {
     case bodyMSB
     case bodySSB
     case caption
+    case captionB
 }
 
 enum MoneyUnitType {
@@ -80,6 +81,8 @@ extension MoneyText {
             BodySSBText(text, textColor: color, accentColor: symbolColor ?? .textSecondary)
         case .caption:
             CaptionMText(text, textColor: color, accentColor: symbolColor ?? .textSecondary)
+        case .captionB:
+            CaptionBText(text, textColor: color, accentColor: symbolColor ?? .textSecondary)
         }
     }
 }

--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -286,6 +286,7 @@ struct MainNavView: View {
             // Advanced settings
             case .coinSelection: CoinSelectionSettingsView()
             case .connections: LightningConnectionsView()
+            case let .closeConnection(channel: channel): CloseConnectionConfirmation(channel: channel)
             case .node: NodeStateView()
             case .electrumSettings: ElectrumSettingsScreen()
             case .addressViewer: AddressViewer()

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -40,21 +40,29 @@ class LightningService {
 
         let builder = Builder.fromConfig(config: config)
 
-        let electrumConfig = ElectrumSyncConfig(
-            backgroundSyncConfig: .init(
-                onchainWalletSyncIntervalSecs: Env.walletSyncIntervalSecs,
-                lightningWalletSyncIntervalSecs: Env.walletSyncIntervalSecs,
-                feeRateCacheUpdateIntervalSecs: Env.walletSyncIntervalSecs
-            )
-        )
-
         Logger.info("LDK-node log path: \(ldkStoragePath)")
 
         let logFilePath = generateLogFilePath()
         currentLogFilePath = logFilePath
         builder.setFilesystemLogger(logFilePath: logFilePath, maxLogLevel: Env.ldkLogLevel)
 
-        builder.setChainSourceElectrum(serverUrl: electrumServerUrl, config: electrumConfig)
+        // let electrumConfig = ElectrumSyncConfig(
+        //     backgroundSyncConfig: .init(
+        //         onchainWalletSyncIntervalSecs: Env.walletSyncIntervalSecs,
+        //         lightningWalletSyncIntervalSecs: Env.walletSyncIntervalSecs,
+        //         feeRateCacheUpdateIntervalSecs: Env.walletSyncIntervalSecs
+        //     )
+        // )
+        // builder.setChainSourceElectrum(serverUrl: electrumServerUrl, config: electrumConfig)
+        let esploraConfig = EsploraSyncConfig(
+            backgroundSyncConfig: .init(
+                onchainWalletSyncIntervalSecs: Env.walletSyncIntervalSecs,
+                lightningWalletSyncIntervalSecs: Env.walletSyncIntervalSecs,
+                feeRateCacheUpdateIntervalSecs: Env.walletSyncIntervalSecs
+            )
+        )
+        builder.setChainSourceEsplora(serverUrl: Env.esploraServerUrl, config: esploraConfig)
+
         if let rgsServerUrl = Env.ldkRgsServerUrl {
             builder.setGossipSourceRgs(rgsServerUrl: rgsServerUrl)
         } else {

--- a/Bitkit/ViewModels/BlocktankViewModel.swift
+++ b/Bitkit/ViewModels/BlocktankViewModel.swift
@@ -259,4 +259,24 @@ class BlocktankViewModel: ObservableObject {
             throw error
         }
     }
+
+    /// Checks for pending orders and notifies TransferViewModel to start watching them
+    /// This should be called on app startup to resume watching orders after app restart
+    func startWatchingPendingOrders(transferViewModel: TransferViewModel) async {
+        guard let orders else { return }
+
+        let pendingOrders = orders.filter { order in
+            // Watch orders that are created or paid but not yet completed
+            order.state2 == .created || order.state2 == .paid
+        }
+
+        if !pendingOrders.isEmpty {
+            Logger.info("Found \(pendingOrders.count) pending orders to watch: \(pendingOrders.map(\.id))")
+
+            // Notify TransferViewModel to start watching each pending order
+            for order in pendingOrders {
+                await transferViewModel.startWatchingOrderFromRestart(order)
+            }
+        }
+    }
 }

--- a/Bitkit/ViewModels/NavigationViewModel.swift
+++ b/Bitkit/ViewModels/NavigationViewModel.swift
@@ -1,4 +1,5 @@
 import BitkitCore
+import LDKNode
 import SwiftUI
 
 enum Route: Hashable {
@@ -75,6 +76,7 @@ enum Route: Hashable {
     // Advanced settings
     case coinSelection
     case connections
+    case closeConnection(channel: ChannelDetails)
     case node
     case electrumSettings
     case addressViewer

--- a/Bitkit/ViewModels/TransferViewModel.swift
+++ b/Bitkit/ViewModels/TransferViewModel.swift
@@ -104,7 +104,20 @@ class TransferViewModel: ObservableObject {
         watchOrder(orderId: order.id)
     }
 
-    private func watchOrder(orderId: String, frequencyMs: Double = 2500) {
+    /// Starts watching an order from app restart (when no UI state is set)
+    func startWatchingOrderFromRestart(_ order: IBtOrder) async {
+        Logger.info("Starting to watch order from restart: \(order.id)")
+
+        // Set the order in UI state so the watching logic works
+        uiState.order = order
+        uiState.isAdvanced = false
+        uiState.defaultOrder = nil
+
+        // Start watching the order
+        watchOrder(orderId: order.id)
+    }
+
+    private func watchOrder(orderId: String, frequencyMs: Double = 15000) {
         stopPolling()
 
         let frequencySecs = frequencyMs / 1000.0

--- a/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
+++ b/Bitkit/Views/Settings/Advanced/AdvancedSettingsView.swift
@@ -7,20 +7,14 @@ struct AdvancedSettingsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBar(title: t("settings__advanced_title"))
+                .padding(.bottom, 16)
 
             ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 16) {
                     // PAYMENTS Section
                     VStack(alignment: .leading, spacing: 0) {
-                        HStack {
-                            BodyMText(
-                                t("settings__adv__section_payments"),
-                                textColor: .textSecondary
-                            )
+                        CaptionMText(t("settings__adv__section_payments"))
                             .padding(.bottom, 8)
-
-                            Spacer()
-                        }
 
                         // Maybe never implemented
                         // NavigationLink(destination: Text("Coming soon")) {
@@ -31,96 +25,62 @@ struct AdvancedSettingsView: View {
                         // }
 
                         NavigationLink(value: Route.coinSelection) {
-                            SettingsListLabel(
-                                title: t("settings__adv__coin_selection")
-                            )
+                            SettingsListLabel(title: t("settings__adv__coin_selection"))
                         }
 
                         // NavigationLink(destination: Text("Coming soon")) {
-                        //     SettingsListLabel(
-                        //         title: t("settings__adv__payment_preference")
-                        //     )
+                        //     SettingsListLabel(title: t("settings__adv__payment_preference"))
                         // }
 
                         // NavigationLink(destination: Text("Coming soon")) {
-                        //     SettingsListLabel(
-                        //         title: t("settings__adv__gap_limit")
-                        //     )
+                        //     SettingsListLabel(title: t("settings__adv__gap_limit"))
                         // }
                     }
 
                     // NETWORKS Section
                     VStack(alignment: .leading, spacing: 0) {
-                        HStack {
-                            BodyMText(
-                                t("settings__adv__section_networks"),
-                                textColor: .textSecondary
-                            )
+                        CaptionMText(t("settings__adv__section_networks"))
                             .padding(.top, 24)
                             .padding(.bottom, 8)
 
-                            Spacer()
-                        }
-
                         NavigationLink(value: Route.connections) {
-                            SettingsListLabel(
-                                title: t("settings__adv__lightning_connections")
-                            )
+                            SettingsListLabel(title: t("settings__adv__lightning_connections"))
                         }
 
                         NavigationLink(value: Route.node) {
-                            SettingsListLabel(
-                                title: t("settings__adv__lightning_node")
-                            )
+                            SettingsListLabel(title: t("settings__adv__lightning_node"))
                         }
 
                         NavigationLink(value: Route.electrumSettings) {
-                            SettingsListLabel(
-                                title: t("settings__adv__electrum_server")
-                            )
+                            SettingsListLabel(title: t("settings__adv__electrum_server"))
                         }
 
                         NavigationLink(destination: Text("Coming soon")) {
-                            SettingsListLabel(
-                                title: t("settings__adv__rgs_server")
-                            )
+                            SettingsListLabel(title: t("settings__adv__rgs_server"))
                         }
                     }
 
                     // OTHER Section
                     VStack(alignment: .leading, spacing: 0) {
-                        HStack {
-                            BodyMText(
-                                t("settings__adv__section_other"),
-                                textColor: .textSecondary
-                            )
-                            .padding(.top, 24)
-                            .padding(.bottom, 8)
-                            Spacer()
-                        }
+                        CaptionMText(
+                            t("settings__adv__section_other"),
+                        )
+                        .padding(.top, 24)
+                        .padding(.bottom, 8)
 
                         NavigationLink(value: Route.addressViewer) {
-                            SettingsListLabel(
-                                title: t("settings__adv__address_viewer")
-                            )
+                            SettingsListLabel(title: t("settings__adv__address_viewer"))
                         }
 
-                        // SettingsListLabel(
-                        //     title: t("settings__adv__rescan"),
-                        //     rightIcon: nil
-                        // )
+                        // SettingsListLabel(title: t("settings__adv__rescan"), rightIcon: nil)
 
                         Button(action: {
                             showingResetAlert = true
                         }) {
-                            SettingsListLabel(
-                                title: t("settings__adv__suggestions_reset")
-                            )
+                            SettingsListLabel(title: t("settings__adv__suggestions_reset"))
                         }
 
-                        // Add spacing at the bottom for the last section
                         Spacer()
-                            .frame(height: 32)
                     }
                 }
             }

--- a/Bitkit/Views/Settings/Advanced/CloseConnectionConfirmation.swift
+++ b/Bitkit/Views/Settings/Advanced/CloseConnectionConfirmation.swift
@@ -4,9 +4,9 @@ import SwiftUI
 struct CloseConnectionConfirmation: View {
     let channel: ChannelDetails
 
-    @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject var transfer: TransferViewModel
     @EnvironmentObject var app: AppViewModel
+    @EnvironmentObject var transfer: TransferViewModel
+    @Environment(\.dismiss) private var dismiss
 
     @State private var isClosing = false
 
@@ -28,20 +28,11 @@ struct CloseConnectionConfirmation: View {
             Spacer()
 
             HStack(spacing: 16) {
-                CustomButton(
-                    title: t("common__cancel"),
-                    variant: .secondary,
-                    isDisabled: isClosing,
-                    shouldExpand: true
-                ) {
+                CustomButton(title: t("common__cancel"), variant: .secondary, isDisabled: isClosing) {
                     dismiss()
                 }
 
-                CustomButton(
-                    title: t("lightning__close_button"),
-                    isDisabled: isClosing,
-                    shouldExpand: true
-                ) {
+                CustomButton(title: t("lightning__close_button"), isDisabled: isClosing) {
                     Task {
                         await closeChannel()
                     }

--- a/Bitkit/Views/Settings/Advanced/LightningConnectionsView.swift
+++ b/Bitkit/Views/Settings/Advanced/LightningConnectionsView.swift
@@ -3,6 +3,7 @@ import LDKNode
 import SwiftUI
 
 struct LightningConnectionsView: View {
+    @EnvironmentObject var app: AppViewModel
     @EnvironmentObject var blocktank: BlocktankViewModel
     @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var wallet: WalletViewModel
@@ -16,63 +17,135 @@ struct LightningConnectionsView: View {
                 title: t("lightning__connections"),
                 action: AnyView(
                     NavigationLink(value: Route.fundingOptions) {
-                        Image(systemName: "plus")
-                            .foregroundColor(.white)
+                        Image("plus")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.textPrimary)
                     }
                 )
             )
             .padding(.bottom, 16)
 
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Header section with spending balance and receiving capacity
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            CaptionMText(t("lightning__spending_label"))
-                            HStack(spacing: 4) {
-                                Image("arrow-up")
-                                    .resizable()
-                                    .frame(width: 22, height: 22)
-                                    .foregroundColor(.purpleAccent)
-                                TitleText(formatNumber(spendingBalance), textColor: .purpleAccent)
+            GeometryReader { geometry in
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Header section with spending balance and receiving capacity
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                CaptionMText(t("lightning__spending_label"))
+                                HStack(spacing: 4) {
+                                    Image("arrow-up")
+                                        .resizable()
+                                        .frame(width: 22, height: 22)
+                                        .foregroundColor(.purpleAccent)
+                                    TitleText(formatNumber(spendingBalance), textColor: .purpleAccent)
+                                }
                             }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                        VStack(alignment: .leading, spacing: 4) {
-                            CaptionMText(t("lightning__receiving_label"))
-                            HStack(spacing: 4) {
-                                Image("arrow-down")
-                                    .resizable()
-                                    .frame(width: 22, height: 22)
-                                    .foregroundColor(.white)
-                                TitleText(formatNumber(receivingCapacity), textColor: .white)
+                            VStack(alignment: .leading, spacing: 4) {
+                                CaptionMText(t("lightning__receiving_label"))
+                                HStack(spacing: 4) {
+                                    Image("arrow-down")
+                                        .resizable()
+                                        .frame(width: 22, height: 22)
+                                        .foregroundColor(.white)
+                                    TitleText(formatNumber(receivingCapacity), textColor: .white)
+                                }
                             }
+                            .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .padding(.bottom, 16)
+                        .padding(.bottom, 16)
 
-                    Divider()
+                        Divider()
 
-                    // Pending Connections section
-                    if !pendingChannels.isEmpty {
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack {
+                        // Pending Connections section
+                        if !pendingConnections.isEmpty {
+                            VStack(alignment: .leading, spacing: 16) {
                                 CaptionMText(t("lightning__conn_pending"))
-                                    .padding(.top, 32)
-                                    .padding(.bottom, 16)
-                                Spacer()
-                            }
+                                    .padding(.top, 16)
 
-                            ForEach(Array(pendingChannels.enumerated()), id: \.element.channelId) { index, channel in
-                                NavigationLink(
-                                    destination: LightningConnectionDetailView(
+                                ForEach(Array(pendingConnections.enumerated()), id: \.element.channelId) { index, channel in
+                                    NavigationLink(destination: LightningConnectionDetailView(
                                         channel: channel,
                                         linkedOrder: findLinkedOrder(for: channel),
                                         title: "\(t("lightning__connection")) \(index + 1)"
-                                    )
-                                ) {
+                                    )) {
+                                        VStack(spacing: 0) {
+                                            HStack {
+                                                SubtitleText("\(t("lightning__connection")) \(index + 1)")
+                                                Spacer()
+                                                Image("chevron")
+                                                    .resizable()
+                                                    .foregroundColor(.textSecondary)
+                                                    .frame(width: 24, height: 24)
+                                            }
+                                            .padding(.bottom, 6)
+
+                                            LightningChannel(
+                                                capacity: channel.channelValueSats,
+                                                localBalance: channel.outboundCapacityMsat / 1000,
+                                                remoteBalance: channel.inboundCapacityMsat / 1000,
+                                                status: .pending
+                                            )
+                                            .padding(.bottom, 16)
+
+                                            Divider()
+                                        }
+                                    }
+                                }
+                            }
+                            .padding(.bottom, 16)
+                        }
+
+                        // Open Connections section
+                        if !openChannels.isEmpty {
+                            VStack(alignment: .leading, spacing: 16) {
+                                CaptionMText(t("lightning__conn_open"))
+                                    .padding(.top, 16)
+
+                                ForEach(Array(openChannels.enumerated()), id: \.element.channelId) { index, channel in
+                                    NavigationLink(
+                                        destination: LightningConnectionDetailView(
+                                            channel: channel,
+                                            linkedOrder: findLinkedOrder(for: channel),
+                                            title: "\(t("lightning__connection")) \(index + 1)"
+                                        )
+                                    ) {
+                                        VStack(spacing: 0) {
+                                            HStack {
+                                                SubtitleText("\(t("lightning__connection")) \(index + 1)")
+                                                Spacer()
+                                                Image("chevron")
+                                                    .resizable()
+                                                    .foregroundColor(.textSecondary)
+                                                    .frame(width: 24, height: 24)
+                                            }
+                                            .padding(.bottom, 6)
+
+                                            LightningChannel(
+                                                capacity: channel.channelValueSats,
+                                                localBalance: channel.outboundCapacityMsat / 1000,
+                                                remoteBalance: channel.inboundCapacityMsat / 1000,
+                                                status: .open
+                                            )
+                                            .padding(.bottom, 16)
+
+                                            Divider()
+                                        }
+                                        .opacity((!channel.isChannelReady || !channel.isUsable) ? 0.64 : 1.0)
+                                    }
+                                }
+                            }
+                        }
+
+                        // Closed Connections section
+                        if showClosedConnections && !closedConnections.isEmpty {
+                            VStack(alignment: .leading, spacing: 16) {
+                                CaptionMText(t("lightning__conn_closed"))
+                                    .padding(.top, 16)
+
+                                ForEach(Array(closedConnections.enumerated()), id: \.element.id) { index, order in
                                     VStack(spacing: 0) {
                                         HStack {
                                             SubtitleText("\(t("lightning__connection")) \(index + 1)")
@@ -85,124 +158,53 @@ struct LightningConnectionsView: View {
                                         .padding(.bottom, 12)
 
                                         LightningChannel(
-                                            capacity: channel.channelValueSats,
-                                            localBalance: channel.outboundCapacityMsat / 1000,
-                                            remoteBalance: channel.inboundCapacityMsat / 1000,
-                                            status: .pending
+                                            capacity: order.lspBalanceSat + order.clientBalanceSat,
+                                            localBalance: order.clientBalanceSat,
+                                            remoteBalance: order.lspBalanceSat,
+                                            status: .closed
                                         )
                                         .padding(.bottom, 16)
 
                                         Divider()
                                     }
                                     .opacity(0.64)
-                                }
-                            }
-                        }
-                        .padding(.bottom, 16)
-                    }
-
-                    // Open Connections section
-                    if !openChannels.isEmpty {
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack {
-                                CaptionMText(t("lightning__conn_open"))
-                                    .padding(.top, 16)
-                                    .padding(.bottom, 16)
-                                Spacer()
-                            }
-
-                            ForEach(Array(openChannels.enumerated()), id: \.element.channelId) { index, channel in
-                                NavigationLink(
-                                    destination: LightningConnectionDetailView(
-                                        channel: channel,
-                                        linkedOrder: findLinkedOrder(for: channel),
-                                        title: "\(t("lightning__connection")) \(index + 1)"
-                                    )
-                                ) {
-                                    VStack(spacing: 0) {
-                                        HStack {
-                                            SubtitleText("\(t("lightning__connection")) \(index + 1)")
-                                            Spacer()
-                                            Image("chevron")
-                                                .resizable()
-                                                .foregroundColor(.textSecondary)
-                                                .frame(width: 24, height: 24)
-                                        }
-                                        .padding(.bottom, 12)
-
-                                        LightningChannel(
-                                            capacity: channel.channelValueSats,
-                                            localBalance: channel.outboundCapacityMsat / 1000,
-                                            remoteBalance: channel.inboundCapacityMsat / 1000,
-                                            status: .open
-                                        )
-                                        .padding(.bottom, 16)
-
-                                        Divider()
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        // Handle tap for order details
                                     }
-                                    .opacity((!channel.isChannelReady || !channel.isUsable) ? 0.64 : 1.0)
                                 }
+                            }
+                            .padding(.bottom, 16)
+                        }
+
+                        if !closedConnections.isEmpty {
+                            // Show Closed & Failed button
+                            CustomButton(
+                                title: showClosedConnections
+                                    ? t("lightning__conn_closed_hide")
+                                    : t("lightning__conn_closed_show"),
+                                variant: .tertiary,
+                            ) {
+                                showClosedConnections.toggle()
+                            }
+                            .padding(.top, 16)
+                        }
+
+                        Spacer()
+                        // .frame(height: 32)
+
+                        HStack(spacing: 16) {
+                            CustomButton(title: t("lightning__conn_button_export_logs"), variant: .secondary) {
+                                onExportLogs()
+                            }
+
+                            CustomButton(title: t("lightning__conn_button_add")) {
+                                navigation.navigate(.fundingOptions)
                             }
                         }
                     }
-
-                    // Closed Connections section
-                    if showClosedConnections && !closedConnections.isEmpty {
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack {
-                                CaptionMText(t("lightning__conn_closed"))
-                                    .padding(.top, 16)
-                                    .padding(.bottom, 16)
-                                Spacer()
-                            }
-
-                            ForEach(Array(closedConnections.enumerated()), id: \.element.id) { index, order in
-                                VStack(spacing: 0) {
-                                    HStack {
-                                        SubtitleText("\(t("lightning__connection")) \(index + 1)")
-                                        Spacer()
-                                        Image("chevron")
-                                            .resizable()
-                                            .foregroundColor(.textSecondary)
-                                            .frame(width: 24, height: 24)
-                                    }
-                                    .padding(.bottom, 12)
-
-                                    LightningChannel(
-                                        capacity: order.lspBalanceSat + order.clientBalanceSat,
-                                        localBalance: order.clientBalanceSat,
-                                        remoteBalance: order.lspBalanceSat,
-                                        status: .closed
-                                    )
-                                    .padding(.bottom, 16)
-
-                                    Divider()
-                                }
-                                .opacity(0.64)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    // Handle tap for order details
-                                }
-                            }
-                        }
-                        .padding(.bottom, 16)
-                    }
-
-                    if !closedConnections.isEmpty {
-                        // Show Closed & Failed button
-                        CustomButton(
-                            title: showClosedConnections
-                                ? t("lightning__conn_closed_hide")
-                                : t("lightning__conn_closed_show"),
-                            variant: .tertiary,
-                        ) {
-                            showClosedConnections.toggle()
-                        }
-                        .padding(.top, 16)
-                    }
-
-                    Spacer()
-                        .frame(height: 32)
+                    .frame(minHeight: geometry.size.height)
+                    .bottomSafeAreaPadding()
                 }
             }
         }
@@ -210,26 +212,6 @@ struct LightningConnectionsView: View {
         .padding(.horizontal, 16)
         .refreshable {
             await refreshData()
-        }
-        .safeAreaInset(edge: .bottom) {
-            HStack(spacing: 16) {
-                CustomButton(
-                    title: t("lightning__conn_button_export_logs"),
-                    variant: .secondary,
-                    shouldExpand: true
-                ) {
-                    // Handle export logs
-                }
-
-                CustomButton(
-                    title: t("lightning__conn_button_add"),
-                    variant: .primary,
-                    shouldExpand: true,
-                ) {
-                    navigation.navigate(.fundingOptions)
-                }
-            }
-            .padding(.horizontal, 16)
         }
     }
 
@@ -247,6 +229,73 @@ struct LightningConnectionsView: View {
     private var pendingChannels: [ChannelDetails] {
         guard let channels = wallet.channels else { return [] }
         return channels.filter { !$0.isChannelReady }
+    }
+
+    private var pendingOrders: [IBtOrder] {
+        guard let orders = blocktank.orders else { return [] }
+        return orders.filter { order in
+            // Include orders that are created or paid but not yet opened
+            order.state2 == .created || order.state2 == .paid
+        }
+    }
+
+    private var pendingConnections: [ChannelDetails] {
+        var connections: [ChannelDetails] = []
+
+        // Add actual pending channels
+        connections.append(contentsOf: pendingChannels)
+
+        // Create fake channels from pending orders
+        for order in pendingOrders {
+            let fakeChannel = createFakeChannel(from: order)
+            connections.append(fakeChannel)
+        }
+
+        return connections
+    }
+
+    /// Creates a fake channel from a Blocktank order for UI display purposes
+    private func createFakeChannel(from order: IBtOrder) -> ChannelDetails {
+        return ChannelDetails(
+            channelId: order.id,
+            counterpartyNodeId: order.lspNode.pubkey,
+            fundingTxo: OutPoint(txid: Txid(order.channel?.fundingTx.id ?? ""), vout: UInt32(order.channel?.fundingTx.vout ?? 0)),
+            shortChannelId: order.channel?.shortChannelId.flatMap(UInt64.init),
+            outboundScidAlias: nil,
+            inboundScidAlias: nil,
+            channelValueSats: order.lspBalanceSat + order.clientBalanceSat,
+            unspendablePunishmentReserve: 1000,
+            userChannelId: order.id,
+            feerateSatPer1000Weight: 2500,
+            outboundCapacityMsat: order.clientBalanceSat * 1000,
+            inboundCapacityMsat: order.lspBalanceSat * 1000,
+            confirmationsRequired: nil,
+            confirmations: 0,
+            isOutbound: false,
+            isChannelReady: false,
+            isUsable: false,
+            isAnnounced: false,
+            cltvExpiryDelta: 144,
+            counterpartyUnspendablePunishmentReserve: 1000,
+            counterpartyOutboundHtlcMinimumMsat: 1000,
+            counterpartyOutboundHtlcMaximumMsat: 99_000_000,
+            counterpartyForwardingInfoFeeBaseMsat: 1000,
+            counterpartyForwardingInfoFeeProportionalMillionths: 100,
+            counterpartyForwardingInfoCltvExpiryDelta: 144,
+            nextOutboundHtlcLimitMsat: order.clientBalanceSat * 1000,
+            nextOutboundHtlcMinimumMsat: 1000,
+            forceCloseSpendDelay: nil,
+            inboundHtlcMinimumMsat: 1000,
+            inboundHtlcMaximumMsat: order.lspBalanceSat * 1000,
+            config: .init(
+                forwardingFeeProportionalMillionths: 0,
+                forwardingFeeBaseMsat: 0,
+                cltvExpiryDelta: 0,
+                maxDustHtlcExposure: .feeRateMultiplier(multiplier: 0),
+                forceCloseAvoidanceMaxFeeSatoshis: 0,
+                acceptUnderpayingHtlcs: true
+            )
+        )
     }
 
     private var openChannels: [ChannelDetails] {
@@ -290,6 +339,13 @@ struct LightningConnectionsView: View {
 
     private func findLinkedOrder(for channel: ChannelDetails) -> IBtOrder? {
         guard let orders = blocktank.orders else { return nil }
+
+        // For fake channels created from orders, match by userChannelId (which we set to order.id)
+        for order in orders {
+            if order.id == channel.userChannelId {
+                return order
+            }
+        }
 
         // Try to match by short channel ID first (most reliable)
         if let shortChannelId = channel.shortChannelId {
@@ -335,6 +391,29 @@ struct LightningConnectionsView: View {
         formatter.groupingSize = 3
         formatter.usesGroupingSeparator = true
         return formatter.string(from: NSNumber(value: number)) ?? String(number)
+    }
+
+    private func onExportLogs() {
+        Task {
+            guard let zipURL = LogService.shared.zipLogs() else {
+                app.toast(type: .error, title: "Error", description: "Failed to create log zip file")
+                return
+            }
+
+            // Present share sheet
+            await MainActor.run {
+                let activityViewController = UIActivityViewController(
+                    activityItems: [zipURL],
+                    applicationActivities: nil
+                )
+
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let window = windowScene.windows.first
+                {
+                    window.rootViewController?.present(activityViewController, animated: true)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Description

- show pending LSP orders in Connections screen
- watch orders after restart
- use Esplora instead of Electrum (for now)
- polishing

### Screenshot / Video


https://github.com/user-attachments/assets/6cf191ed-2477-4edc-bc68-35c4d82062aa

