### PR TITLE
fix(lightning): update external scorer url

### DIFF
--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -163,7 +163,7 @@ enum Env {
 
     static var ldkScorerUrl: String? {
         switch network {
-        case .bitcoin: "https://api.blocktank.to/scorer.bin"
+        case .bitcoin: "https://api.blocktank.to/scorer-prod"
         case .signet: nil
         case .testnet: nil
         case .regtest: "https://api.stag0.blocktank.to/scorer"

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -95,7 +95,7 @@ class LightningService {
         )
         builder.setChainSourceElectrum(serverUrl: resolvedElectrumServerUrl, config: electrumConfig)
 
-        // Set pathfinding scores source from scorer.bin file
+        // Set pathfinding scores source from external scorer
         if let scorerUrl = Env.ldkScorerUrl {
             Logger.info("Setting pathfinding scores source from scorer url: \(scorerUrl)")
             builder.setPathfindingScoresSource(url: scorerUrl)


### PR DESCRIPTION
### Description

- update external scorer source to new Blocktank scorer

Same as https://github.com/synonymdev/bitkit-android/pull/805