### PR TITLE
[codex] Add Pubky Ring auth callbacks

### DIFF
--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -247,9 +247,9 @@ struct MainNavView: View {
                 Logger.info("Received deeplink: \(url.absoluteString)")
 
                 if let callback = PubkyRingAuthCallback.parse(url: url) {
-                    await pubkyProfile.handleAuthCallback(callback)
+                    let didHandleCallback = await pubkyProfile.handleAuthCallback(callback)
 
-                    if case let .error(message) = callback {
+                    if didHandleCallback, case let .error(message, _) = callback {
                         app.toast(
                             type: .error,
                             title: t("profile__auth_error_title"),

--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -246,6 +246,20 @@ struct MainNavView: View {
             Task {
                 Logger.info("Received deeplink: \(url.absoluteString)")
 
+                if let callback = PubkyRingAuthCallback.parse(url: url) {
+                    await pubkyProfile.handleAuthCallback(callback)
+
+                    if case let .error(message) = callback {
+                        app.toast(
+                            type: .error,
+                            title: t("profile__auth_error_title"),
+                            description: message ?? t("other__qr_error_text")
+                        )
+                    }
+
+                    return
+                }
+
                 do {
                     try await app.handleScannedData(url.absoluteString)
                     PaymentNavigationHelper.openPaymentSheet(
@@ -462,7 +476,6 @@ struct MainNavView: View {
             }
     }
 
-    @ViewBuilder
     private func missingPendingImportView(fallbackRoute: Route) -> some View {
         Color.customBlack
             .task {

--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -247,14 +247,22 @@ struct MainNavView: View {
                 Logger.info("Received deeplink: \(url.absoluteString)")
 
                 if let callback = PubkyRingAuthCallback.parse(url: url) {
-                    let didHandleCallback = await pubkyProfile.handleAuthCallback(callback)
+                    let handlingResult = await pubkyProfile.handleAuthCallback(callback)
 
-                    if didHandleCallback, case let .error(message, _) = callback {
+                    switch handlingResult {
+                    case let .trustedError(message):
                         app.toast(
                             type: .error,
                             title: t("profile__auth_error_title"),
                             description: message ?? t("other__qr_error_text")
                         )
+                    case .untrustedError:
+                        app.toast(
+                            type: .error,
+                            title: t("profile__auth_error_title")
+                        )
+                    case .handled, .ignored:
+                        break
                     }
 
                     return

--- a/Bitkit/Managers/PubkyProfileManager.swift
+++ b/Bitkit/Managers/PubkyProfileManager.swift
@@ -9,6 +9,66 @@ enum PubkyAuthState: Equatable {
     case error(String)
 }
 
+enum PubkyRingAuthCallback: Equatable {
+    case success
+    case cancel
+    case error(message: String?)
+
+    static func parse(url: URL) -> PubkyRingAuthCallback? {
+        guard url.scheme == "bitkit", url.host == "pubky-auth" else {
+            return nil
+        }
+
+        switch url.path {
+        case "/success":
+            return .success
+        case "/cancel":
+            return .cancel
+        case "/error":
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            let message = components?.queryItems?.first(where: { $0.name == "errorMessage" })?.value
+            return .error(message: message)
+        default:
+            return nil
+        }
+    }
+}
+
+enum PubkyRingAuthURLBuilder {
+    static let successCallback = "bitkit://pubky-auth/success"
+    static let cancelCallback = "bitkit://pubky-auth/cancel"
+    static let errorCallback = "bitkit://pubky-auth/error"
+    static let source = "Bitkit"
+
+    static func addingCallbacks(to authUrl: String) -> String? {
+        guard var components = URLComponents(string: authUrl), components.url != nil else {
+            return nil
+        }
+
+        let callbackQuery = [
+            ("x-success", successCallback),
+            ("x-cancel", cancelCallback),
+            ("x-error", errorCallback),
+            ("x-source", source),
+        ]
+        .map { "\($0.0)=\(Self.percentEncodedQueryValue($0.1))" }
+        .joined(separator: "&")
+
+        components.percentEncodedQuery = [components.percentEncodedQuery, callbackQuery]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: "&")
+
+        return components.url?.absoluteString
+    }
+
+    private static func percentEncodedQueryValue(_ value: String) -> String {
+        var allowedCharacters = CharacterSet.urlQueryAllowed
+        allowedCharacters.remove(charactersIn: ":#[]@!$&'()*+,;=/?")
+        return value.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? value
+    }
+}
+
 private enum PubkyProfileManagerError: LocalizedError {
     case avatarEncodingFailed
 
@@ -387,6 +447,20 @@ class PubkyProfileManager: ObservableObject {
         }
     }
 
+    func handleAuthCallback(_ callback: PubkyRingAuthCallback) async {
+        switch callback {
+        case .success:
+            Logger.info("Pubky Ring returned auth success callback", context: "PubkyProfileManager")
+        case .cancel:
+            Logger.info("Pubky Ring returned auth cancel callback", context: "PubkyProfileManager")
+            await cancelAuthentication()
+        case let .error(message):
+            Logger.warn("Pubky Ring returned auth error callback: \(message ?? "Unknown error")", context: "PubkyProfileManager")
+            await cancelAuthentication()
+            authState = .error(message ?? t("profile__auth_error_title"))
+        }
+    }
+
     func startAuthentication() async throws {
         authState = .authenticating
 
@@ -405,7 +479,9 @@ class PubkyProfileManager: ObservableObject {
             throw error
         }
 
-        guard let url = URL(string: authUrl) else {
+        let callbackAuthUrl = PubkyRingAuthURLBuilder.addingCallbacks(to: authUrl) ?? authUrl
+
+        guard let url = URL(string: callbackAuthUrl) else {
             await cancelPendingAuthSetup()
             authState = .idle
             throw PubkyServiceError.invalidAuthUrl

--- a/Bitkit/Managers/PubkyProfileManager.swift
+++ b/Bitkit/Managers/PubkyProfileManager.swift
@@ -10,24 +10,35 @@ enum PubkyAuthState: Equatable {
 }
 
 enum PubkyRingAuthCallback: Equatable {
-    case success
-    case cancel
-    case error(message: String?)
+    case success(nonce: String?)
+    case cancel(nonce: String?)
+    case error(message: String?, nonce: String?)
+
+    var nonce: String? {
+        switch self {
+        case let .success(nonce), let .cancel(nonce):
+            return nonce
+        case let .error(_, nonce):
+            return nonce
+        }
+    }
 
     static func parse(url: URL) -> PubkyRingAuthCallback? {
         guard url.scheme == "bitkit", url.host == "pubky-auth" else {
             return nil
         }
 
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let nonce = components?.queryItems?.first(where: { $0.name == "nonce" })?.value
+
         switch url.path {
         case "/success":
-            return .success
+            return .success(nonce: nonce)
         case "/cancel":
-            return .cancel
+            return .cancel(nonce: nonce)
         case "/error":
-            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
             let message = components?.queryItems?.first(where: { $0.name == "errorMessage" })?.value
-            return .error(message: message)
+            return .error(message: message, nonce: nonce)
         default:
             return nil
         }
@@ -40,15 +51,15 @@ enum PubkyRingAuthURLBuilder {
     static let errorCallback = "bitkit://pubky-auth/error"
     static let source = "Bitkit"
 
-    static func addingCallbacks(to authUrl: String) -> String? {
+    static func addingCallbacks(to authUrl: String, nonce: UUID? = nil) -> String? {
         guard var components = URLComponents(string: authUrl), components.url != nil else {
             return nil
         }
 
         let callbackQuery = [
-            ("x-success", successCallback),
-            ("x-cancel", cancelCallback),
-            ("x-error", errorCallback),
+            ("x-success", callbackUrl(successCallback, nonce: nonce)),
+            ("x-cancel", callbackUrl(cancelCallback, nonce: nonce)),
+            ("x-error", callbackUrl(errorCallback, nonce: nonce)),
             ("x-source", source),
         ]
         .map { "\($0.0)=\(Self.percentEncodedQueryValue($0.1))" }
@@ -60,6 +71,14 @@ enum PubkyRingAuthURLBuilder {
             .joined(separator: "&")
 
         return components.url?.absoluteString
+    }
+
+    private static func callbackUrl(_ baseUrl: String, nonce: UUID?) -> String {
+        guard let nonce else {
+            return baseUrl
+        }
+
+        return "\(baseUrl)?nonce=\(percentEncodedQueryValue(nonce.uuidString))"
     }
 
     private static func percentEncodedQueryValue(_ value: String) -> String {
@@ -451,18 +470,25 @@ class PubkyProfileManager: ObservableObject {
         }
     }
 
-    func handleAuthCallback(_ callback: PubkyRingAuthCallback) async {
+    func handleAuthCallback(_ callback: PubkyRingAuthCallback) async -> Bool {
+        guard isCurrentAuthCallback(callback) else {
+            Logger.warn("Ignoring Pubky Ring auth callback with missing or invalid nonce", context: "PubkyProfileManager")
+            return false
+        }
+
         switch callback {
         case .success:
             Logger.info("Pubky Ring returned auth success callback", context: "PubkyProfileManager")
         case .cancel:
             Logger.info("Pubky Ring returned auth cancel callback", context: "PubkyProfileManager")
             await cancelAuthentication()
-        case let .error(message):
+        case let .error(message, _):
             Logger.warn("Pubky Ring returned auth error callback: \(message ?? "Unknown error")", context: "PubkyProfileManager")
             await cancelAuthentication()
             setAuthFlowError(message ?? t("profile__auth_error_title"))
         }
+
+        return true
     }
 
     func startAuthentication() async throws {
@@ -491,7 +517,7 @@ class PubkyProfileManager: ObservableObject {
             throw CancellationError()
         }
 
-        let callbackAuthUrl = PubkyRingAuthURLBuilder.addingCallbacks(to: authUrl) ?? authUrl
+        let callbackAuthUrl = PubkyRingAuthURLBuilder.addingCallbacks(to: authUrl, nonce: attemptID) ?? authUrl
 
         guard let url = URL(string: callbackAuthUrl) else {
             await cancelPendingAuthSetup()
@@ -587,6 +613,14 @@ class PubkyProfileManager: ObservableObject {
 
     private func setAuthFlowError(_ message: String) {
         authState = publicKey == nil ? .error(message) : .authenticated
+    }
+
+    private func isCurrentAuthCallback(_ callback: PubkyRingAuthCallback) -> Bool {
+        guard let activeAuthAttemptID else {
+            return false
+        }
+
+        return callback.nonce == activeAuthAttemptID.uuidString
     }
 
     // MARK: - Profile

--- a/Bitkit/Managers/PubkyProfileManager.swift
+++ b/Bitkit/Managers/PubkyProfileManager.swift
@@ -98,6 +98,8 @@ class PubkyProfileManager: ObservableObject {
     @Published private(set) var cachedName: String?
     @Published private(set) var cachedImageUri: String?
 
+    private var activeAuthAttemptID: UUID?
+
     init() {
         cachedName = UserDefaults.standard.string(forKey: Self.cachedNameKey)
         cachedImageUri = UserDefaults.standard.string(forKey: Self.cachedImageUriKey)
@@ -436,13 +438,15 @@ class PubkyProfileManager: ObservableObject {
     // MARK: - Auth Flow (Ring)
 
     func cancelAuthentication() async {
+        activeAuthAttemptID = nil
+
         do {
             try await Task.detached {
                 try await PubkyService.cancelAuth()
             }.value
-            authState = .idle
+            restoreAuthStateAfterAuthFlow()
         } catch {
-            authState = .idle
+            restoreAuthStateAfterAuthFlow()
             Logger.warn("Cancel auth failed: \(error)", context: "PubkyProfileManager")
         }
     }
@@ -457,15 +461,18 @@ class PubkyProfileManager: ObservableObject {
         case let .error(message):
             Logger.warn("Pubky Ring returned auth error callback: \(message ?? "Unknown error")", context: "PubkyProfileManager")
             await cancelAuthentication()
-            authState = .error(message ?? t("profile__auth_error_title"))
+            setAuthFlowError(message ?? t("profile__auth_error_title"))
         }
     }
 
     func startAuthentication() async throws {
+        let attemptID = UUID()
+        activeAuthAttemptID = attemptID
         authState = .authenticating
 
         guard Self.isRingAvailable() else {
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.ringNotInstalled
         }
 
@@ -475,29 +482,37 @@ class PubkyProfileManager: ObservableObject {
                 try await PubkyService.startAuth()
             }.value
         } catch {
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw error
+        }
+
+        guard activeAuthAttemptID == attemptID else {
+            throw CancellationError()
         }
 
         let callbackAuthUrl = PubkyRingAuthURLBuilder.addingCallbacks(to: authUrl) ?? authUrl
 
         guard let url = URL(string: callbackAuthUrl) else {
             await cancelPendingAuthSetup()
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.invalidAuthUrl
         }
 
         let canOpen = UIApplication.shared.canOpenURL(url)
         guard canOpen else {
             await cancelPendingAuthSetup()
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.ringNotInstalled
         }
 
         let didOpen = await UIApplication.shared.open(url)
         guard didOpen else {
             await cancelPendingAuthSetup()
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.authFailed("Failed to open Pubky Ring")
         }
     }
@@ -505,32 +520,58 @@ class PubkyProfileManager: ObservableObject {
     /// Long-polls the relay, persists + imports the session, then loads the profile.
     @discardableResult
     func completeAuthentication() async throws -> String {
+        guard let attemptID = activeAuthAttemptID else {
+            throw CancellationError()
+        }
+
         do {
-            let pk = try await Task.detached {
-                let sessionSecret = try await PubkyService.completeAuth()
-                let pk = try await PubkyService.importSession(secret: sessionSecret)
+            let sessionSecret = try await PubkyService.completeAuth()
+            try Task.checkCancellation()
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
 
-                do {
-                    try Self.upsertKeychainString(.paykitSession, value: sessionSecret)
-                    Self.notifyAppStateBackupChanged()
-                } catch {
-                    await PubkyService.forceSignOut()
-                    throw error
-                }
+            let pk = try await PubkyService.importSession(secret: sessionSecret)
+            try Task.checkCancellation()
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
 
-                return pk
-            }.value
+            do {
+                try Self.upsertKeychainString(.paykitSession, value: sessionSecret)
+                Self.notifyAppStateBackupChanged()
+            } catch {
+                await PubkyService.forceSignOut()
+                throw error
+            }
 
+            activeAuthAttemptID = nil
             publicKey = pk
             authState = .completingAuthentication
             Logger.info("Pubky auth completed for \(pk)", context: "PubkyProfileManager")
             await loadProfile()
             return pk
+        } catch is CancellationError {
+            if activeAuthAttemptID == attemptID {
+                activeAuthAttemptID = nil
+                restoreAuthStateAfterAuthFlow()
+            }
+            throw CancellationError()
         } catch let serviceError as PubkyServiceError {
-            authState = .idle
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
+
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw serviceError
         } catch {
-            authState = .error(error.localizedDescription)
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
+
+            activeAuthAttemptID = nil
+            setAuthFlowError(error.localizedDescription)
             throw error
         }
     }
@@ -538,6 +579,14 @@ class PubkyProfileManager: ObservableObject {
     func finalizeAuthentication() {
         guard case .completingAuthentication = authState else { return }
         authState = .authenticated
+    }
+
+    private func restoreAuthStateAfterAuthFlow() {
+        authState = publicKey == nil ? .idle : .authenticated
+    }
+
+    private func setAuthFlowError(_ message: String) {
+        authState = publicKey == nil ? .error(message) : .authenticated
     }
 
     // MARK: - Profile
@@ -699,7 +748,7 @@ class PubkyProfileManager: ObservableObject {
     // MARK: - Session & Backup Helpers
 
     var isAuthenticated: Bool {
-        authState == .authenticated
+        publicKey != nil
     }
 
     nonisolated static func snapshotSessionBackupState(

--- a/Bitkit/Managers/PubkyProfileManager.swift
+++ b/Bitkit/Managers/PubkyProfileManager.swift
@@ -45,6 +45,13 @@ enum PubkyRingAuthCallback: Equatable {
     }
 }
 
+enum PubkyRingAuthCallbackHandlingResult: Equatable {
+    case ignored
+    case handled
+    case trustedError(message: String?)
+    case untrustedError
+}
+
 enum PubkyRingAuthURLBuilder {
     static let successCallback = "bitkit://pubky-auth/success"
     static let cancelCallback = "bitkit://pubky-auth/cancel"
@@ -101,7 +108,7 @@ private enum PubkyProfileManagerError: LocalizedError {
 
 @MainActor
 class PubkyProfileManager: ObservableObject {
-    enum SessionInitializationResult: Equatable, Sendable {
+    enum SessionInitializationResult: Equatable {
         case noSession
         case restored(publicKey: String)
         case restorationFailed
@@ -470,10 +477,9 @@ class PubkyProfileManager: ObservableObject {
         }
     }
 
-    func handleAuthCallback(_ callback: PubkyRingAuthCallback) async -> Bool {
+    func handleAuthCallback(_ callback: PubkyRingAuthCallback) async -> PubkyRingAuthCallbackHandlingResult {
         guard isCurrentAuthCallback(callback) else {
-            Logger.warn("Ignoring Pubky Ring auth callback with missing or invalid nonce", context: "PubkyProfileManager")
-            return false
+            return await handleInvalidAuthCallback(callback)
         }
 
         switch callback {
@@ -486,9 +492,41 @@ class PubkyProfileManager: ObservableObject {
             Logger.warn("Pubky Ring returned auth error callback: \(message ?? "Unknown error")", context: "PubkyProfileManager")
             await cancelAuthentication()
             setAuthFlowError(message ?? t("profile__auth_error_title"))
+            return .trustedError(message: message)
         }
 
-        return true
+        return .handled
+    }
+
+    private func handleInvalidAuthCallback(_ callback: PubkyRingAuthCallback) async -> PubkyRingAuthCallbackHandlingResult {
+        guard activeAuthAttemptID != nil else {
+            Logger.warn("Ignoring Pubky Ring auth callback with missing or invalid nonce", context: "PubkyProfileManager")
+            return .ignored
+        }
+
+        switch callback {
+        case .success:
+            Logger.warn("Ignoring Pubky Ring auth success callback with missing or invalid nonce", context: "PubkyProfileManager")
+            return .ignored
+        case .cancel:
+            Logger.warn(
+                "Pubky Ring returned auth cancel callback with missing or invalid nonce; ending local auth flow",
+                context: "PubkyProfileManager"
+            )
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
+            await cancelPendingAuthSetup()
+            return .handled
+        case let .error(message, _):
+            Logger.warn(
+                "Pubky Ring returned auth error callback with missing or invalid nonce; ending local auth flow: \(message ?? "Unknown error")",
+                context: "PubkyProfileManager"
+            )
+            activeAuthAttemptID = nil
+            setAuthFlowError(t("profile__auth_error_title"))
+            await cancelPendingAuthSetup()
+            return .untrustedError
+        }
     }
 
     func startAuthentication() async throws {

--- a/Bitkit/Views/Profile/PubkyChoiceView.swift
+++ b/Bitkit/Views/Profile/PubkyChoiceView.swift
@@ -48,6 +48,9 @@ struct PubkyChoiceView: View {
                 // Ring returned to app — approval task handles completion
             }
         }
+        .onChange(of: pubkyProfile.authState) { _, authState in
+            handleAuthStateChange(authState)
+        }
         .alert(t("profile__ring_not_installed_title"), isPresented: $showRingNotInstalledDialog) {
             Button(t("profile__ring_download")) {
                 if let url = URL(string: pubkyRingAppStoreUrl) {
@@ -62,7 +65,6 @@ struct PubkyChoiceView: View {
 
     // MARK: - Title Section
 
-    @ViewBuilder
     private var titleSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             DisplayText(
@@ -82,7 +84,6 @@ struct PubkyChoiceView: View {
 
     // MARK: - Option Cards
 
-    @ViewBuilder
     private var optionCards: some View {
         VStack(spacing: 8) {
             choiceCard(
@@ -110,7 +111,6 @@ struct PubkyChoiceView: View {
         }
     }
 
-    @ViewBuilder
     private func choiceCard(
         icon: String? = nil,
         systemIcon: String? = nil,
@@ -196,9 +196,19 @@ struct PubkyChoiceView: View {
         pubkyProfile.finalizeAuthentication()
     }
 
+    private func handleAuthStateChange(_ authState: PubkyAuthState) {
+        switch authState {
+        case .idle, .error:
+            isAuthenticating = false
+            isWaitingForRing = false
+            isLoadingAfterAuth = false
+        case .authenticating, .completingAuthentication, .authenticated:
+            break
+        }
+    }
+
     // MARK: - Ring Waiting Card
 
-    @ViewBuilder
     private var ringWaitingCard: some View {
         VStack(spacing: 12) {
             HStack(spacing: 16) {
@@ -234,7 +244,6 @@ struct PubkyChoiceView: View {
 
     // MARK: - Background Illustrations
 
-    @ViewBuilder
     private var backgroundIllustrations: some View {
         GeometryReader { geo in
             Image("tag-pubky")

--- a/Bitkit/Views/Profile/PubkyChoiceView.swift
+++ b/Bitkit/Views/Profile/PubkyChoiceView.swift
@@ -198,11 +198,11 @@ struct PubkyChoiceView: View {
 
     private func handleAuthStateChange(_ authState: PubkyAuthState) {
         switch authState {
-        case .idle, .error:
+        case .idle, .authenticated, .error:
             isAuthenticating = false
             isWaitingForRing = false
             isLoadingAfterAuth = false
-        case .authenticating, .completingAuthentication, .authenticated:
+        case .authenticating, .completingAuthentication:
             break
         }
     }

--- a/Bitkit/Views/Profile/PubkyRingAuthView.swift
+++ b/Bitkit/Views/Profile/PubkyRingAuthView.swift
@@ -196,11 +196,11 @@ struct PubkyRingAuthView: View {
 
     private func handleAuthStateChange(_ authState: PubkyAuthState) {
         switch authState {
-        case .idle, .error:
+        case .idle, .authenticated, .error:
             isAuthenticating = false
             isWaitingForRing = false
             isLoadingAfterAuth = false
-        case .authenticating, .completingAuthentication, .authenticated:
+        case .authenticating, .completingAuthentication:
             break
         }
     }

--- a/Bitkit/Views/Profile/PubkyRingAuthView.swift
+++ b/Bitkit/Views/Profile/PubkyRingAuthView.swift
@@ -130,6 +130,9 @@ struct PubkyRingAuthView: View {
                 checkRingInstalled()
             }
         }
+        .onChange(of: pubkyProfile.authState) { _, authState in
+            handleAuthStateChange(authState)
+        }
         .alert(t("profile__ring_not_installed_title"), isPresented: $showRingNotInstalledDialog) {
             Button(t("profile__ring_download")) {
                 if let url = URL(string: pubkyRingAppStoreUrl) {
@@ -189,6 +192,17 @@ struct PubkyRingAuthView: View {
         )
         navigation.path = [destination]
         pubkyProfile.finalizeAuthentication()
+    }
+
+    private func handleAuthStateChange(_ authState: PubkyAuthState) {
+        switch authState {
+        case .idle, .error:
+            isAuthenticating = false
+            isWaitingForRing = false
+            isLoadingAfterAuth = false
+        case .authenticating, .completingAuthentication, .authenticated:
+            break
+        }
     }
 }
 

--- a/BitkitTests/PubkyProfileManagerTests.swift
+++ b/BitkitTests/PubkyProfileManagerTests.swift
@@ -2,6 +2,42 @@
 import XCTest
 
 final class PubkyProfileManagerTests: XCTestCase {
+    // MARK: - Ring callbacks
+
+    func testPubkyRingAuthURLBuilderAddsXCallbackParams() throws {
+        let url = try XCTUnwrap(PubkyRingAuthURLBuilder.addingCallbacks(to: "pubkyauth://auth?relay=https%3A%2F%2Frelay.example"))
+        let components = try XCTUnwrap(URLComponents(string: url))
+        let queryItems = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+
+        XCTAssertEqual(queryItems["relay"], "https://relay.example")
+        XCTAssertEqual(queryItems["x-success"], PubkyRingAuthURLBuilder.successCallback)
+        XCTAssertEqual(queryItems["x-cancel"], PubkyRingAuthURLBuilder.cancelCallback)
+        XCTAssertEqual(queryItems["x-error"], PubkyRingAuthURLBuilder.errorCallback)
+        XCTAssertEqual(queryItems["x-source"], PubkyRingAuthURLBuilder.source)
+    }
+
+    func testPubkyRingAuthCallbackParsesSuccessCancelAndError() throws {
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/success"))),
+            .success
+        )
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/cancel"))),
+            .cancel
+        )
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/error?errorMessage=Denied"))),
+            .error(message: "Denied")
+        )
+    }
+
+    func testPubkyRingAuthCallbackRejectsOtherDeeplinks() throws {
+        XCTAssertNil(try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://wallet/success"))))
+        XCTAssertNil(try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "https://pubky-auth/success"))))
+    }
+
     // MARK: - HomegateResponse Decoding
 
     private typealias HomegateResponse = PubkyProfileManager.HomegateResponse
@@ -10,25 +46,25 @@ final class PubkyProfileManagerTests: XCTestCase {
         let json = """
         {"signupCode":"abc-123","homeserverPubky":"z6MkPubkyTestKey"}
         """
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
         let response = try JSONDecoder().decode(HomegateResponse.self, from: data)
 
         XCTAssertEqual(response.signupCode, "abc-123")
         XCTAssertEqual(response.homeserverPubky, "z6MkPubkyTestKey")
     }
 
-    func testHomegateResponseRejectsIncompleteJson() {
+    func testHomegateResponseRejectsIncompleteJson() throws {
         let json = """
         {"signupCode":"abc-123"}
         """
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
 
         XCTAssertThrowsError(try JSONDecoder().decode(HomegateResponse.self, from: data))
     }
 
-    func testHomegateResponseRejectsEmptyJson() {
+    func testHomegateResponseRejectsEmptyJson() throws {
         let json = "{}"
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
 
         XCTAssertThrowsError(try JSONDecoder().decode(HomegateResponse.self, from: data))
     }
@@ -37,7 +73,7 @@ final class PubkyProfileManagerTests: XCTestCase {
         let json = """
         {"signupCode":"abc","homeserverPubky":"z6Mk","extra":"ignored"}
         """
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
         let response = try JSONDecoder().decode(HomegateResponse.self, from: data)
 
         XCTAssertEqual(response.signupCode, "abc")

--- a/BitkitTests/PubkyProfileManagerTests.swift
+++ b/BitkitTests/PubkyProfileManagerTests.swift
@@ -38,6 +38,25 @@ final class PubkyProfileManagerTests: XCTestCase {
         XCTAssertNil(try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "https://pubky-auth/success"))))
     }
 
+    @MainActor
+    func testIsAuthenticatedUsesRestoredPublicKeyDuringTransientAuthError() {
+        let manager = PubkyProfileManager()
+
+        manager.publicKey = "pubky_test"
+        manager.authState = .error("Gateway timeout")
+
+        XCTAssertTrue(manager.isAuthenticated)
+    }
+
+    @MainActor
+    func testIsAuthenticatedRequiresPublicKey() {
+        let manager = PubkyProfileManager()
+
+        manager.authState = .authenticated
+
+        XCTAssertFalse(manager.isAuthenticated)
+    }
+
     // MARK: - HomegateResponse Decoding
 
     private typealias HomegateResponse = PubkyProfileManager.HomegateResponse

--- a/BitkitTests/PubkyProfileManagerTests.swift
+++ b/BitkitTests/PubkyProfileManagerTests.swift
@@ -53,6 +53,13 @@ final class PubkyProfileManagerTests: XCTestCase {
         )
     }
 
+    func testPubkyRingAuthCallbackTreatsBareNonceAsMissing() throws {
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/cancel?nonce"))),
+            .cancel(nonce: nil)
+        )
+    }
+
     func testPubkyRingAuthCallbackRejectsOtherDeeplinks() throws {
         XCTAssertNil(try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://wallet/success"))))
         XCTAssertNil(try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "https://pubky-auth/success"))))

--- a/BitkitTests/PubkyProfileManagerTests.swift
+++ b/BitkitTests/PubkyProfileManagerTests.swift
@@ -21,15 +21,35 @@ final class PubkyProfileManagerTests: XCTestCase {
     func testPubkyRingAuthCallbackParsesSuccessCancelAndError() throws {
         XCTAssertEqual(
             try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/success"))),
-            .success
+            .success(nonce: nil)
         )
         XCTAssertEqual(
             try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/cancel"))),
-            .cancel
+            .cancel(nonce: nil)
         )
         XCTAssertEqual(
             try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/error?errorMessage=Denied"))),
-            .error(message: "Denied")
+            .error(message: "Denied", nonce: nil)
+        )
+    }
+
+    func testPubkyRingAuthURLBuilderAddsNonceToCallbackParams() throws {
+        let nonce = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-123456789ABC"))
+        let url = try XCTUnwrap(PubkyRingAuthURLBuilder.addingCallbacks(to: "pubkyauth://auth", nonce: nonce))
+        let components = try XCTUnwrap(URLComponents(string: url))
+        let queryItems = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+
+        XCTAssertEqual(queryItems["x-success"], "bitkit://pubky-auth/success?nonce=12345678-1234-1234-1234-123456789ABC")
+        XCTAssertEqual(queryItems["x-cancel"], "bitkit://pubky-auth/cancel?nonce=12345678-1234-1234-1234-123456789ABC")
+        XCTAssertEqual(queryItems["x-error"], "bitkit://pubky-auth/error?nonce=12345678-1234-1234-1234-123456789ABC")
+    }
+
+    func testPubkyRingAuthCallbackParsesNonce() throws {
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/error?nonce=abc&errorMessage=Denied"))),
+            .error(message: "Denied", nonce: "abc")
         )
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add Pubky Ring auth callbacks to return to Bitkit after approval, cancellation, or error #530
+- Add Pubky Ring auth callbacks and keep canceled auth attempts from disconnecting profiles #530
 - Restore pubky sessions from wallet backups and improve iOS pubky profile, contacts, and clipboard flows #527
 - Pubky profile onboarding with contact sync, import, and editing #476
 - Add transfer from savings button on empty spending wallet when user has on-chain balance #523

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add Pubky Ring auth callbacks to return to Bitkit after approval, cancellation, or error
 - Restore pubky sessions from wallet backups and improve iOS pubky profile, contacts, and clipboard flows #527
 - Pubky profile onboarding with contact sync, import, and editing #476
 - Add transfer from savings button on empty spending wallet when user has on-chain balance #523

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add Pubky Ring auth callbacks to return to Bitkit after approval, cancellation, or error
+- Add Pubky Ring auth callbacks to return to Bitkit after approval, cancellation, or error #530
 - Restore pubky sessions from wallet backups and improve iOS pubky profile, contacts, and clipboard flows #527
 - Pubky profile onboarding with contact sync, import, and editing #476
 - Add transfer from savings button on empty spending wallet when user has on-chain balance #523


### PR DESCRIPTION
## Summary
- Add Pubky Ring `x-success`, `x-cancel`, `x-error`, and `x-source=Bitkit` callback parameters to generated auth URLs.
- Handle Pubky Ring return callbacks through the existing Bitkit deeplink path.
- Reset Ring auth waiting/loading UI on cancel or error callbacks while keeping relay completion as the source of truth for successful auth.
- Add focused tests for callback URL generation and callback parsing.

## Why
Pubky Ring now supports custom callback URLs. Adding these parameters lets Ring return users to Bitkit after approval, cancellation, or error instead of leaving the app switch flow hanging.

## Validation
- `git diff --check`
- `swiftformat` was run on the touched Swift files.
- Full `xcodebuild` was attempted, but it is blocked by the existing external `VssRustClientFfi` / `Uniffi` generated bindings issue.