### PR TITLE
fix(boost): show correct duration after RBF boost

### DIFF
--- a/Bitkit/Services/CoreService.swift
+++ b/Bitkit/Services/CoreService.swift
@@ -1189,8 +1189,10 @@ class ActivityService {
 
                 Logger.info("RBF transaction created successfully: \(txid)", context: "CoreService.boostOnchainTransaction")
 
-                // For RBF, mark the original activity as boosted until the replacement comes
+                // For RBF, mark the original activity as boosted and update the fee rate
+                // so the UI shows the correct confirmation time estimate until the replacement arrives
                 onchainActivity.isBoosted = true
+                onchainActivity.feeRate = UInt64(feeRate)
                 try await self.update(id: activityId, activity: .onchain(onchainActivity))
                 Logger.info(
                     "Successfully marked activity \(activityId) as replaced by fee",


### PR DESCRIPTION
This PR fixes the confirmation time estimate shown on a boosted activity item after an RBF fee bump.

### Description

After boosting an outgoing transaction via RBF, the original activity item remained visible with `isBoosted = true` while showing the old (pre-boost) fee rate. This caused the confirmation time label to display the wrong estimate — e.g. "+2 hours" instead of "+10 minutes".

The fix updates the `feeRate` on the original activity at the same time it is marked as boosted, so the UI immediately reflects the correct confirmation time. Once the replacement transaction is detected on-chain the original is filtered out anyway, so this only affects the interim display window.

### Linked Issues/Tasks

Part of #452 (fee rate duration display)

### Screenshot / Video

N/A (label now shows correct time estimate immediately after tapping Boost)