### PR TITLE
fix(receive): fix cjit order not found on channelReady

### DIFF
--- a/Bitkit/Components/TabBar/TabBar.swift
+++ b/Bitkit/Components/TabBar/TabBar.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TabBar: View {
     @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var sheets: SheetViewModel
+    @EnvironmentObject var wallet: WalletViewModel
 
     var shouldShow: Bool {
         if navigation.activeDrawerMenuItem == .wallet || navigation.activeDrawerMenuItem == .activity {
@@ -54,7 +55,11 @@ struct TabBar: View {
     }
 
     private func onReceivePress() {
-        if navigation.currentRoute == .spendingWallet {
+        let hasInboundCapacity = (wallet.totalInboundLightningSats ?? 0) > 0
+        let hasPendingTransfersToSpending = wallet.balanceInTransferToSpending > 0
+
+        if navigation.currentRoute == .spendingWallet && !hasInboundCapacity && !hasPendingTransfersToSpending {
+            // On spending wallet screen, show CJIT flow when user can't receive normally
             sheets.showSheet(.receive, data: ReceiveConfig(view: .cjitAmount))
         } else {
             sheets.showSheet(.receive)

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -728,6 +728,16 @@ extension LightningService {
         }
         return (trusted: trusted, nonTrusted: nonTrusted)
     }
+
+    /// Get a channel by ID from the channel cache
+    /// This is more reliable than using the cachedChannels array when handling events,
+    /// as the channelCache is updated immediately when channel events occur
+    func getChannelFromCache(channelId: ChannelId) async -> ChannelDetails? {
+        let channelIdString = channelId.description
+        return await MainActor.run {
+            channelCache[channelIdString]
+        }
+    }
 }
 
 // MARK: Events


### PR DESCRIPTION
### Description

- fixes an issue where the CJIT channel was not found on `.channelReady`, consequently no activity item was added and not `.receiveTx` sheet was shown
- also fixes the behavior of the "Receive" button on the TabBar when the user is on the spending wallet screen
