### PR TITLE
chore: run workflows on PR ready

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,7 @@ on:
         required: false
         default: "default-feature-branch"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   TERM: xterm-256color

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   validate:


### PR DESCRIPTION
### Description

Run workflows when PR state changes from 'draft' to 'ready for review'.

From https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request

> By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. To trigger workflows by different activity types, use the types keyword.