### PR TITLE
fix: lightning activities not displayed on spending wallet

### DIFF
--- a/Bitkit/ViewModels/ActivityListViewModel.swift
+++ b/Bitkit/ViewModels/ActivityListViewModel.swift
@@ -152,7 +152,7 @@ class ActivityListViewModel: ObservableObject {
             // Fetch all activities
             await updateFilteredActivities()
 
-            let lightningActivities = try await coreService.activity.get(filter: .lightning)
+            lightningActivities = try await coreService.activity.get(filter: .lightning)
 
             let onchain = try await coreService.activity.get(filter: .onchain)
             onchainActivities = await filterOutReplacedSentTransactions(onchain)


### PR DESCRIPTION
Fixes #411

### Description

This PR fixes a bug where lightning activities were not displayed on the spending wallet screen, even though they appeared in "show all".

The issue was a variable shadowing bug: `let lightningActivities = ...` created a local variable that shadowed the `@Published` class property, so the fetched activities were never assigned to the published property and the UI showed "No activity yet".

### Linked Issues/Tasks

- Fixes https://github.com/synonymdev/bitkit-ios/issues/411

### Screenshot / Video

N/A - bug fix