### PR TITLE
fix: delete core db and logs on wipe wallet

### DIFF
--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -359,6 +359,7 @@ struct MainNavView: View {
 
             // Dev settings
             case .blocktankRegtest: BlocktankRegtestView()
+            case .orders: ChannelOrders()
             case .logs: LogView()
             }
         }

--- a/Bitkit/Utilities/AppReset.swift
+++ b/Bitkit/Utilities/AppReset.swift
@@ -1,3 +1,4 @@
+import BitkitCore
 import SwiftUI
 
 enum AppReset {
@@ -8,26 +9,44 @@ enum AppReset {
         session: SessionManager,
         toastType: Toast.ToastType = .success
     ) async throws {
-        // 1) Stop node and wipe LDK/core persistence via the wallet API.
+        // Stop node and wipe LDK persistence via the wallet API.
         try await wallet.wipe()
 
-        // 2) Wipe persistence
+        // Wipe bitkit-core DB
+        let coreWipeResult = try await wipeAllDatabases()
+        Logger.info("Core DB wipe: \(coreWipeResult)")
+
+        // Wipe keychain
         try Keychain.wipeEntireKeychain()
 
+        // Wipe user defaults
         if let bundleID = Bundle.main.bundleIdentifier {
             UserDefaults.standard.removePersistentDomain(forName: bundleID)
         }
 
-        // 3) Recreate the entire app state tree to guarantee clean defaults for all @StateObject VMs.
+        // Wipe logs
+        try wipeLogs()
+
+        // Recreate the entire app state tree to guarantee clean defaults for all @StateObject VMs.
         // Avoid showing splash during when app is reset
         session.skipSplashOnce = true
         session.bump()
 
-        // 4) Show toast
+        // Show toast
         app.toast(
             type: toastType,
             title: t("security__wiped_title"),
             description: t("security__wiped_message")
         )
+    }
+
+    private static func wipeLogs() throws {
+        let path = Env.logDirectory
+        if FileManager.default.fileExists(atPath: path) {
+            Logger.warn("Wiping entire logs directory...")
+            try FileManager.default.removeItem(at: URL(fileURLWithPath: path))
+        } else {
+            Logger.warn("No logs directory found to wipe: \(path)")
+        }
     }
 }

--- a/Bitkit/ViewModels/NavigationViewModel.swift
+++ b/Bitkit/ViewModels/NavigationViewModel.swift
@@ -88,6 +88,7 @@ enum Route: Hashable {
 
     // Dev settings
     case blocktankRegtest
+    case orders
     case logs
 }
 

--- a/Bitkit/Views/Settings/DevSettingsView.swift
+++ b/Bitkit/Views/Settings/DevSettingsView.swift
@@ -20,6 +20,10 @@ struct DevSettingsView: View {
                         }
                     }
 
+                    NavigationLink(value: Route.orders) {
+                        SettingsListLabel(title: "Orders")
+                    }
+
                     Button {
                         Task {
                             do {


### PR DESCRIPTION
### Description

- use new bitkit-core wipe DB method to clean orders & activities on wipe wallet
- delete logs on wipe wallet
- add orders screen in dev settings
