### PR TITLE
fix(ui): re-enable swipe-to-back gesture

### DIFF
--- a/Bitkit/Extensions/UINavigationController+SwipeBack.swift
+++ b/Bitkit/Extensions/UINavigationController+SwipeBack.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+/// Shared state for swipe-back gesture. Views can set this via the `.allowSwipeBack(_:)` modifier
+/// to disable the gesture on screens that don't show a back button (e.g. SheetHeader without back).
+enum SwipeBackState {
+    /// When false, the interactive pop gesture is disabled. Set by views that hide the back button.
+    static var allowSwipeBack: Bool = true
+}
+
+/// Re-enables the interactive swipe-back gesture when the navigation bar is hidden
+/// (e.g. when using a custom NavigationBar with `.navigationBarHidden(true)`).
+/// Without this, the system disables the gesture when the bar is hidden.
+/// Use `.allowSwipeBack(false)` on views that don't show a back button to disable the gesture there.
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        // Only allow swipe-back when not at root — avoids iOS 17+ freeze when re-pushing after swiping to root
+        guard viewControllers.count > 1 else { return false }
+        return SwipeBackState.allowSwipeBack
+    }
+}

--- a/Bitkit/Extensions/View+AllowSwipeBack.swift
+++ b/Bitkit/Extensions/View+AllowSwipeBack.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+extension View {
+    /// Controls whether the interactive swipe-back gesture is enabled on this screen.
+    /// Use `.allowSwipeBack(false)` on screens that use a custom header without a back button
+    /// (e.g. `SheetHeader` with default `showBackButton: false`) so users can't swipe to dismiss.
+    /// Default is `true`; only apply this modifier when you want to disable the gesture.
+    func allowSwipeBack(_ allowed: Bool) -> some View {
+        modifier(AllowSwipeBackModifier(allowed: allowed))
+    }
+}
+
+private struct AllowSwipeBackModifier: ViewModifier {
+    let allowed: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { SwipeBackState.allowSwipeBack = allowed }
+            .onDisappear { SwipeBackState.allowSwipeBack = true }
+    }
+}

--- a/Bitkit/Views/Backup/BackupMnemonic.swift
+++ b/Bitkit/Views/Backup/BackupMnemonic.swift
@@ -99,6 +99,7 @@ struct BackupMnemonicView: View {
             .padding(.horizontal, 16)
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Bitkit/Views/Backup/BackupPassphrase.swift
+++ b/Bitkit/Views/Backup/BackupPassphrase.swift
@@ -7,7 +7,7 @@ struct BackupPassphrase: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SheetHeader(title: t("security__pass_your"))
+            SheetHeader(title: t("security__pass_your"), showBackButton: true)
 
             VStack(spacing: 0) {
                 BodyMText(t("security__pass_text"))

--- a/Bitkit/Views/Gift/GiftError.swift
+++ b/Bitkit/Views/Gift/GiftError.swift
@@ -30,6 +30,7 @@ struct GiftFailed: View {
             }
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
         .accessibilityIdentifier("GiftError")

--- a/Bitkit/Views/Gift/GiftUsed.swift
+++ b/Bitkit/Views/Gift/GiftUsed.swift
@@ -30,6 +30,7 @@ struct GiftUsed: View {
             }
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
         .accessibilityIdentifier("GiftUsed")

--- a/Bitkit/Views/Gift/GiftUsedUp.swift
+++ b/Bitkit/Views/Gift/GiftUsedUp.swift
@@ -30,6 +30,7 @@ struct GiftUsedUp: View {
             }
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
         .accessibilityIdentifier("GiftUsedUp")

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityBiometrics.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityBiometrics.swift
@@ -60,6 +60,7 @@ struct SecurityBiometrics: View {
             .padding(.horizontal, 16)
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
         .alert(

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecurityPin.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecurityPin.swift
@@ -52,6 +52,7 @@ struct SecurityPin: View {
             }
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .sheetBackground()
     }
 

--- a/Bitkit/Views/Settings/Security/SecuritySheet/SecuritySuccess.swift
+++ b/Bitkit/Views/Settings/Security/SecuritySheet/SecuritySuccess.swift
@@ -60,6 +60,7 @@ struct SecuritySuccess: View {
             .padding(.horizontal, 16)
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
     }

--- a/Bitkit/Views/Transfer/FundManualSuccessView.swift
+++ b/Bitkit/Views/Transfer/FundManualSuccessView.swift
@@ -47,7 +47,7 @@ struct FundManualSuccessView: View {
             .accessibilityIdentifier("ExternalSuccess")
         }
         .navigationBarHidden(true)
-        .interactiveDismissDisabled()
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
     }
 }

--- a/Bitkit/Views/Transfer/SavingsProgressView.swift
+++ b/Bitkit/Views/Transfer/SavingsProgressView.swift
@@ -42,7 +42,7 @@ struct SavingsProgressContentView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            NavigationBar(title: navTitle)
+            NavigationBar(title: navTitle, showBackButton: false)
                 .padding(.bottom, 16)
 
             DisplayText(title, accentColor: .brandAccent)
@@ -113,9 +113,9 @@ struct SavingsProgressContentView: View {
             .accessibilityIdentifierIfPresent(progressState == .success ? "TransferSuccess-button" : nil)
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .bottomSafeAreaPadding()
-        .interactiveDismissDisabled()
     }
 }
 

