### PR TITLE
fix(lightning): use external scores from blocktank

### DIFF
--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -161,6 +161,15 @@ enum Env {
         }
     }
 
+    static var ldkScorerUrl: String? {
+        switch network {
+        case .bitcoin: "https://api.blocktank.to/scorer.bin"
+        case .signet: nil
+        case .testnet: nil
+        case .regtest: "https://api.stag0.blocktank.to/scorer"
+        }
+    }
+
     // TODO: remove this to load from BT API instead
     static var trustedLnPeers: [LnPeer] {
         switch network {

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -95,6 +95,12 @@ class LightningService {
         )
         builder.setChainSourceElectrum(serverUrl: resolvedElectrumServerUrl, config: electrumConfig)
 
+        // Set pathfinding scores source from scorer.bin file
+        if let scorerUrl = Env.ldkScorerUrl {
+            Logger.info("Setting pathfinding scores source from scorer url: \(scorerUrl)")
+            builder.setPathfindingScoresSource(url: scorerUrl)
+        }
+
         // Configure gossip source from current settings
         configureGossipSource(builder: builder, rgsServerUrl: rgsServerUrl)
 


### PR DESCRIPTION
### Description

Configures ldk-node to use external scores hosted by Blocktank

### QA Notes

Test (large) payments to different nodes via either the probing tool in dev settings or make actual payments