### PR TITLE
Feat/clipboard alert dialog

### DIFF
--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -13,6 +13,10 @@ struct MainNavView: View {
     @State private var showClipboardAlert = false
     @State private var clipboardUri: String?
 
+    // Delay constants for clipboard processing
+    private static let nodeReadyDelayNanoseconds: UInt64 = 500_000_000 // 0.5 seconds
+    private static let statePropagationDelayNanoseconds: UInt64 = 500_000_000 // 0.5 seconds
+
     var body: some View {
         NavigationStack(path: $navigation.path) {
             navigationContent
@@ -409,10 +413,10 @@ struct MainNavView: View {
         Task { @MainActor in
             do {
                 await wallet.waitForNodeToRun()
-                try await Task.sleep(nanoseconds: 500_000_000)
+                try await Task.sleep(nanoseconds: Self.nodeReadyDelayNanoseconds)
                 try await app.handleScannedData(uri)
 
-                try await Task.sleep(nanoseconds: 500_000_000)
+                try await Task.sleep(nanoseconds: Self.statePropagationDelayNanoseconds)
                 PaymentNavigationHelper.openPaymentSheet(
                     app: app,
                     currency: currency,


### PR DESCRIPTION
### Description

This PR Implements the clipboard navigation alert dialog and adds delays to the state propagate after the node run

Qa notes:
- Enable the feature in "Security and privacy"settings
- there is a bug in the clipboard when you copy from android emulator and try to paste directly into iOS emulator. You have to pass somewhere else and copy again

### Linked Issues/Tasks

Closes #173 

### Screenshot / Video

https://github.com/user-attachments/assets/f580f170-b4c5-4b41-9558-41724c96aa19



