### PR TITLE
fix: large font accessibility issues

### DIFF
--- a/Bitkit/Components/DrawerView.swift
+++ b/Bitkit/Components/DrawerView.swift
@@ -183,6 +183,7 @@ struct DrawerView: View {
                     .foregroundColor(.white)
                     .kerning(-1)
                     .padding(.vertical, 18)
+                    .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             }
             .frame(height: 56)
 

--- a/Bitkit/Components/EmptyStateView.swift
+++ b/Bitkit/Components/EmptyStateView.swift
@@ -36,7 +36,7 @@ struct EmptyStateView: View {
 
             HStack(alignment: .bottom, spacing: 0) {
                 DisplayText(t(type.localizationKey), accentColor: type.accentColor)
-                    .frame(width: 224)
+                    .frame(width: 240)
 
                 Image("empty-state-arrow")
                     .resizable()

--- a/Bitkit/Styles/TextStyle.swift
+++ b/Bitkit/Styles/TextStyle.swift
@@ -43,6 +43,7 @@ struct DisplayText: View {
         .textCase(.uppercase)
         .padding(.bottom, -9)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .dynamicTypeSize(...DynamicTypeSize.xxLarge)
     }
 }
 


### PR DESCRIPTION
### Description

This PR fixes text layout issues that occur when users have large accessibility text sizes enabled. At high Dynamic Type settings, text was breaking mid-word in the empty state view and drawer menu items were becoming too large to fit.

Changes:
- Limits Dynamic Type scaling to `xxLarge` for `DisplayText` and drawer menu items to prevent excessive text growth
- Increases empty state text frame width from 224 to 240 to accommodate longer words without mid-word breaks

### Linked Issues/Tasks

N/A

### Screenshot / Video

<!-- Before/after screenshots showing text at high accessibility settings -->