### PR TITLE
Update backup and restore to match Android

### DIFF
--- a/Bitkit/Models/BackupPayloads.swift
+++ b/Bitkit/Models/BackupPayloads.swift
@@ -50,3 +50,67 @@ struct ActivityBackupV1: Codable {
     let activityTags: [ActivityTags]
     let closedChannels: [ClosedChannelDetails]
 }
+
+struct SettingsBackupV1 {
+    let version: Int
+    let createdAt: UInt64
+    let settings: [String: Any]
+
+    init(version: Int, createdAt: UInt64, settings: [String: Any]) {
+        self.version = version
+        self.createdAt = createdAt
+        self.settings = settings
+    }
+
+    static func decode(from data: Data) throws -> SettingsBackupV1 {
+        guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let version = dict["version"] as? Int,
+              let createdAt = dict["createdAt"] as? UInt64,
+              let settings = dict["settings"] as? [String: Any]
+        else {
+            throw NSError(domain: "BackupService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to decode SettingsBackupV1"])
+        }
+        return SettingsBackupV1(version: version, createdAt: createdAt, settings: settings)
+    }
+
+    func encode() throws -> Data {
+        let dict: [String: Any] = [
+            "version": version,
+            "createdAt": createdAt,
+            "settings": settings,
+        ]
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+}
+
+struct WidgetsBackupV1 {
+    let version: Int
+    let createdAt: UInt64
+    let widgets: [String: Any]
+
+    init(version: Int, createdAt: UInt64, widgets: [String: Any]) {
+        self.version = version
+        self.createdAt = createdAt
+        self.widgets = widgets
+    }
+
+    static func decode(from data: Data) throws -> WidgetsBackupV1 {
+        guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let version = dict["version"] as? Int,
+              let createdAt = dict["createdAt"] as? UInt64,
+              let widgets = dict["widgets"] as? [String: Any]
+        else {
+            throw NSError(domain: "BackupService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to decode WidgetsBackupV1"])
+        }
+        return WidgetsBackupV1(version: version, createdAt: createdAt, widgets: widgets)
+    }
+
+    func encode() throws -> Data {
+        let dict: [String: Any] = [
+            "version": version,
+            "createdAt": createdAt,
+            "widgets": widgets,
+        ]
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+}

