### PR TITLE
fix: replace Zip dependency with native ZipService

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -13,8 +13,6 @@
 		3D76260F4C9C4A53B1E4A001 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D76260E4C9C4A53B1E4A001 /* CoreBluetooth.framework */; };
 		3D7626104C9C4A53B1E4A001 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D76260E4C9C4A53B1E4A001 /* CoreBluetooth.framework */; };
 		4AAB08CA2E1FE77600BA63DF /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 4AAB08C92E1FE77600BA63DF /* Lottie */; };
-		4AFCA3702E05933800205CAE /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = 4AFCA36F2E05933800205CAE /* Zip */; };
-		4AFCA3722E0596D900205CAE /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = 4AFCA3712E0596D900205CAE /* Zip */; };
 		961058E32C355B5500E1F1D8 /* BitkitNotification.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 961058DC2C355B5500E1F1D8 /* BitkitNotification.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		968FDF162DFAFE230053CD7F /* LDKNode in Frameworks */ = {isa = PBXBuildFile; productRef = 9613018B2C5022D700878183 /* LDKNode */; };
 		968FE1402DFB016B0053CD7F /* LDKNode in Frameworks */ = {isa = PBXBuildFile; productRef = 968FE13F2DFB016B0053CD7F /* LDKNode */; };
@@ -158,7 +156,6 @@
 				3D7626104C9C4A53B1E4A001 /* CoreBluetooth.framework in Frameworks */,
 				968FE1402DFB016B0053CD7F /* LDKNode in Frameworks */,
 				96DEA03C2DE8BBAB009932BF /* BitkitCore in Frameworks */,
-				4AFCA3722E0596D900205CAE /* Zip in Frameworks */,
 				96E493A82C943184000E8BC2 /* secp256k1 in Frameworks */,
 				18D65E022EB964BD00252335 /* VssRustClientFfi in Frameworks */,
 			);
@@ -170,7 +167,6 @@
 			files = (
 				182817C12F59A7F10055A441 /* Paykit in Frameworks */,
 				3D76260F4C9C4A53B1E4A001 /* CoreBluetooth.framework in Frameworks */,
-				4AFCA3702E05933800205CAE /* Zip in Frameworks */,
 				968FDF162DFAFE230053CD7F /* LDKNode in Frameworks */,
 				18D65E002EB964B500252335 /* VssRustClientFfi in Frameworks */,
 				96E493A42C942FD1000E8BC2 /* secp256k1 in Frameworks */,
@@ -248,7 +244,6 @@
 			packageProductDependencies = (
 				96E493A72C943184000E8BC2 /* secp256k1 */,
 				96DEA03B2DE8BBAB009932BF /* BitkitCore */,
-				4AFCA3712E0596D900205CAE /* Zip */,
 				968FE13F2DFB016B0053CD7F /* LDKNode */,
 				18D65E012EB964BD00252335 /* VssRustClientFfi */,
 			);
@@ -280,7 +275,6 @@
 				96E493A32C942FD1000E8BC2 /* secp256k1 */,
 				96E20CD32CB6D91A00C24149 /* CodeScanner */,
 				96DEA0392DE8BBA1009932BF /* BitkitCore */,
-				4AFCA36F2E05933800205CAE /* Zip */,
 				4AAB08C92E1FE77600BA63DF /* Lottie */,
 				18D65DFF2EB964B500252335 /* VssRustClientFfi */,
 				182817C02F59A7F10055A441 /* Paykit */,
@@ -387,7 +381,6 @@
 				96E493A22C942FD1000E8BC2 /* XCRemoteSwiftPackageReference "swift-secp256k1" */,
 				96E20CD22CB6D91A00C24149 /* XCRemoteSwiftPackageReference "CodeScanner" */,
 				96DEA0382DE8BBA1009932BF /* XCRemoteSwiftPackageReference "bitkit-core" */,
-				4AFCA36E2E05933800205CAE /* XCRemoteSwiftPackageReference "Zip" */,
 				968FE13E2DFB016B0053CD7F /* XCRemoteSwiftPackageReference "ldk-node" */,
 				4AAB08C82E1FE77600BA63DF /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				18D65DFE2EB9649F00252335 /* XCRemoteSwiftPackageReference "vss-rust-client-ffi" */,
@@ -931,14 +924,6 @@
 				minimumVersion = 4.5.2;
 			};
 		};
