### PR TITLE
Update ldk-node to avoid repeated tx sheet

### DIFF
--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -25,7 +25,7 @@
       "location" : "https://github.com/synonymdev/ldk-node",
       "state" : {
         "branch" : "main",
-        "revision" : "db505e4ca9419759cbb983b173d8cb71af372aed"
+        "revision" : "551e31436035884e48aa89e09cc343e835af17b6"
       }
     },
     {


### PR DESCRIPTION
Update the ldk-node to avoid repeated incoming tx sheet on restart.

Testing is easier when changing this line to `return false`
https://github.com/synonymdev/bitkit-ios/blob/56262f6c3ce0be70d1255391bd8437cb02ec543a/Bitkit/Services/CoreService.swift#L117

This should make the issue happen on every time the app is closed and reopened (after receving an LN payment).