### PR TITLE
Fix: Prevent editing amount for fixed Lightning invoices on send confirm

### DIFF
--- a/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
+++ b/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
@@ -95,7 +95,7 @@ struct SendConfirmationView: View {
                         sats: Int(wallet.sendAmountSats ?? invoice.amountSatoshis),
                         showSymbol: true,
                         testIdPrefix: "ReviewAmount",
-                        onTap: canEditAmount ? navigateToAmount : {}
+                        onTap: navigateToAmount
                     )
                     .padding(.bottom, 44)
                     lightningView(invoice)


### PR DESCRIPTION
### Description

Related to https://github.com/synonymdev/bitkit-ios/pull/271#discussion_r2619289207

### Linked Issues/Tasks

Additinal checks included in e2e lightning test: 
 - https://github.com/synonymdev/bitkit-e2e-tests/pull/71

### Screenshot / Video

| lightning invoice, no amt [can edit amt] | lightning invoice, fixed amt [cannot edit amt] |
|---|---|
| <video src="https://github.com/user-attachments/assets/a53de12a-ed80-48a7-b53f-ed7e5c3ec521"> | <video src="https://github.com/user-attachments/assets/bb8e9735-7f85-41b8-b6d8-d6a925994569"> |













