### PR TITLE
chore: bump github actions for node 24

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
       actions: read        # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for git operations
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       code: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.code == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -68,7 +68,7 @@ jobs:
           brew install xcbeautify
 
       - name: Cache Swift Package Manager
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -123,7 +123,7 @@ jobs:
           cp -r DerivedData/Build/Products/Debug-iphonesimulator/Bitkit.app e2e-app/bitkit.app
 
       - name: Upload iOS app (local)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: e2e-app/
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -156,7 +156,7 @@ jobs:
           brew install xcbeautify
 
       - name: Cache Swift Package Manager
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -212,7 +212,7 @@ jobs:
           cp -r DerivedData/Build/Products/Debug-iphonesimulator/Bitkit.app e2e-app/bitkit.app
 
       - name: Upload iOS app (regtest)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bitkit-e2e-ios-regtest_${{ github.run_number }}
           path: e2e-app/
@@ -249,14 +249,14 @@ jobs:
         run: echo $E2E_BRANCH
 
       - name: Clone E2E tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
           ref: ${{ needs.e2e-branch.outputs.branch }}
 
       - name: Download iOS app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -265,12 +265,12 @@ jobs:
         run: ls -l bitkit-e2e-tests/aut
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
       - name: Cache npm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -388,14 +388,14 @@ jobs:
         run: echo $E2E_BRANCH
 
       - name: Clone E2E tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
           ref: ${{ needs.e2e-branch.outputs.branch }}
 
       - name: Download iOS app (regtest)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: bitkit-e2e-ios-regtest_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -404,12 +404,12 @@ jobs:
         run: ls -l bitkit-e2e-tests/aut
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
       - name: Cache npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -497,7 +497,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-artifacts-regtest_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/e2e_migration.yml
+++ b/.github/workflows/e2e_migration.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -48,7 +48,7 @@ jobs:
           brew install xcbeautify
 
       - name: Cache Swift Package Manager
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -103,7 +103,7 @@ jobs:
           cp -r DerivedData/Build/Products/Debug-iphonesimulator/Bitkit.app e2e-app/bitkit.app
 
       - name: Upload iOS app (regtest)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: e2e-app/
@@ -163,20 +163,20 @@ jobs:
         run: echo $E2E_BRANCH
 
       - name: Clone E2E tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
           ref: ${{ needs.e2e-branch.outputs.branch }}
 
       - name: Download iOS app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
 
       - name: Download migration env
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: migration-env_${{ matrix.rn_version }}_${{ matrix.scenario.name }}
           path: bitkit-e2e-tests/artifacts
@@ -210,12 +210,12 @@ jobs:
         run: ls -la bitkit-e2e-tests/aut
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
       - name: Cache npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -315,7 +315,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.scenario.name }})
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-artifacts_${{ matrix.scenario.name }}_${{ matrix.rn_version }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -34,7 +34,7 @@ jobs:
           brew install xcbeautify
 
       - name: Cache Swift Package Manager
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -92,7 +92,7 @@ jobs:
           exit 1
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: integration-test-results

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -33,7 +33,7 @@ jobs:
           brew install xcbeautify
 
       - name: Cache Swift Package Manager
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -76,7 +76,7 @@ jobs:
           echo "✅ Unit tests completed at $(date)"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure()
         with:
           name: test-results

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: "18"
 


### PR DESCRIPTION
### Description

This PR bumps official GitHub Actions to releases that target Node.js 24 on runners (`actions/checkout` v6, `actions/cache` v5, `actions/upload-artifact` / `download-artifact` v6, `actions/setup-node` v5), addressing the deprecation warning for Node.js 20–based action runtimes.

### Linked Issues/Tasks

N/A — CI maintenance to stay ahead of the [Node 20 deprecation on GitHub Actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

### Screenshot / Video

### QA Notes

#### 1. CI
1. Open a workflow run for this branch (e.g. unit tests, integration tests, or e2e if applicable).
2. Confirm the run completes successfully.
3. Confirm the job summary no longer lists the updated actions under the Node.js 20 deprecation notice.
