### PR TITLE
fix: min and max amount validation

### DIFF
--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -9,6 +9,7 @@ enum Env {
     static let isPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
     static let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
     static let isUnitTest = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    static let dustLimit = 547
 
     /// The current execution context of the app
     static var currentExecutionContext: ExecutionContext {

--- a/Bitkit/Views/Wallets/Send/SendAmountView.swift
+++ b/Bitkit/Views/Wallets/Send/SendAmountView.swift
@@ -31,6 +31,12 @@ struct SendAmountView: View {
         }
     }
 
+    private var isValidAmount: Bool {
+        let minAmount = app.selectedWalletToPayFrom == .lightning ? 1 : Env.dustLimit
+
+        return amountSats >= minAmount && amountSats <= availableAmount
+    }
+
     /// Determines if the current amount is a max amount send
     var isMaxAmountSend: Bool {
         guard app.selectedWalletToPayFrom == .onchain else { return false }
@@ -97,7 +103,7 @@ struct SendAmountView: View {
                     amountViewModel.handleNumberPadInput(key, currency: currency)
                 }
 
-                CustomButton(title: t("common__continue"), isDisabled: amountSats == 0) {
+                CustomButton(title: t("common__continue"), isDisabled: !isValidAmount) {
                     Task {
                         await onContinue()
                     }


### PR DESCRIPTION
### Description
This PR fixes the min and max amount validation in SendAmount screen and implements the dust limit of 147 sats

### Linked Issues/Tasks
Closes #167 

### Screenshot / Video

https://github.com/user-attachments/assets/349b35a8-7fa3-4ff7-b5c6-662a3277a465


Insert relevant screenshot / recording
