### PR TITLE
chore: update ldk-node to rc.32

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -928,7 +928,7 @@
 			repositoryURL = "https://github.com/synonymdev/ldk-node";
 			requirement = {
 				kind = revision;
-				revision = 6f6bc44526695d4c5c6b2bb578aaba48b66f6c2c;
+				revision = c5698d00066e0e50f33696afc562d71023da2373;
 			};
 		};
 		96DEA0382DE8BBA1009932BF /* XCRemoteSwiftPackageReference "bitkit-core" */ = {

--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/synonymdev/ldk-node",
       "state" : {
-        "revision" : "6f6bc44526695d4c5c6b2bb578aaba48b66f6c2c"
+        "revision" : "c5698d00066e0e50f33696afc562d71023da2373"
       }
     },
     {


### PR DESCRIPTION
### Description

Bumps `ldk-node` version to rc.32