### PR TITLE
fix(restore): clear VSS store ID cache on wipe

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 				Services/RNBackupClient.swift,
 				Services/ServiceQueue.swift,
 				Services/TransferStorage.swift,
+				Services/VssBackupClient.swift,
 				Services/VssStoreIdProvider.swift,
 				Utilities/Crypto.swift,
 				Utilities/Errors.swift,

--- a/Bitkit/Services/BackupService.swift
+++ b/Bitkit/Services/BackupService.swift
@@ -179,6 +179,7 @@ class BackupService {
             }
         }
 
+        // Reset VSS client
         VssStoreIdProvider.shared.clearCache()
         await VssBackupClient.shared.reset()
 

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -37,7 +37,9 @@ class LightningService {
             throw CustomServiceError.mnemonicNotFound
         }
 
-        var passphrase = try Keychain.loadString(key: .bip39Passphrase(index: walletIndex))
+        // Normalize empty strings to nil - empty passphrase should be treated as no passphrase
+        let passphraseRaw = try Keychain.loadString(key: .bip39Passphrase(index: walletIndex))
+        var passphrase = passphraseRaw?.isEmpty == true ? nil : passphraseRaw
 
         currentWalletIndex = walletIndex
 

--- a/Bitkit/Services/MigrationsService.swift
+++ b/Bitkit/Services/MigrationsService.swift
@@ -1696,6 +1696,10 @@ extension MigrationsService {
         isRestoringFromRNRemoteBackup = true
         Logger.info("Starting RN remote backup restore", context: "Migration")
 
+        // Reset VSS client
+        VssStoreIdProvider.shared.clearCache()
+        await VssBackupClient.shared.reset()
+
         clearPinSettings()
 
         // Fetch LDK data (channel_manager and channel_monitors)

--- a/Bitkit/Services/VssBackupClient.swift
+++ b/Bitkit/Services/VssBackupClient.swift
@@ -79,7 +79,9 @@ class VssBackupClient {
                     guard let mnemonic = try Keychain.loadString(key: .bip39Mnemonic(index: walletIndex)) else {
                         throw CustomServiceError.mnemonicNotFound
                     }
-                    let passphrase = try Keychain.loadString(key: .bip39Passphrase(index: walletIndex))
+                    // Normalize empty strings to nil - empty passphrase should be treated as no passphrase
+                    let passphraseRaw = try Keychain.loadString(key: .bip39Passphrase(index: walletIndex))
+                    let passphrase = passphraseRaw?.isEmpty == true ? nil : passphraseRaw
 
                     try await vssNewClientWithLnurlAuth(
                         baseUrl: vssUrl,

--- a/Bitkit/Utilities/AppReset.swift
+++ b/Bitkit/Utilities/AppReset.swift
@@ -18,6 +18,7 @@ enum AppReset {
         // Stop backup observers and reset VSS client
         await BackupService.shared.stopObservingBackups()
         await VssBackupClient.shared.reset()
+        VssStoreIdProvider.shared.clearCache()
 
         // Stop node and wipe LDK persistence via the wallet API.
         try await wallet.wipe()

--- a/Bitkit/Utilities/StartupHandler.swift
+++ b/Bitkit/Utilities/StartupHandler.swift
@@ -13,14 +13,16 @@ class StartupHandler {
         let mnemonic = generateEntropyMnemonic(wordCount: .words12)
 
         try Keychain.saveString(key: .bip39Mnemonic(index: walletIndex), str: mnemonic)
-        if let bip39Passphrase {
+
+        // Normalize empty strings to nil - empty passphrase should be treated as no passphrase
+        if let bip39Passphrase, !bip39Passphrase.isEmpty {
             try Keychain.saveString(key: .bip39Passphrase(index: walletIndex), str: bip39Passphrase)
         }
 
         return mnemonic
     }
 
-    /// Restores a wallet from a mnemoni and, saves it to the keychain
+    /// Restores a wallet from a mnemonic and saves it to the keychain
     /// - Parameters:
     ///   - mnemonic: 12 or 24 word mnemonic
     ///   - bip39Passphrase: optional bip39 passphrase
@@ -32,7 +34,9 @@ class StartupHandler {
         }
 
         try Keychain.saveString(key: .bip39Mnemonic(index: walletIndex), str: mnemonic)
-        if let bip39Passphrase {
+
+        // Normalize empty strings to nil - empty passphrase should be treated as no passphrase
+        if let bip39Passphrase, !bip39Passphrase.isEmpty {
             try Keychain.saveString(key: .bip39Passphrase(index: walletIndex), str: bip39Passphrase)
         }
     }


### PR DESCRIPTION
### Description

- clear VSS store ID cache
    - on app wipe (probably all that's needed)
    - when restoring from a react native backup (additional defensive code)
- also defensively normalizes empty passphrase
    - when visiting "Restore" screen, tapping "Advanced" and not entering a passphrase it is set to empty string
    - under the hood it is normalized I'm fairly sure but this ensures that

Related: https://github.com/synonymdev/bitkit-ios/issues/363
