### PR TITLE
fix e2e regex

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -107,7 +107,7 @@ jobs:
           # - { name: onchain_boost_receive_widgets, grep: "@onchain|@boost|@receive|@widgets" }
           # - { name: settings, grep: "@settings" }
           # - { name: security, grep: "@security" }
-          - { name: e2e, grep: '(@onboarding|@onchain_1|@numberpad|@widgets|@boost|@receive|@settings)(?!.*@settings_10)' }
+          - { name: e2e, grep: '^(?!.*@settings_10)(@onboarding|@onchain_1|@numberpad|@widgets|@boost|@receive|@settings)' }
 
     name: e2e-tests - ${{ matrix.shard.name }}
 
@@ -200,7 +200,7 @@ jobs:
         continue-on-error: true
         id: test1
         working-directory: bitkit-e2e-tests
-        run: ./ci_run_ios.sh --mochaOpts.grep "${{ matrix.shard.grep }}"
+        run: ./ci_run_ios.sh --mochaOpts.grep '${{ matrix.shard.grep }}'
         env:
           RECORD_VIDEO: true
           ATTEMPT: 1


### PR DESCRIPTION
### Description

Fix and update e2e regex to skip test @settings_10 (not ready), previous regex was not correct but seems that PR got merged despite e2e tests were skipped (https://github.com/synonymdev/bitkit-ios/pull/228).

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Screenshot / Video

Insert relevant screenshot / recording
