### PR TITLE
feat(send): add routing fee estimation

### DIFF
--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -25,7 +25,7 @@
       "location" : "https://github.com/synonymdev/ldk-node",
       "state" : {
         "branch" : "main",
-        "revision" : "51e46248bbd3bf7da6430f5567e9b2edd33a0853"
+        "revision" : "508f038bfcda46b4bc621cd3df0bc08dcf592fa7"
       }
     },
     {

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -636,4 +636,26 @@ extension LightningService {
             return fee
         }
     }
+
+    func estimateRoutingFees(bolt11: String, amountSats: UInt64? = nil) async throws -> UInt64 {
+        guard let node else {
+            throw AppError(serviceError: .nodeNotSetup)
+        }
+
+        return try await ServiceQueue.background(.ldk) {
+            let invoice = try Bolt11Invoice.fromStr(invoiceStr: bolt11)
+            let feesMsat: UInt64
+
+            if let amountSats {
+                let amountMsat = amountSats * 1000
+                feesMsat = try node.bolt11Payment().estimateRoutingFeesUsingAmount(invoice: invoice, amountMsat: amountMsat)
+            } else {
+                feesMsat = try node.bolt11Payment().estimateRoutingFees(invoice: invoice)
+            }
+
+            let feeSat = feesMsat / 1000
+
+            return feeSat
+        }
+    }
 }

--- a/Bitkit/Utilities/Errors.swift
+++ b/Bitkit/Utilities/Errors.swift
@@ -200,6 +200,9 @@ struct AppError: LocalizedError {
         case let .ProbeSendingFailed(message: ldkMessage):
             message = "Failed to send probe"
             debugMessage = ldkMessage
+        case let .RouteNotFound(message: ldkMessage):
+            message = "Failed to find a route for fee estimation"
+            debugMessage = ldkMessage
         case let .ChannelCreationFailed(message: ldkMessage):
             message = "Failed to create channel"
             debugMessage = ldkMessage

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -10,6 +10,7 @@ class WalletViewModel: ObservableObject {
     @AppStorage("totalOnchainSats") var totalOnchainSats: Int = 0 // The total balance of our on-chain wallet
     @AppStorage("totalLightningSats") var totalLightningSats: Int = 0 // Combined LN
     @AppStorage("spendableOnchainBalanceSats") var spendableOnchainBalanceSats: Int = 0 // The spendable balance of our on-chain wallet
+    @AppStorage("maxSendLightningSats") var maxSendLightningSats: Int = 0 // Maximum amount that can be sent via lightning (outbound capacity)
 
     // Receive flow
     @AppStorage("onchainAddress") var onchainAddress = ""
@@ -362,6 +363,11 @@ class WalletViewModel: ObservableObject {
         return spendableBalance >= fee ? spendableBalance - fee : 0
     }
 
+    /// Estimates the routing fees for a lightning payment
+    func estimateRoutingFees(bolt11: String, amountSats: UInt64? = nil) async throws -> UInt64 {
+        return try await lightningService.estimateRoutingFees(bolt11: bolt11, amountSats: amountSats)
+    }
+
     /// Sends a lightning payment and waits for the result using async/await
     /// A LN payment can throw an error right away, be successful right away,
     /// or take a while to complete/fail because it's retrying different paths.
@@ -374,7 +380,7 @@ class WalletViewModel: ObservableObject {
             // Add event listener for this specific payment
             addOnEvent(id: eventId) { event in
                 switch event {
-                case let .paymentSuccessful(paymentId, paymentHash, _, _):
+                case let .paymentSuccessful(_, paymentHash, _, _):
                     if paymentHash == hash {
                         self.removeOnEvent(id: eventId)
                         continuation.resume(returning: paymentHash)
@@ -412,6 +418,14 @@ class WalletViewModel: ObservableObject {
 
         if let channels {
             channelCount = channels.count
+
+            // Calculate maximum sendable lightning amount (outbound capacity)
+            let totalNextOutboundHtlcLimitSats = channels
+                .filter(\.isUsable)
+                .map(\.nextOutboundHtlcLimitMsat)
+                .reduce(0, +) / 1000 // Convert from msat to sat
+
+            maxSendLightningSats = Int(totalNextOutboundHtlcLimitSats)
         }
 
         if let balanceDetails {
@@ -544,6 +558,7 @@ class WalletViewModel: ObservableObject {
         totalBalanceSats = 0
         totalOnchainSats = 0
         totalLightningSats = 0
+        maxSendLightningSats = 0
         channelCount = 0
 
         onchainAddress = ""


### PR DESCRIPTION
### Description

Adds routing fee estimation in the send flow

- show estimated routing fee on confirm screen
- properly calculate max lightning send amount using outbound capacity and estimated routing fee
- upgrade ldk-node dependency

### Screenshot / Video

https://github.com/user-attachments/assets/c215dc64-0312-4962-936d-8d1755a093df