-		4AFCA36E2E05933800205CAE /* XCRemoteSwiftPackageReference "Zip" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/marmelroy/Zip.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.1.2;
-			};
-		};
 		968FE13E2DFB016B0053CD7F /* XCRemoteSwiftPackageReference "ldk-node" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/synonymdev/ldk-node";
@@ -993,16 +978,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4AAB08C82E1FE77600BA63DF /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
-		};
-		4AFCA36F2E05933800205CAE /* Zip */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4AFCA36E2E05933800205CAE /* XCRemoteSwiftPackageReference "Zip" */;
-			productName = Zip;
-		};
-		4AFCA3712E0596D900205CAE /* Zip */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4AFCA36E2E05933800205CAE /* XCRemoteSwiftPackageReference "Zip" */;
-			productName = Zip;
 		};
 		9613018B2C5022D700878183 /* LDKNode */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,15 +60,6 @@
         "branch" : "master",
         "revision" : "9f01c135c7e22e594bb1dee749130b82b505ab5e"
       }
-    },
-    {
-      "identity" : "zip",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/marmelroy/Zip.git",
-      "state" : {
-        "revision" : "67fa55813b9e7b3b9acee9c0ae501def28746d76",
-        "version" : "2.1.2"
-      }
     }
   ],
   "version" : 3

--- a/Bitkit/Services/LogService.swift
+++ b/Bitkit/Services/LogService.swift
@@ -1,8 +1,8 @@
 import Foundation
