### PR TITLE
e2e-status for branch protection

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -236,3 +236,17 @@ jobs:
         working-directory: bitkit-e2e-tests
         run: |
           cd docker && docker compose down -v || true
+
+  e2e-status:
+    name: e2e-status
+    runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    if: always()
+    steps:
+      - name: Verify all E2E shards succeeded
+        run: |
+          if [ "${{ needs.e2e-tests.result }}" != "success" ]; then
+            echo "❌ Some E2E shards failed."
+            exit 1
+          fi
+          echo "✅ All E2E shards passed!"


### PR DESCRIPTION
### Description

Adds an `e2e-status` job that aggregates the results of all E2E test shards.
This job provides a single unified status check (`e2e-status`) that can be used in branch protection rules to ensure all E2E shards pass before merging.

### Linked Issues/Tasks

As in: https://github.com/synonymdev/bitkit-android/pull/466

### Screenshot / Video

Insert relevant screenshot / recording
