### PR TITLE
chore: tighten migration workflow to v1.1.6 only

### DIFF
--- a/.github/workflows/e2e_migration.yml
+++ b/.github/workflows/e2e_migration.yml
@@ -124,8 +124,6 @@ jobs:
       matrix:
         rn_version:
           - v1.1.6
-          - v1.1.4
-          - v1.1.3
         scenario:
           - { name: migration_1-restore, setup_type: standard }
           - { name: migration_2-migration, setup_type: standard }
@@ -147,8 +145,6 @@ jobs:
       matrix:
         rn_version:
           - v1.1.6
-          - v1.1.4
-          - v1.1.3
         scenario:
           - { name: migration_1-restore, setup_type: standard, grep: "@migration_1" }
           - { name: migration_2-migration, setup_type: standard, grep: "@migration_2" }


### PR DESCRIPTION
### Description

This PR tightens the E2E migration workflow to run migration tests only from RN v1.1.6, removing v1.1.4 and v1.1.3 from the matrix.

Observed instability of macos-latest runners when many jobs run in parallel. Reducing the matrix from 3 RN versions to 1 cuts parallel load significantly (prepare-wallets and e2e-tests each run 4 jobs instead of 12). Migration from v1.1.6 is a good enough tradeoff for coverage while improving CI reliability.

### Linked Issues/Tasks

N/A

### Screenshot / Video

N/A
