### PR TITLE
feat: one-time stale channel monitor recovery (v2)

### DIFF
--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -9,6 +9,17 @@ class LightningService {
     private var node: Node?
     var currentWalletIndex: Int = 0
 
+    // MARK: - Stale monitor recovery (one-time recovery for channel monitor desync)
+
+    private static let staleMonitorRecoveryAttemptedKey = "staleMonitorRecoveryAttempted"
+
+    /// Whether we've already attempted stale monitor recovery (prevents infinite retry).
+    /// Persisted so the retry only happens once, even across app restarts.
+    private static var staleMonitorRecoveryAttempted: Bool {
+        get { UserDefaults.standard.bool(forKey: staleMonitorRecoveryAttemptedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: staleMonitorRecoveryAttemptedKey) }
+    }
+
     private let syncStatusChangedSubject = PassthroughSubject<UInt64, Never>()
 
     private var channelCache: [String: ChannelDetails] = [:]
@@ -124,20 +135,57 @@ class LightningService {
         builder.setEntropyBip39Mnemonic(mnemonic: mnemonic, passphrase: passphrase)
 
         try await ServiceQueue.background(.ldk) {
-            if !lnurlAuthServerUrl.isEmpty {
-                self.node = try builder.buildWithVssStore(
-                    vssUrl: vssUrl,
-                    storeId: storeId,
-                    lnurlAuthServerUrl: lnurlAuthServerUrl,
-                    fixedHeaders: [:]
+            do {
+                if !lnurlAuthServerUrl.isEmpty {
+                    self.node = try builder.buildWithVssStore(
+                        vssUrl: vssUrl,
+                        storeId: storeId,
+                        lnurlAuthServerUrl: lnurlAuthServerUrl,
+                        fixedHeaders: [:]
+                    )
+                } else {
+                    self.node = try builder.buildWithVssStoreAndFixedHeaders(
+                        vssUrl: vssUrl,
+                        storeId: storeId,
+                        fixedHeaders: [:]
+                    )
+                }
+            } catch let error as BuildError {
+                guard case .ReadFailed = error, !Self.staleMonitorRecoveryAttempted else {
+                    throw error
+                }
+
+                // Build failed with ReadFailed — likely a stale ChannelMonitor (DangerousValue).
+                // Retry once with accept_stale_channel_monitors to recover.
+                Logger.warn(
+                    "Build failed with ReadFailed. Retrying with accept_stale_channel_monitors for one-time recovery.",
+                    context: "Recovery"
                 )
-            } else {
-                self.node = try builder.buildWithVssStoreAndFixedHeaders(
-                    vssUrl: vssUrl,
-                    storeId: storeId,
-                    fixedHeaders: [:]
-                )
+                Self.staleMonitorRecoveryAttempted = true
+                builder.setAcceptStaleChannelMonitors(accept: true)
+
+                if !lnurlAuthServerUrl.isEmpty {
+                    self.node = try builder.buildWithVssStore(
+                        vssUrl: vssUrl,
+                        storeId: storeId,
+                        lnurlAuthServerUrl: lnurlAuthServerUrl,
+                        fixedHeaders: [:]
+                    )
+                } else {
+                    self.node = try builder.buildWithVssStoreAndFixedHeaders(
+                        vssUrl: vssUrl,
+                        storeId: storeId,
+                        fixedHeaders: [:]
+                    )
+                }
+                Logger.info("Stale monitor recovery: build succeeded with accept_stale", context: "Recovery")
             }
+        }
+
+        // Mark recovery as attempted after any successful build (whether recovery was needed or not).
+        // This ensures unaffected users never trigger the retry path on future startups.
+        if !Self.staleMonitorRecoveryAttempted {
+            Self.staleMonitorRecoveryAttempted = true
         }
 
         Logger.info("LDK node setup")


### PR DESCRIPTION
### Description

This PR adds automatic one-time recovery for users affected by stale channel monitors caused by the RN migration overwrite bug (#462, #495).

On `BuildError.ReadFailed`, the app automatically retries the LDK node build once with `accept_stale_channel_monitors` enabled. A persisted `staleMonitorRecoveryAttempted` UserDefaults flag ensures this only happens once — the flag is set on any successful build, so unaffected users see zero impact.

This is a clean cherry-pick of the recovery logic from #500 onto `release-2.1.1`, without the unrelated pubky work that was in the original branch.

### Linked Issues/Tasks

- Supersedes #500 (same fix, cleaner branch base)
- Related: #462, #480, #495
- Depends on: [synonymdev/ldk-node#76](https://github.com/synonymdev/ldk-node/pull/76)

### Screenshot / Video

N/A - backend logic change

### QA Notes

1. Reproduce the stale monitor state (overwrite a channel monitor in VSS with an older update_id)
2. Launch the app — first build fails with ReadFailed
3. Verify the retry succeeds and the node starts
4. Check logs for "Stale monitor recovery: build succeeded with accept_stale"
5. Kill and relaunch — verify normal startup (no retry triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)