### PR TITLE
fix(notifications): handling for payments and channel opening

### DIFF
--- a/Bitkit/ViewModels/AppViewModel.swift
+++ b/Bitkit/ViewModels/AppViewModel.swift
@@ -423,6 +423,11 @@ extension AppViewModel {
                         )
 
                         try await CoreService.shared.activity.insert(.lightning(ln))
+
+                        // Show receivedTx sheet for CJIT payment
+                        await MainActor.run {
+                            sheetViewModel.showSheet(.receivedTx, data: ReceivedTxSheetDetails(type: .lightning, sats: amount))
+                        }
                     } else {
                         toast(
                             type: .lightning,


### PR DESCRIPTION
### Description

- Ensure LSP peer connection before opening channel in `.orderPaymentConfirmed`
- Match payment hash in `.paymentReceived` to prevent wrong payment notifications
- Add activity item and `.receivedTx` sheet for CJIT payments
- Clean up commented code and unused variables
