### PR TITLE
Fix: move e2e build to macos-latest

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -148,12 +148,6 @@ jobs:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
 
-      - name: Extract iOS app
-        working-directory: bitkit-e2e-tests/aut
-        run: |
-          unzip -q bitkit.app.zip
-          rm bitkit.app.zip
-
       - name: List iOS app directory contents
         run: ls -l bitkit-e2e-tests/aut
 


### PR DESCRIPTION
### Description

Some issues observed on hosted macmini in e2e flow in build step:
 - RPC/network issues (https://github.com/synonymdev/bitkit-ios/actions/runs/21357243807/job/61467447554?pr=401)
 - upload artifact stalled (https://github.com/synonymdev/bitkit-ios/actions/runs/21357243807/job/61469919899?pr=401) 
 
The latter seems to be known, but probably on-and-off issue on hosted macos runners, see:
 - https://github.com/actions/upload-artifact/issues/527
 - https://github.com/actions/upload-artifact/issues/623
 - https://github.com/actions/upload-artifact/issues/740
 
Tried few things to fix (bumping to v6 `upload_artifacts`, adding env `ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY=10`, removing actions cache), eventually switched to build on hosted `macos-latest` which seems to work.

Still e2e tests are run on mac-mini and `upload_artifacts` is used there, but hopefully the run artifacts are not that heavy and will work.
 

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Screenshot / Video

Insert relevant screenshot / recording
