### PR TITLE
chore: use e2e updater url for e2e builds

### DIFF
--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -277,7 +277,12 @@ enum Env {
     static let playStoreUrl = "https://play.google.com/store/apps/details?id=to.bitkit"
     static let githubUrl = "https://www.github.com/synonymdev/bitkit"
     static let githubReleasesUrl = "https://www.github.com/synonymdev/bitkit/releases"
-    static let updaterUrl = "https://github.com/synonymdev/bitkit/releases/download/updater/release.json"
+    static var updaterUrl: String {
+        isE2E
+            ? "https://github.com/synonymdev/bitkit-e2e-tests/releases/download/updater/release.json"
+            : "https://github.com/synonymdev/bitkit/releases/download/updater/release.json"
+    }
+
     static let termsOfServiceUrl = "https://www.bitkit.to/terms-of-use"
     static let privacyPolicyUrl = "https://www.bitkit.to/privacy-policy"
     static let geoCheckUrl = "https://api1.blocktank.to/api/geocheck"


### PR DESCRIPTION
This PR points E2E builds to a separate updater release.json hosted in bitkit-e2e-tests, so production critical updates don't block E2E test runs.

### Description

The production updater currently has `critical: true` for both platforms. E2E builds from master with lower build numbers hit the blocking update screen immediately, making all tests fail.

When `isE2E` is true, `updaterUrl` now resolves to:
`https://github.com/synonymdev/bitkit-e2e-tests/releases/download/updater/release.json`

That file has `buildNumber: 0, critical: false` by default, so E2E builds are never blocked. When update flow testing is needed, the E2E release.json can be updated independently.

### Linked Issues/Tasks

N/A

### Screenshot / Video

N/A

Made with [Cursor](https://cursor.com)