### PR TITLE
feat(ui): #314 prevent mnemonic screenshots

### DIFF
--- a/Bitkit/Components/ScreenshotPreventMask.swift
+++ b/Bitkit/Components/ScreenshotPreventMask.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import UIKit
+
+struct ScreenShotPreventMask: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UITextField()
+        view.isSecureTextEntry = true
+        view.text = ""
+        view.isUserInteractionEnabled = false
+
+        if let autoHideLayer = findAutoHideLayer(in: view) {
+            autoHideLayer.backgroundColor = UIColor.white.cgColor
+        } else {
+            view.layer.sublayers?.last?.backgroundColor = UIColor.white.cgColor
+        }
+
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    private func findAutoHideLayer(in view: UIView) -> CALayer? {
+        if let layers = view.layer.sublayers {
+            if let layer = layers.first(where: { layer in
+                layer.delegate.debugDescription.contains("UITextLayoutCanvasView")
+            }) {
+                return layer
+            }
+        }
+
+        return nil
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func screenshotPreventMask(_ isEnabled: Bool) -> some View {
+        if isEnabled {
+            mask(
+                ScreenShotPreventMask()
+                    .ignoresSafeArea()
+            )
+            .background(EmptyView())
+        } else {
+            self
+        }
+    }
+}

--- a/Bitkit/Views/Backup/BackupMnemonic.swift
+++ b/Bitkit/Views/Backup/BackupMnemonic.swift
@@ -53,7 +53,7 @@ struct BackupMnemonicView: View {
                     .padding(32)
                     .background(Color.gray6)
                     .blur(radius: showMnemonic ? 0 : 5)
-                    .privacySensitive()
+                    .screenshotPreventMask(true)
                     .accessibilityElement(children: .ignore)
                     .accessibilityIdentifier("SeedContainer")
                     .accessibilityLabel(mnemonicAccessibilityLabel)

--- a/Bitkit/Views/Onboarding/RestoreWalletView.swift
+++ b/Bitkit/Views/Onboarding/RestoreWalletView.swift
@@ -105,8 +105,13 @@ struct RestoreWalletView: View {
                 ScrollView(showsIndicators: false) {
                     VStack(spacing: 0) {
                         headerSection
-                        wordInputSection
-                        passphraseSection
+
+                        Group {
+                            wordInputSection
+                            passphraseSection
+                        }
+                        .screenshotPreventMask(true)
+
                         validationSection
                         Spacer(minLength: 16)
                         buttonSection

--- a/Bitkit/Views/Recovery/RecoveryMnemonicScreen.swift
+++ b/Bitkit/Views/Recovery/RecoveryMnemonicScreen.swift
@@ -54,7 +54,7 @@ struct RecoveryMnemonicScreen: View {
                             .padding(32)
                             .background(Color.white10)
                             .cornerRadius(16)
-                            .privacySensitive()
+                            .screenshotPreventMask(true)
 
                             // Passphrase section (if available)
                             if !passphrase.isEmpty {


### PR DESCRIPTION
### Description

- add screenshot prevention for views that show mnemonic/passphrase

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit-ios/issues/314

### QA Notes

Only works on real devices