### PR TITLE
fix: add retry logic for channel monitor retrieval during migration

### DIFF
--- a/Bitkit/Services/MigrationsService.swift
+++ b/Bitkit/Services/MigrationsService.swift
@@ -1927,7 +1927,7 @@ extension MigrationsService {
                 if attempt < maxAttempts {
                     let delayMs = baseDelayMs * UInt64(attempt)
                     Logger.debug(
-                        "Retrying channel monitor retrieval for \(channelId) (attempt \(attempt + 1)/\(maxAttempts)) after \(delayMs)ms",
+                        "Retrying channel monitor retrieval for \(channelId) (attempt \(attempt + 1)/\(maxAttempts)) after \(delayMs)ms: \(error)",
                         context: "Migration"
                     )
                     try? await Task.sleep(nanoseconds: delayMs * 1_000_000)


### PR DESCRIPTION
### Description

This PR fixes a critical bug where channel monitor retrieval failures during migration from the React Native app were silently dropped, potentially causing permanent loss of Lightning channel state.

1. Adds `retrieveChannelMonitorWithRetry` method with configurable retry attempts and linear backoff
2. Implements parallel retrieval with proper error tracking for each channel
3. Logs individual failures with channel IDs for debugging
4. Validates expected vs retrieved monitor count with warnings

This is the iOS equivalent of the Android fix: https://github.com/synonymdev/bitkit-android/pull/760

### Linked Issues/Tasks

Related: https://github.com/synonymdev/bitkit-android/pull/760

### Screenshot / Video

N/A - internal migration logic fix