### PR TITLE
Fix: Show savings activity list when balance is zero but activities exist

### DIFF
--- a/Bitkit/Views/Wallets/SavingsWalletView.swift
+++ b/Bitkit/Views/Wallets/SavingsWalletView.swift
@@ -6,6 +6,12 @@ struct SavingsWalletView: View {
     @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var wallet: WalletViewModel
 
+    /// Whether there are any onchain activities to display
+    private var hasOnchainActivities: Bool {
+        guard let activities = activity.onchainActivities else { return false }
+        return !activities.isEmpty
+    }
+
     /// Calculate remaining duration for force close transfers
     private var forceCloseRemainingDuration: String? {
         guard let claimableAtHeight = wallet.forceCloseClaimableAtHeight,
@@ -42,8 +48,8 @@ struct SavingsWalletView: View {
                     .padding(.top, 16)
                 }
 
-                if wallet.totalOnchainSats > 0 {
-                    if !GeoService.shared.isGeoBlocked {
+                if wallet.totalOnchainSats > 0 || hasOnchainActivities {
+                    if wallet.totalOnchainSats > 0, !GeoService.shared.isGeoBlocked {
                         transferButton
                             .transition(.move(edge: .leading).combined(with: .opacity))
                             .padding(.top, 32)
@@ -96,7 +102,7 @@ struct SavingsWalletView: View {
         .navigationBarHidden(true)
         .animation(.spring(response: 0.3), value: wallet.totalOnchainSats)
         .overlay {
-            if wallet.totalOnchainSats == 0 {
+            if wallet.totalOnchainSats == 0 && !hasOnchainActivities {
                 EmptyStateView(type: .savings)
                     .padding(.horizontal)
                     .transition(.move(edge: .trailing).combined(with: .opacity))

--- a/Bitkit/Views/Wallets/SpendingWalletView.swift
+++ b/Bitkit/Views/Wallets/SpendingWalletView.swift
@@ -6,6 +6,12 @@ struct SpendingWalletView: View {
     @EnvironmentObject var navigation: NavigationViewModel
     @EnvironmentObject var wallet: WalletViewModel
 
+    /// Whether there are any lightning activities to display
+    private var hasLightningActivities: Bool {
+        guard let activities = activity.lightningActivities else { return false }
+        return !activities.isEmpty
+    }
+
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
@@ -27,8 +33,8 @@ struct SpendingWalletView: View {
                         .padding(.top, 16)
                 }
 
-                if wallet.totalLightningSats > 0 {
-                    if let channels = wallet.channels, !channels.isEmpty {
+                if wallet.totalLightningSats > 0 || hasLightningActivities {
+                    if wallet.totalLightningSats > 0, let channels = wallet.channels, !channels.isEmpty {
                         transferButton
                             .transition(.move(edge: .leading).combined(with: .opacity))
                             .padding(.top, 32)
@@ -81,7 +87,7 @@ struct SpendingWalletView: View {
         .navigationBarHidden(true)
         .animation(.spring(response: 0.3), value: wallet.totalLightningSats)
         .overlay {
-            if wallet.totalLightningSats == 0 {
+            if wallet.totalLightningSats == 0 && !hasLightningActivities {
                 EmptyStateView(type: .spending)
                     .padding(.horizontal)
                     .transition(.move(edge: .trailing).combined(with: .opacity))


### PR DESCRIPTION
## Summary

Fixes #464 — When savings balance is `0`, tapping the savings card showed the generic "SEND BITCOIN TO YOUR SAVING BALANCE" empty state screen instead of the savings activity list.

## Root Cause

In `SavingsWalletView`, the activity list (ScrollView with ActivityList) was only rendered when `wallet.totalOnchainSats > 0`. When balance reached zero (e.g., after transferring all funds to spending), the view fell through to the `EmptyStateView` overlay, hiding all transaction history.

## Changes

- **`SavingsWalletView.swift`**: Show activity list when balance > 0 OR when there are onchain activities. Only show empty state when both balance is zero AND no activities exist. Transfer button remains gated behind positive balance.
- **`SpendingWalletView.swift`**: Applied the same fix for consistency — show activity list when balance > 0 OR when there are lightning activities.

## Testing

- Have on-chain funds
- Transfer all funds from savings to spending
- Tap on savings card → should show the activity list with past transactions
- Fresh wallet with no history → should still show the empty state screen
- Same behavior verified for spending wallet view