--- a/Bitkit/Views/Transfer/SettingUpView.swift
+++ b/Bitkit/Views/Transfer/SettingUpView.swift
@@ -194,9 +194,9 @@ struct SettingUpView: View {
             }
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .bottomSafeAreaPadding()
-        .interactiveDismissDisabled()
         .onAppear {
             Logger.debug("View appeared - TransferViewModel is handling order updates")
 

--- a/Bitkit/Views/Wallets/Send/SendFailure.swift
+++ b/Bitkit/Views/Wallets/Send/SendFailure.swift
@@ -31,6 +31,7 @@ struct SendFailure: View {
                 .padding(.horizontal, 16)
             }
             .navigationBarHidden(true)
+            .allowSwipeBack(false)
             .sheetBackground()
         }
     }

--- a/Bitkit/Views/Wallets/Send/SendPendingScreen.swift
+++ b/Bitkit/Views/Wallets/Send/SendPendingScreen.swift
@@ -70,6 +70,7 @@ struct SendPendingScreen: View {
             }
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Bitkit/Views/Wallets/Send/SendQuickpay.swift
+++ b/Bitkit/Views/Wallets/Send/SendQuickpay.swift
@@ -72,6 +72,7 @@ struct SendQuickpay: View {
             DisplayText(t("wallet__send_quickpay__title"), accentColor: .purpleAccent)
         }
         .navigationBarHidden(true)
+        .allowSwipeBack(false)
         .padding(.horizontal, 16)
         .sheetBackground()
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Bitkit/Views/Wallets/Send/SendSuccess.swift
+++ b/Bitkit/Views/Wallets/Send/SendSuccess.swift
@@ -77,6 +77,7 @@ struct SendSuccess: View {
                 .padding(.horizontal, 16)
             }
             .navigationBarHidden(true)
+            .allowSwipeBack(false)
             .sheetBackground()
         }
         .task {


### PR DESCRIPTION
### Description

We are using a custom `NavigationBar` and hiding the system bar with `.navigationBarHidden(true)` on each screen. In SwiftUI, that hides the UINavigationController’s navigation bar. The interactive pop gesture (swipe from the left edge) is managed by that same navigation controller, and when the bar is hidden the system disables that gesture. This re-enables the interactive pop gesture by configuring the underlying `UINavigationController` and allows the gesture when there is more than one view controller on the stack, except when explicitly disabled with by using `.allowSwipeBack(false)`

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit-ios/issues/423

### Screenshot / Video

https://github.com/user-attachments/assets/f800f3ba-5d66-4b4f-8f25-ec7061865649

### QA Notes

- check for quirks/freezes
- should only be able to navigate back on screens that have a back button