-import Zip
 
 class LogService {
     static let shared = LogService()
+    private let zipService = ZipService()
 
     private init() {}
 
@@ -32,7 +32,8 @@ class LogService {
             dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
             let timestamp = dateFormatter.string(from: Date())
             let fileName = "bitkit_logs_\(timestamp)"
-            return try Zip.quickZipFiles(logFiles, fileName: fileName)
+            let filesToZip = logFiles.map { FileToZip.existingFile($0) }
+            return try zipService.createZipAtTmp(zipFilename: fileName, filesToZip: filesToZip)
 
         } catch {
             Logger.error(error, context: "Failed to create zip file for logs")
@@ -85,17 +86,12 @@ class LogService {
             let timestamp = dateFormatter.string(from: Date())
             let fileName = "bitkit_support_logs_\(timestamp)"
 
-            // Use quickZip helper to create zip file with selected log files
-            let zipURL = try Zip.quickZipFiles(filesToZip, fileName: fileName)
-
-            let zipData = try Data(contentsOf: zipURL)
+            let zipInputs = filesToZip.map { FileToZip.existingFile($0) }
+            let zipData = try zipService.getZipData(zipFilename: fileName, filesToZip: zipInputs)
             let base64Logs = zipData.base64EncodedString()
-            let finalFileName = zipURL.lastPathComponent
+            let finalFileName = "\(fileName).zip"
 
             Logger.info("Support logs zip created: \(zipData.count) bytes, base64: \(base64Logs.count) characters")
-
-            // Clean up temporary zip file
-            try? FileManager.default.removeItem(at: zipURL)
 
             return (logs: base64Logs, fileName: finalFileName)
 

--- a/Bitkit/Services/ZipService.swift
+++ b/Bitkit/Services/ZipService.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+// MARK: - Extensions
+
+extension URL {
+    var isDirectory: Bool {
+        (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+    }
+}
+
+// MARK: - Errors
+
+enum CreateZipError: Swift.Error {
+    case urlNotADirectory(URL)
+    case invalidFilename(String)
+    case failedToCreateZIP(Swift.Error)
+    case failedToGetDataFromZipURL
+}
+
+// MARK: - FileToZip
+
+enum FileToZip {
+    case data(Data, filename: String)
+    case existingFile(URL)
+    case renamedFile(URL, toFilename: String)
+}
+
+extension FileToZip {
+    func prepareInDirectory(directoryURL: URL, usedFilenames: inout Set<String>) throws {
+        func uniqueDestinationURL(for suggestedFilename: String) throws -> URL {
+            let sanitizedFilename = Self.sanitizedFilename(suggestedFilename)
+            guard !sanitizedFilename.isEmpty else {
+                throw CreateZipError.invalidFilename(suggestedFilename)
+            }
+
+            let baseName = URL(fileURLWithPath: sanitizedFilename).deletingPathExtension().lastPathComponent
+            let fileExtension = URL(fileURLWithPath: sanitizedFilename).pathExtension
+
+            var candidateFilename = sanitizedFilename
+            var duplicateIndex = 1
+            while usedFilenames.contains(candidateFilename) {
+                let suffixedBaseName = "\(baseName)_\(duplicateIndex)"
+                candidateFilename = fileExtension.isEmpty
+                    ? suffixedBaseName
+                    : "\(suffixedBaseName).\(fileExtension)"
+                duplicateIndex += 1
+            }
+
+            usedFilenames.insert(candidateFilename)
+            return directoryURL.appendingPathComponent(candidateFilename)
+        }
+
+        switch self {
+        case let .data(data, filename: filename):
+            let fileURL = try uniqueDestinationURL(for: filename)
+            try data.write(to: fileURL)
+        case let .existingFile(existingFileURL):
+            let newFileURL = try uniqueDestinationURL(for: existingFileURL.lastPathComponent)
+            try FileManager.default.copyItem(at: existingFileURL, to: newFileURL)
+        case let .renamedFile(existingFileURL, toFilename: filename):
+            let newFileURL = try uniqueDestinationURL(for: filename)
+            try FileManager.default.copyItem(at: existingFileURL, to: newFileURL)
+        }
+    }
+
+    private static func sanitizedFilename(_ filename: String) -> String {
+        filename
+            .replacingOccurrences(of: "\\", with: "/")
+            .split(separator: "/")
+            .last
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}
+
+// MARK: - ZipService
+
+final class ZipService {
+    init() {}
+
+    func createZip(
+        zipFinalURL: URL,
+        fromDirectory directoryURL: URL
+    ) throws -> URL {
+        guard directoryURL.isDirectory else {
+            throw CreateZipError.urlNotADirectory(directoryURL)
+        }
+
+        var fileManagerError: Swift.Error?
+        var coordinatorError: NSError?
+        let coordinator = NSFileCoordinator()
+        coordinator.coordinate(
+            readingItemAt: directoryURL,
+            options: .forUploading,
+            error: &coordinatorError
+        ) { zipAccessURL in
+            do {
+                if FileManager.default.fileExists(atPath: zipFinalURL.path) {
+                    _ = try FileManager.default.replaceItemAt(zipFinalURL, withItemAt: zipAccessURL)
+                } else {
+                    try FileManager.default.moveItem(at: zipAccessURL, to: zipFinalURL)
+                }
+            } catch {
+                fileManagerError = error
+            }
+        }
+        if let error = coordinatorError ?? fileManagerError {
+            throw CreateZipError.failedToCreateZIP(error)
+        }
+        return zipFinalURL
+    }
+
+    func createZipAtTmp(
+        zipFilename: String,
+        zipExtension: String = "zip",
+        fromDirectory directoryURL: URL
+    ) throws -> URL {
+        let finalURL = FileManager.default.temporaryDirectory
+            .appending(path: zipFilename)
+            .appendingPathExtension(zipExtension)
+        return try createZip(
+            zipFinalURL: finalURL,
+            fromDirectory: directoryURL
+        )
+    }
+
+    func createZipAtTmp(
+        zipFilename: String,
+        zipExtension: String = "zip",
+        filesToZip: [FileToZip]
+    ) throws -> URL {
+        let uuidDirectoryURL = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString)
+        let directoryToZipURL = uuidDirectoryURL
+            .appending(path: zipFilename)
+        try FileManager.default.createDirectory(at: directoryToZipURL, withIntermediateDirectories: true, attributes: [:])
+        defer {
+            try? FileManager.default.removeItem(at: uuidDirectoryURL)
+        }
+        var usedFilenames = Set<String>()
+        for fileToZip in filesToZip {
+            try fileToZip.prepareInDirectory(directoryURL: directoryToZipURL, usedFilenames: &usedFilenames)
+        }
+
+        return try createZipAtTmp(
+            zipFilename: zipFilename,
+            zipExtension: zipExtension,
+            fromDirectory: directoryToZipURL
+        )
+    }
+
+    private func getZipData(zipFileURL: URL) throws -> Data {
+        defer {
+            try? FileManager.default.removeItem(at: zipFileURL)
+        }
+        guard let data = FileManager.default.contents(atPath: zipFileURL.path) else {
+            throw CreateZipError.failedToGetDataFromZipURL
+        }
+        return data
+    }
+
+    func getZipData(
+        zipFilename: String = UUID().uuidString,
+        fromDirectory directoryURL: URL
+    ) throws -> Data {
+        let zipURL = try createZipAtTmp(
+            zipFilename: zipFilename,
+            fromDirectory: directoryURL
+        )
+        return try getZipData(zipFileURL: zipURL)
+    }
+
+    func getZipData(
+        zipFilename: String = UUID().uuidString,
+        filesToZip: [FileToZip]
+    ) throws -> Data {
+        let zipURL = try createZipAtTmp(
+            zipFilename: zipFilename,
+            filesToZip: filesToZip
+        )
+        return try getZipData(zipFileURL: zipURL)
+    }
+}

--- a/BitkitTests/ZipServiceTests.swift
+++ b/BitkitTests/ZipServiceTests.swift
@@ -1,0 +1,68 @@
+@testable import Bitkit
+import Foundation
+import XCTest
+
+final class ZipServiceTests: XCTestCase {
+    private var testRootDirectoryURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        testRootDirectoryURL = FileManager.default.temporaryDirectory.appendingPathComponent("ZipServiceTests_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: testRootDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let testRootDirectoryURL {
+            try? FileManager.default.removeItem(at: testRootDirectoryURL)
+        }
+        testRootDirectoryURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testCreateZipFromFilesToZipHandlesDuplicateAndPathLikeNames() throws {
+        let sourceA = testRootDirectoryURL.appendingPathComponent("sourceA.log")
+        let sourceB = testRootDirectoryURL.appendingPathComponent("sourceB.log")
+        try "alpha".data(using: .utf8)?.write(to: sourceA)
+        try "beta".data(using: .utf8)?.write(to: sourceB)
+
+        let filesToZip: [FileToZip] = [
+            .renamedFile(sourceA, toFilename: "logs/app.log"),
+            .renamedFile(sourceB, toFilename: "logs/app.log"),
+        ]
+
+        let zipService = ZipService()
+        let zipData = try zipService.getZipData(zipFilename: "sanitized", filesToZip: filesToZip)
+
+        XCTAssertFalse(zipData.isEmpty)
+        XCTAssertEqual(String(data: zipData.prefix(2), encoding: .ascii), "PK")
+    }
+
+    func testCreateZipThrowsForInvalidFilename() throws {
+        let zipService = ZipService()
+        let filesToZip: [FileToZip] = [.data(Data([0x01]), filename: " / ")]
+
+        XCTAssertThrowsError(try zipService.getZipData(zipFilename: "invalid", filesToZip: filesToZip)) { error in
+            guard case CreateZipError.invalidFilename = error else {
+                return XCTFail("Expected invalidFilename error, got \(error)")
+            }
+        }
+    }
+
+    func testCreateZipOverwritesExistingFileByDefault() throws {
+        let sourceDirectory = testRootDirectoryURL.appendingPathComponent("input")
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        let sourceFile = sourceDirectory.appendingPathComponent("sample.log")
+        try "sample".data(using: .utf8)?.write(to: sourceFile)
+
+        let zipFinalURL = testRootDirectoryURL.appendingPathComponent("output.zip")
+        try Data("old-content".utf8).write(to: zipFinalURL)
+
+        let zipService = ZipService()
+        let outputURL = try zipService.createZip(zipFinalURL: zipFinalURL, fromDirectory: sourceDirectory)
+        let zipData = try Data(contentsOf: outputURL)
+
+        XCTAssertEqual(outputURL, zipFinalURL)
+        XCTAssertFalse(zipData.isEmpty)
+        XCTAssertEqual(String(data: zipData.prefix(2), encoding: .ascii), "PK")
+    }
+}

--- a/changelog.d/next/526.fixed.md
+++ b/changelog.d/next/526.fixed.md
@@ -1,0 +1,1 @@
+Replaced the third-party Zip dependency with a native ZipService built on NSFileCoordinator for log archive creation.


### PR DESCRIPTION
### Description

Switch log zipping to an internal NSFileCoordinator-based service, add safer filename/overwrite/temp-file handling, and cover key zip edge cases with tests.

### QA Notes

Zipping logs works as before with same compression level.

1. Go to Settings -> Advanced -> Lightning Connections
2. Tap "Export Logs"
3. Unpack the .zip and verify log files are usable
