### PR TITLE
Reload last used tags after migration/ restore

### DIFF
--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -77,6 +77,7 @@ struct AppScene: View {
                 if !isLoading {
                     widgets.loadSavedWidgets()
                     suggestionsManager.reloadDismissed()
+                    tagManager.reloadLastUsedTags()
                     if UserDefaults.standard.bool(forKey: "pinOnLaunch") && settings.pinEnabled {
                         isPinVerified = false
                     }

--- a/Bitkit/Managers/TagManager.swift
+++ b/Bitkit/Managers/TagManager.swift
@@ -10,7 +10,7 @@ final class TagManager: ObservableObject {
     private let maxLastUsedTags = 10
 
     init() {
-        loadLastUsedTags()
+        reloadLastUsedTags()
     }
 
     // MARK: - Tag Selection Management
@@ -63,7 +63,7 @@ final class TagManager: ObservableObject {
     }
 
     /// Load last used tags from UserDefaults
-    private func loadLastUsedTags() {
+    func reloadLastUsedTags() {
         lastUsedTags = UserDefaults.standard.stringArray(forKey: userDefaultsKey) ?? []
     }
 

--- a/Bitkit/Views/Onboarding/WalletRestoreSuccess.swift
+++ b/Bitkit/Views/Onboarding/WalletRestoreSuccess.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct WalletRestoreSuccess: View {
     @EnvironmentObject var wallet: WalletViewModel
+    @EnvironmentObject var suggestionsManager: SuggestionsManager
+    @EnvironmentObject var tagManager: TagManager
 
     var body: some View {
         VStack(spacing: 0) {
@@ -25,6 +27,10 @@ struct WalletRestoreSuccess: View {
 
             CustomButton(title: t("onboarding__get_started")) {
                 Haptics.play(.light)
+
+                suggestionsManager.reloadDismissed()
+                tagManager.reloadLastUsedTags()
+
                 wallet.isRestoringWallet = false
             }
             .accessibilityIdentifier("GetStartedButton")


### PR DESCRIPTION
Reload last used tags after migration/ restore so they properly show app.

Fix #311 