### PR TITLE
fix(lightning): fix orphaned channels migration

### DIFF
--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -27,7 +27,7 @@ class WalletViewModel: ObservableObject {
     @Published var availableUtxos: [SpendableUtxo] = []
     @Published var isMaxAmountSend: Bool = false
 
-    // LNURL withdraw flow
+    /// LNURL withdraw flow
     @Published var lnurlWithdrawAmount: UInt64?
 
     // For bolt11 details and bip21 params
@@ -142,7 +142,8 @@ class WalletViewModel: ObservableObject {
                 let (remoteMigration, allRetrieved) = await fetchOrphanedChannelMonitorsIfNeeded(walletIndex: walletIndex)
                 if let remoteMigration {
                     channelMigration = ChannelDataMigration(
-                        channelManager: [UInt8](remoteMigration.channelManager),
+                        // don't overwrite channel manager, we only need the monitors for the sweep
+                        channelManager: nil,
                         channelMonitors: remoteMigration.channelMonitors.map { [UInt8]($0) }
                     )
                     MigrationsService.shared.pendingChannelMigration = nil


### PR DESCRIPTION
### Description

Don't overwrite channel manager, we only need the monitors to sweep the funds from force closed channels

### Screenshot / Video

https://github.com/user-attachments/assets/15494924-032e-47d9-8ff9-030503dc2a54

[logs.txt](https://github.com/user-attachments/files/25791346/logs.txt)

### Repro steps

1. Install RN app (master)
2. Open channel
3. Backup seed
4. Delete RN app
5. Install native app (modified: fail to retrieve channel monitor & disable orphaned channel recovery)
6. Restore from seed (channel is lost w/o sweep)
7. Open new channel
8. Update app (master)
9. new channel force closed
