### PR TITLE
fix: roll back electrum connection on failure

### DIFF
--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -69,17 +69,18 @@ enum Env {
 
     static var electrumServerUrl: String {
         if isE2E {
-            return "127.0.0.1:60001"
+            return "tcp://127.0.0.1:60001"
         }
+
         switch network {
-        case .regtest:
-            return "34.65.252.32:18483"
         case .bitcoin:
-            return "35.187.18.233:18484"
-        case .testnet:
-            fatalError("Testnet network not implemented")
+            return "ssl://35.187.18.233:8900"
         case .signet:
             fatalError("Signet network not implemented")
+        case .testnet:
+            return "ssl://electrum.blockstream.info:60002"
+        case .regtest:
+            return "tcp://34.65.252.32:18483"
         }
     }
 

--- a/Bitkit/Models/ElectrumServer.swift
+++ b/Bitkit/Models/ElectrumServer.swift
@@ -14,6 +14,12 @@ struct ElectrumServer: Equatable, Codable {
         return "\(host):\(port)"
     }
 
+    /// Returns the full URL with protocol prefix (tcp:// or ssl://)
+    var fullUrl: String {
+        let protocolPrefix = protocolType == .ssl ? "ssl://" : "tcp://"
+        return "\(protocolPrefix)\(host):\(port)"
+    }
+
     var portString: String {
         return String(port)
     }

--- a/Bitkit/ViewModels/Extensions/SettingsViewModel+Rgs.swift
+++ b/Bitkit/ViewModels/Extensions/SettingsViewModel+Rgs.swift
@@ -26,7 +26,7 @@ extension SettingsViewModel {
             rgsConfigService.saveServerUrl(url)
 
             // Restart the Lightning node with the new RGS server
-            let currentElectrumUrl = electrumConfigService.getCurrentServer().url
+            let currentElectrumUrl = electrumConfigService.getCurrentServer().fullUrl
             try await lightningService.restart(electrumServerUrl: currentElectrumUrl, rgsServerUrl: url.isEmpty ? nil : url)
 
             rgsIsLoading = false

--- a/Bitkit/ViewModels/SettingsViewModel.swift
+++ b/Bitkit/ViewModels/SettingsViewModel.swift
@@ -342,9 +342,7 @@ class SettingsViewModel: NSObject, ObservableObject {
             }
         }
 
-        let electrumServer = electrumConfigService.getCurrentServer()
-        let protocolPrefix = electrumServer.protocolType == .ssl ? "ssl://" : "tcp://"
-        let electrumServerUrl = "\(protocolPrefix)\(electrumServer.url)"
+        let electrumServerUrl = electrumConfigService.getCurrentServer().fullUrl
         if !electrumServerUrl.isEmpty { dict["electrumServer"] = electrumServerUrl }
 
         let rgsServerUrl = rgsConfigService.getCurrentServerUrl()
@@ -375,7 +373,7 @@ class SettingsViewModel: NSObject, ObservableObject {
         }
 
         if urlString.hasPrefix("tcp://") || urlString.hasPrefix("ssl://") {
-            let withoutProtocol = urlString.replacingOccurrences(of: "tcp://", with: "").replacingOccurrences(of: "ssl://", with: "")
+            let withoutProtocol = String(urlString.dropFirst(6)) // Remove "ssl://" or "tcp://"
             let parts = withoutProtocol.split(separator: ":")
             guard parts.count >= 2 else { return nil }
 

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -100,7 +100,7 @@ class WalletViewModel: ObservableObject {
 
         syncState()
         do {
-            let electrumServerUrl = electrumConfigService.getCurrentServer().url
+            let electrumServerUrl = electrumConfigService.getCurrentServer().fullUrl
             let rgsServerUrl = rgsConfigService.getCurrentServerUrl()
             try await lightningService.setup(
                 walletIndex: walletIndex,
@@ -472,10 +472,19 @@ class WalletViewModel: ObservableObject {
         syncBalances()
     }
 
-    /// Sync node status and ID only
+    /// Sync node status, ID and lifecycle state
     private func syncNodeStatus() {
         nodeStatus = lightningService.status
         nodeId = lightningService.nodeId
+
+        // Sync lifecycle state based on service status
+        if let status = lightningService.status {
+            if status.isRunning && nodeLifecycleState != .running {
+                nodeLifecycleState = .running
+            } else if !status.isRunning && nodeLifecycleState == .running {
+                nodeLifecycleState = .stopped
+            }
+        }
     }
 
     /// Sync channels and peers only

--- a/Bitkit/Views/Settings/Advanced/ElectrumSettingsScreen.swift
+++ b/Bitkit/Views/Settings/Advanced/ElectrumSettingsScreen.swift
@@ -4,6 +4,7 @@ struct ElectrumSettingsScreen: View {
     @EnvironmentObject var app: AppViewModel
     @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var settings: SettingsViewModel
+    @EnvironmentObject var wallet: WalletViewModel
 
     @FocusState private var isTextFieldFocused: Bool
 
@@ -100,12 +101,17 @@ struct ElectrumSettingsScreen: View {
                             }
                             .accessibilityIdentifier("ConnectToHost")
                         }
-                        .buttonBottomPadding(isFocused: isTextFieldFocused)
+                        .bottomSafeAreaPadding()
                     }
                     .frame(minHeight: geometry.size.height)
-                    .bottomSafeAreaPadding()
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        isTextFieldFocused = false
+                    }
                 }
+                .scrollDismissesKeyboard(.interactively)
             }
+            .ignoresSafeArea(.keyboard, edges: .bottom)
         }
         .navigationBarHidden(true)
         .padding(.horizontal, 16)
@@ -117,6 +123,8 @@ struct ElectrumSettingsScreen: View {
     private func onConnect() {
         Task {
             let result = await settings.connectToElectrumServer()
+            // Sync wallet state to update node lifecycle state for app status
+            wallet.syncState()
             showToast(result.success, result.host, result.port, result.errorMessage)
         }
     }
@@ -124,6 +132,8 @@ struct ElectrumSettingsScreen: View {
     private func onReset() {
         Task {
             let result = await settings.resetElectrumToDefault()
+            // Sync wallet state to update node lifecycle state for app status
+            wallet.syncState()
             showToast(result.success, result.host, result.port, result.errorMessage)
         }
     }


### PR DESCRIPTION
### Description

- pass connection protocol to ldk-node
- roll back to last working electrum connection on failure
- keep app status in sync on connection change
- make keyboard dismissible by scroll and tap outside

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit-ios/issues/256 https://github.com/synonymdev/bitkit-ios/issues/257

### Screenshot / Video

https://github.com/user-attachments/assets/988d1c4d-bedc-42e1-a020-6e714cf6f3c5

