### PR TITLE
fix: remove next item trigger from timed sheet manager

### DIFF
--- a/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
+++ b/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
@@ -139,12 +139,6 @@ class TimedSheetManager: ObservableObject {
             currentSheet.onDismissed()
             currentlyShowingSheet = nil
         }
-
-        // If still on home screen, restart timer to check for next sheet
-        // NOTE: could be annoying to show sheets immediately after one another, maybe remove
-        if isOnHomeScreen {
-            onHomeScreenEntered()
-        }
     }
 
     /// Check the queue and show the highest priority sheet that should be shown


### PR DESCRIPTION
### Description

This PR removes the broken next item trigger from TimedSheetManager to align the code with the app behavior

Test steps:

1. Go to dev settings
2. Receive 100 000 000
3. Mine a block
4. Go to home
5. Display the backup sheet
6. Dismiss it
7. Stay in home
8. Should NOT display high balance sheet
9. Leave home
10. Return to home
11. Should display high balance sheet

### Linked Issues/Tasks

Closes #294 

### Screenshot / Video

https://github.com/user-attachments/assets/9e5f333e-b2e1-42b1-bc6d-fb7b97268a28

