### PR TITLE
fix: migration

### DIFF
--- a/Bitkit/Services/MigrationsService.swift
+++ b/Bitkit/Services/MigrationsService.swift
@@ -416,6 +416,18 @@ extension MigrationsService {
         UserDefaults.standard.bool(forKey: Self.rnMigrationCheckedKey)
     }
 
+    var isMigrationCompleted: Bool {
+        UserDefaults.standard.bool(forKey: Self.rnMigrationCompletedKey)
+    }
+
+    func markMigrationChecked() {
+        UserDefaults.standard.set(true, forKey: Self.rnMigrationCheckedKey)
+    }
+
+    func markMigrationCompleted() {
+        UserDefaults.standard.set(true, forKey: Self.rnMigrationCompletedKey)
+    }
+
     func hasRNWalletData() -> Bool {
         do {
             let mnemonic = try loadStringFromRNKeychain(key: .mnemonic(walletName: rnWalletName))
@@ -489,8 +501,8 @@ extension MigrationsService {
             Logger.warn("No MMKV data found, skipping settings/activities migration", context: "Migration")
         }
 
-        UserDefaults.standard.set(true, forKey: Self.rnMigrationCompletedKey)
-        UserDefaults.standard.set(true, forKey: Self.rnMigrationCheckedKey)
+        markMigrationCompleted()
+        markMigrationChecked()
 
         // Clean up RN data after successful migration
         cleanupAfterMigration()
@@ -575,10 +587,6 @@ extension MigrationsService {
             channelMonitors: monitors
         )
         Logger.info("Prepared \(monitors.count) channel monitors for migration", context: "Migration")
-    }
-
-    func markMigrationChecked() {
-        UserDefaults.standard.set(true, forKey: Self.rnMigrationCheckedKey)
     }
 
     // MARK: - RN Data Cleanup


### PR DESCRIPTION
### Description

- always prefer VSS backup if it exists

## Testing Recommendations

1. Test scenario: User migrates from RN → uses native app → wipes → restores
   - Should only use VSS backup, not RN backup
2. Test scenario: Fresh install (no migration) → restore
   - Should compare timestamps correctly

The fix ensures that once a user has migrated from RN, they'll always use VSS backups for restores, preventing the issue of restoring stale RN channel data.