--- a/Bitkit/Services/BackupService.swift
+++ b/Bitkit/Services/BackupService.swift
@@ -15,12 +15,14 @@ class BackupService {
     private var periodicCheckTask: Task<Void, Never>?
     private var isObserving = false
     private var isRestoring = false
+    private var isWiping = false
     private var lastNotificationTime: UInt64 = 0
 
     private let defaults = UserDefaults.standard
     private let backupStatusesKey = "backupStatuses"
 
     private let statusUpdateQueue = DispatchQueue(label: "backup-service-status-update", qos: .userInitiated)
+    private let stateQueue = DispatchQueue(label: "backup-service-state", qos: .userInitiated)
     private let backupStatusesSubject = PassthroughSubject<[BackupCategory: BackupItemStatus], Never>()
 
     private let backupFailureSubject = PassthroughSubject<Int, Never>()
@@ -65,6 +67,13 @@ class BackupService {
     private static let failedBackupNotificationInterval: UInt64 = 10 * 60 // 10 minutes in seconds
 
     // MARK: - Public Methods
+
+    /// Sets the wiping flag to prevent backups during wipe operations
+    func setWiping(_ isWiping: Bool) {
+        stateQueue.sync {
+            self.isWiping = isWiping
+        }
+    }
 
     func startObservingBackups() {
         Task {
@@ -165,7 +174,15 @@ class BackupService {
 
     /// Performs full restore from latest backup
     func performFullRestoreFromLatestBackup() async {
-        try? await ServiceQueue.background(.backup) { self.isRestoring = true }
+        stateQueue.sync {
+            isRestoring = true
+        }
+
+        defer {
+            stateQueue.sync {
+                isRestoring = false
+            }
+        }
 
         VssStoreIdProvider.shared.clearCache()
         VssBackupClient.shared.reset()
@@ -174,20 +191,14 @@ class BackupService {
 
         do {
             try await performRestore(category: .settings) { dataBytes in
-                guard let settingsDict = try JSONSerialization.jsonObject(with: dataBytes) as? [String: Any] else {
-                    throw NSError(domain: "BackupService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to parse settings JSON"])
-                }
-
-                await SettingsViewModel.shared.restoreSettingsDictionary(settingsDict)
+                let payload = try SettingsBackupV1.decode(from: dataBytes)
+                await SettingsViewModel.shared.restoreSettingsDictionary(payload.settings)
             }
 
             try await performRestore(category: .widgets) { dataBytes in
-                guard let jsonDict = try JSONSerialization.jsonObject(with: dataBytes) as? [String: Any] else {
-                    throw NSError(domain: "BackupService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid widgets format"])
-                }
-
-                let decodedWidgets = try WidgetsBackupConverter.convertFromAndroidFormat(jsonDict: jsonDict)
-                let encodedData = try JSONEncoder().encode(decodedWidgets)
+                let payload = try WidgetsBackupV1.decode(from: dataBytes)
+                let widgets = try WidgetsBackupConverter.convertFromAndroidFormat(jsonDict: payload.widgets)
+                let encodedData = try JSONEncoder().encode(widgets)
                 UserDefaults.standard.set(encodedData, forKey: "savedWidgets")
             }
 
@@ -218,6 +229,9 @@ class BackupService {
 
                 await SettingsViewModel.shared.restoreAppCacheData(payload.cache)
 
+                // Force address rotation by clearing onchain address
+                UserDefaults.standard.set("", forKey: "onchainAddress")
+
                 Logger.debug("Restored caches, \(payload.tagMetadata.count) pre-activity metadata", context: "BackupService")
             }
 
@@ -238,8 +252,6 @@ class BackupService {
         } catch {
             Logger.warn("Full restore error: \(error)", context: "BackupService")
         }
-
-        try? await ServiceQueue.background(.backup) { self.isRestoring = false }
     }
 
     // MARK: - Private Methods
@@ -259,12 +271,9 @@ class BackupService {
             distinctPublisher
                 .dropFirst()
                 .sink { [weak self] status in
-                    guard let self else { return }
-                    Task {
-                        let isRestoring = try? await ServiceQueue.background(.backup) { self.isRestoring }
-                        guard isRestoring != true else { return }
-
-                        if status.isRequired && !status.running {
+                    guard let self, !self.shouldSkipBackup() else { return }
+                    if status.isRequired && !status.running {
+                        Task {
                             await self.scheduleBackup(category: category)
                         }
                     }
@@ -280,7 +289,7 @@ class BackupService {
         SettingsViewModel.shared.settingsPublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 markBackupRequired(category: .settings)
             }
             .store(in: &cancellables)
@@ -289,7 +298,7 @@ class BackupService {
         SettingsViewModel.shared.widgetsPublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 markBackupRequired(category: .widgets)
             }
             .store(in: &cancellables)
@@ -298,7 +307,7 @@ class BackupService {
         TransferStorage.shared.transfersChangedPublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 markBackupRequired(category: .wallet)
             }
             .store(in: &cancellables)
@@ -307,7 +316,7 @@ class BackupService {
         CoreService.shared.activity.activitiesChangedPublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 markBackupRequired(category: .activity)
             }
             .store(in: &cancellables)
@@ -316,7 +325,7 @@ class BackupService {
         CoreService.shared.activity.metadataChangedPublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 markBackupRequired(category: .metadata)
             }
             .store(in: &cancellables)
@@ -325,7 +334,7 @@ class BackupService {
         SettingsViewModel.shared.appStatePublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 markBackupRequired(category: .metadata)
             }
             .store(in: &cancellables)
@@ -334,7 +343,7 @@ class BackupService {
         CoreService.shared.blocktank.stateChangedPublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 markBackupRequired(category: .blocktank)
             }
             .store(in: &cancellables)
@@ -343,7 +352,7 @@ class BackupService {
         LightningService.shared.syncStatusChangedPublisher
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] lastSync in
-                guard let self, !self.isRestoring else { return }
+                guard let self, !self.shouldSkipBackup() else { return }
                 updateBackupStatus(category: .lightningConnections) { _ in
                     BackupItemStatus(
                         synced: lastSync,
@@ -371,6 +380,12 @@ class BackupService {
         }
     }
 
+    private func shouldSkipBackup() -> Bool {
+        return stateQueue.sync {
+            isRestoring || isWiping
+        }
+    }
+
     private func markBackupRequired(category: BackupCategory) {
         updateBackupStatus(category: category) { status in
             BackupItemStatus(
@@ -382,8 +397,7 @@ class BackupService {
 
         Task {
             let status = getBackupStatus(category: category)
-            let isCurrentlyRestoring = try? await ServiceQueue.background(.backup) { self.isRestoring }
-            if status.isRequired && isCurrentlyRestoring != true {
+            if status.isRequired && !shouldSkipBackup() {
                 await scheduleBackup(category: category)
             } else if !status.isRequired {
                 updateBackupStatus(category: category) { status in
@@ -439,8 +453,7 @@ class BackupService {
             }
 
             let status = getBackupStatus(category: category)
-            let isCurrentlyRestoring = try? await ServiceQueue.background(.backup) { self.isRestoring }
-            if status.isRequired && isCurrentlyRestoring != true {
+            if status.isRequired && !shouldSkipBackup() {
                 await triggerBackup(category: category)
             } else {
                 updateBackupStatus(category: category) { status in
@@ -566,19 +579,31 @@ class BackupService {
         switch category {
         case .settings:
             let settingsDict = await SettingsViewModel.shared.getSettingsDictionary()
-            return try JSONSerialization.data(withJSONObject: settingsDict, options: [])
+            let payload = SettingsBackupV1(
+                version: 1,
+                createdAt: UInt64(Date().timeIntervalSince1970),
+                settings: settingsDict
+            )
+            return try payload.encode()
 
         case .widgets:
-            guard let widgetsData = UserDefaults.standard.data(forKey: "savedWidgets") else {
-                return Data()
+            let savedWidgets: [SavedWidget] = if let widgetsData = UserDefaults.standard.data(forKey: "savedWidgets") {
+                try JSONDecoder().decode([SavedWidget].self, from: widgetsData)
+            } else {
+                []
             }
 
-            do {
-                let savedWidgets = try JSONDecoder().decode([SavedWidget].self, from: widgetsData)
-                return try WidgetsBackupConverter.convertToAndroidFormat(savedWidgets: savedWidgets)
-            } catch {
-                return widgetsData
+            let androidWidgetsData = try WidgetsBackupConverter.convertToAndroidFormat(savedWidgets: savedWidgets)
+            guard let androidWidgetsDict = try? JSONSerialization.jsonObject(with: androidWidgetsData) as? [String: Any] else {
+                throw NSError(domain: "BackupService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to convert widgets to Android format"])
             }
+
+            let payload = WidgetsBackupV1(
+                version: 1,
+                createdAt: UInt64(Date().timeIntervalSince1970),
+                widgets: androidWidgetsDict
+            )
+            return try payload.encode()
 
         case .wallet:
             let transfers = try TransferStorage.shared.getAll()

--- a/Bitkit/Utilities/AppReset.swift
+++ b/Bitkit/Utilities/AppReset.swift
@@ -9,6 +9,12 @@ enum AppReset {
         session: SessionManager,
         toastType: Toast.ToastType = .success
     ) async throws {
+        // Set wiping flag to prevent backups during wipe operations
+        BackupService.shared.setWiping(true)
+        defer {
+            BackupService.shared.setWiping(false)
+        }
+
         // Stop backup observers before wallet wipe to prevent race conditions
         BackupService.shared.stopObservingBackups()
 

--- a/Bitkit/Views/Onboarding/RestoreWalletView.swift
+++ b/Bitkit/Views/Onboarding/RestoreWalletView.swift
@@ -148,7 +148,7 @@ struct RestoreWalletView: View {
                         focusedField: $focusedField
                     )
                     .onChange(of: firstFieldText) { newValue in
-                        if index == 0 && newValue.contains(" ") {
+                        if index == 0 && newValue.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {
                             handlePastedWords(newValue)
                         } else if index == 0 {
                             words[index] = newValue


### PR DESCRIPTION
Update the settings and widgets backup format to use payloads, and add flag to avoid backup while wiping data

Testing: update settings and wdgets on iOS and make sure recovery on android works, and vice versa.