### PR TITLE
fix: Dissmiss keyboard in TextEditor

### DIFF
--- a/Bitkit/Extensions/TextEditor+DismissOnReturn.swift
+++ b/Bitkit/Extensions/TextEditor+DismissOnReturn.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+private struct DismissKeyboardOnReturnModifier: ViewModifier {
+    @Binding var text: String
+    var isFocused: FocusState<Bool>.Binding
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: text) { newValue in
+                guard isFocused.wrappedValue else { return }
+                if newValue.last == "\n" {
+                    text = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    isFocused.wrappedValue = false
+                }
+            }
+    }
+}
+
+extension View {
+    func dismissKeyboardOnReturn(text: Binding<String>, isFocused: FocusState<Bool>.Binding) -> some View {
+        modifier(DismissKeyboardOnReturnModifier(text: text, isFocused: isFocused))
+    }
+}

--- a/Bitkit/Views/Wallets/Receive/ReceiveEdit.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveEdit.swift
@@ -53,9 +53,8 @@ struct ReceiveEdit: View {
                             .scrollContentBackground(.hidden)
                             .padding(EdgeInsets(top: -8, leading: -5, bottom: -5, trailing: -5))
                             .frame(minHeight: 30, maxHeight: 50)
-                            .onSubmit {
-                                isNoteEditorFocused = false
-                            }
+                            .dismissKeyboardOnReturn(text: $note, isFocused: $isNoteEditorFocused)
+                            .accessibilityValue(note)
                             .accessibilityIdentifier("ReceiveNote")
                     }
                     .padding()

--- a/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
+++ b/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
@@ -30,6 +30,9 @@ struct SendEnterManuallyView: View {
                     .font(.custom(Fonts.bold, size: 22))
                     .foregroundColor(.textPrimary)
                     .accentColor(.brandAccent)
+                    .submitLabel(.done)
+                    .dismissKeyboardOnReturn(text: $text, isFocused: $isTextEditorFocused)
+                    .accessibilityValue(text)
                     .accessibilityIdentifier("RecipientInput")
             }
             .background(Color.white06)


### PR DESCRIPTION
### Description

Fix to hide keyboard on submit in TextEditor, see: https://github.com/synonymdev/bitkit-ios/issues/216.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit-ios/issues/216.

### Screenshot / Video


https://github.com/user-attachments/assets/3ff8af92-7154-43e5-a94b-5fd50328b47b


