### PR TITLE
fix(widgets): #392 allow scrolling when editing

### DIFF
--- a/Bitkit/Components/Core/DraggableItem.swift
+++ b/Bitkit/Components/Core/DraggableItem.swift
@@ -24,7 +24,7 @@ struct DraggableItem<Content: View, ID: Hashable>: View {
     private let itemHeight: CGFloat
 
     /// Minimum drag distance before reordering starts
-    private let minDragDistance: CGFloat = 0
+    private let minDragDistance: CGFloat = 10
 
     /// Called when a drag operation begins
     let onDragBegan: () -> Void
@@ -116,7 +116,7 @@ struct DraggableItem<Content: View, ID: Hashable>: View {
     }
 
     private var dragGesture: some Gesture {
-        DragGesture(minimumDistance: 0)
+        DragGesture(minimumDistance: minDragDistance)
             .onChanged { gesture in
                 let verticalMovement = abs(gesture.translation.height)
                 let startLocation = gesture.startLocation

--- a/Bitkit/Views/Wallets/HomeView.swift
+++ b/Bitkit/Views/Wallets/HomeView.swift
@@ -65,7 +65,6 @@ struct HomeView: View {
                     .padding(.bottom, 130)
                 }
             }
-            .scrollDisabled(isEditingWidgets)
 
             // Gradients layer
             VStack(spacing: 0) {


### PR DESCRIPTION
### Description

Allow scrolling home screen when editing widgets by assigning higher gesture priority to draggables.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit-ios/issues/392

### Screenshot / Video

https://github.com/user-attachments/assets/a07d64de-77d0-4f6b-8f99-9025bd41e2b0

