### PR TITLE
feat(settings): LDK peer simulation debug UI

### DIFF
--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -213,12 +213,7 @@ class WalletViewModel: ObservableObject {
 
         syncState()
 
-        do {
-            let remotePeers = await fetchTrustedPeersFromBlocktank()
-            try await lightningService.connectToTrustedPeers(remotePeers: remotePeers)
-        } catch {
-            Logger.error("Failed to connect to trusted peers")
-        }
+        await reconnectTrustedPeers()
 
         // Migration only: fetch peers from remote backup (once) and persist in ldk-node
         let peerUris = await MigrationsService.shared.tryFetchMigrationPeersFromBackup(walletIndex: walletIndex)
@@ -276,6 +271,15 @@ class WalletViewModel: ObservableObject {
         }
         Logger.info("Fetched \(peers.count) trusted peers from Blocktank API")
         return peers.isEmpty ? nil : peers
+    }
+
+    func reconnectTrustedPeers() async {
+        do {
+            let remotePeers = await fetchTrustedPeersFromBlocktank()
+            try await lightningService.connectToTrustedPeers(remotePeers: remotePeers)
+        } catch {
+            Logger.error("Failed to connect to trusted peers")
+        }
     }
 
     func stopLightningNode(clearEventCallback: Bool = false) async throws {

--- a/Bitkit/Views/Settings/LdkDebugScreen.swift
+++ b/Bitkit/Views/Settings/LdkDebugScreen.swift
@@ -124,6 +124,7 @@ struct LdkDebugScreen: View {
             isRestartingNode = true
             let lightningService = LightningService.shared
             try await lightningService.restart()
+            await wallet.reconnectTrustedPeers()
             app.toast(type: .success, title: "Node Restarted", description: "Node restarted successfully")
         } catch {
             Logger.error("Failed to restart node: \(error)")


### PR DESCRIPTION
## Summary

- Add **Peer Simulation** segmented picker to LDK Debug screen for testing Blocktank peer connection edge cases
- Add `BlocktankPeerSimulation` enum to `WalletViewModel` with simulation modes: None, API Failure, Unreachable Peers

Stacked on #456.

## Changes

| File | Change |
| --- | --- |
| `WalletViewModel.swift` | Add `BlocktankPeerSimulation` enum, static var, and simulation switch in `fetchTrustedPeersFromBlocktank()` |
| `LdkDebugScreen.swift` | Add "Peer Simulation" segmented picker in the LDK Debug screen (after "Node" section) |

## Test plan

- [ ] Build & run (Cmd+R)
- [ ] Navigate: Settings → Dev Settings → LDK Debug
- [ ] Verify "Peer Simulation" segmented picker is visible below "Node" section
- [ ] Select "API Failure", tap Restart — confirm fallback to env peers
- [ ] Select "Unreachable Peers", tap Restart — confirm verification fallback logic