### PR TITLE
Migrate to-do cards

### DIFF
--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -76,6 +76,7 @@ struct AppScene: View {
             .onChange(of: migrations.isShowingMigrationLoading) { isLoading in
                 if !isLoading {
                     widgets.loadSavedWidgets()
+                    suggestionsManager.reloadDismissed()
                     if UserDefaults.standard.bool(forKey: "pinOnLaunch") && settings.pinEnabled {
                         isPinVerified = false
                     }

--- a/Bitkit/Managers/SuggestionsManager.swift
+++ b/Bitkit/Managers/SuggestionsManager.swift
@@ -8,7 +8,7 @@ final class SuggestionsManager: ObservableObject {
     private let userDefaultsKey = "dismissedSuggestions"
 
     init() {
-        loadDismissed()
+        reloadDismissed()
     }
 
     func dismiss(_ suggestionId: String) {
@@ -25,7 +25,7 @@ final class SuggestionsManager: ObservableObject {
         dismissedIds.contains(suggestionId)
     }
 
-    private func loadDismissed() {
+    func reloadDismissed() {
         let dismissedArray = UserDefaults.standard.stringArray(forKey: userDefaultsKey) ?? []
         dismissedIds = Set(dismissedArray)
     }


### PR DESCRIPTION
Migrates the todo cards in the suggestions below balance to hide the dismissed ones after RN app migration.

Note: iOS has Get Paid and Shop which Android and React Native don't have and we should likely fix this to match.