### PR TITLE
feat: ignore critical update UI on debug mode

### DIFF
--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -36,7 +36,7 @@ struct AppScene: View {
 
     /// Check if there's a critical update available
     private var hasCriticalUpdate: Bool {
-        AppUpdateService.shared.availableUpdate?.critical == true
+        AppUpdateService.shared.availableUpdate?.critical == true && !Env.isDebug
     }
 
     init() {


### PR DESCRIPTION
### Description

This PR skips the critical update UI when the app is running in debug mode. This prevents the critical update screen from blocking development and testing workflows.

### Linked Issues/Tasks

N/A

### Screenshot / Video

N/A