### PR TITLE
[codex] Add Pubky Ring auth callbacks

### DIFF
--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -246,6 +246,28 @@ struct MainNavView: View {
             Task {
                 Logger.info("Received deeplink: \(url.absoluteString)")
 
+                if let callback = PubkyRingAuthCallback.parse(url: url) {
+                    let handlingResult = await pubkyProfile.handleAuthCallback(callback)
+
+                    switch handlingResult {
+                    case let .trustedError(message):
+                        app.toast(
+                            type: .error,
+                            title: t("profile__auth_error_title"),
+                            description: message ?? t("other__qr_error_text")
+                        )
+                    case .untrustedError:
+                        app.toast(
+                            type: .error,
+                            title: t("profile__auth_error_title")
+                        )
+                    case .handled, .ignored:
+                        break
+                    }
+
+                    return
+                }
+
                 do {
                     try await app.handleScannedData(url.absoluteString)
                     PaymentNavigationHelper.openPaymentSheet(
@@ -462,7 +484,6 @@ struct MainNavView: View {
             }
     }
 
-    @ViewBuilder
     private func missingPendingImportView(fallbackRoute: Route) -> some View {
         Color.customBlack
             .task {

--- a/Bitkit/Managers/PubkyProfileManager.swift
+++ b/Bitkit/Managers/PubkyProfileManager.swift
@@ -7,6 +7,107 @@ enum PubkyAuthState: Equatable {
     case completingAuthentication
     case authenticated
     case error(String)
+
+    func resetRingAuthViewStateIfNeeded(
+        isAuthenticating: Binding<Bool>,
+        isWaitingForRing: Binding<Bool>,
+        isLoadingAfterAuth: Binding<Bool>
+    ) {
+        switch self {
+        case .idle, .authenticated, .error:
+            isAuthenticating.wrappedValue = false
+            isWaitingForRing.wrappedValue = false
+            isLoadingAfterAuth.wrappedValue = false
+        case .authenticating, .completingAuthentication:
+            break
+        }
+    }
+}
+
+enum PubkyRingAuthCallback: Equatable {
+    case success(nonce: String?)
+    case cancel(nonce: String?)
+    case error(message: String?, nonce: String?)
+
+    var nonce: String? {
+        switch self {
+        case let .success(nonce), let .cancel(nonce):
+            return nonce
+        case let .error(_, nonce):
+            return nonce
+        }
+    }
+
+    static func parse(url: URL) -> PubkyRingAuthCallback? {
+        guard url.scheme == "bitkit", url.host == "pubky-auth" else {
+            return nil
+        }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let nonce = components?.queryItems?.first(where: { $0.name == "nonce" })?.value
+
+        switch url.path {
+        case "/success":
+            return .success(nonce: nonce)
+        case "/cancel":
+            return .cancel(nonce: nonce)
+        case "/error":
+            let message = components?.queryItems?.first(where: { $0.name == "errorMessage" })?.value
+            return .error(message: message, nonce: nonce)
+        default:
+            return nil
+        }
+    }
+}
+
+enum PubkyRingAuthCallbackHandlingResult: Equatable {
+    case ignored
+    case handled
+    case trustedError(message: String?)
+    case untrustedError
+}
+
+enum PubkyRingAuthURLBuilder {
+    static let successCallback = "bitkit://pubky-auth/success"
+    static let cancelCallback = "bitkit://pubky-auth/cancel"
+    static let errorCallback = "bitkit://pubky-auth/error"
+    static let source = "Bitkit"
+
+    static func addingCallbacks(to authUrl: String, nonce: UUID? = nil) -> String? {
+        guard var components = URLComponents(string: authUrl), components.url != nil else {
+            return nil
+        }
+
+        let callbackQuery = [
+            ("x-success", callbackUrl(successCallback, nonce: nonce)),
+            ("x-cancel", callbackUrl(cancelCallback, nonce: nonce)),
+            ("x-error", callbackUrl(errorCallback, nonce: nonce)),
+            ("x-source", source),
+        ]
+        .map { "\($0.0)=\(Self.percentEncodedQueryValue($0.1))" }
+        .joined(separator: "&")
+
+        components.percentEncodedQuery = [components.percentEncodedQuery, callbackQuery]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: "&")
+
+        return components.url?.absoluteString
+    }
+
+    private static func callbackUrl(_ baseUrl: String, nonce: UUID?) -> String {
+        guard let nonce else {
+            return baseUrl
+        }
+
+        return "\(baseUrl)?nonce=\(percentEncodedQueryValue(nonce.uuidString))"
+    }
+
+    private static func percentEncodedQueryValue(_ value: String) -> String {
+        var allowedCharacters = CharacterSet.urlQueryAllowed
+        allowedCharacters.remove(charactersIn: ":#[]@!$&'()*+,;=/?")
+        return value.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? value
+    }
 }
 
 private enum PubkyProfileManagerError: LocalizedError {
@@ -22,7 +123,7 @@ private enum PubkyProfileManagerError: LocalizedError {
 
 @MainActor
 class PubkyProfileManager: ObservableObject {
-    enum SessionInitializationResult: Equatable, Sendable {
+    enum SessionInitializationResult: Equatable {
         case noSession
         case restored(publicKey: String)
         case restorationFailed
@@ -37,6 +138,8 @@ class PubkyProfileManager: ObservableObject {
     @Published var sessionRestorationFailed = false
     @Published private(set) var cachedName: String?
     @Published private(set) var cachedImageUri: String?
+
+    private var activeAuthAttemptID: UUID?
 
     init() {
         cachedName = UserDefaults.standard.string(forKey: Self.cachedNameKey)
@@ -376,22 +479,64 @@ class PubkyProfileManager: ObservableObject {
     // MARK: - Auth Flow (Ring)
 
     func cancelAuthentication() async {
+        activeAuthAttemptID = nil
+
         do {
             try await Task.detached {
                 try await PubkyService.cancelAuth()
             }.value
-            authState = .idle
+            restoreAuthStateAfterAuthFlow()
         } catch {
-            authState = .idle
+            restoreAuthStateAfterAuthFlow()
             Logger.warn("Cancel auth failed: \(error)", context: "PubkyProfileManager")
         }
     }
 
+    func handleAuthCallback(_ callback: PubkyRingAuthCallback) async -> PubkyRingAuthCallbackHandlingResult {
+        guard isCurrentAuthCallback(callback) else {
+            return await handleInvalidAuthCallback(callback)
+        }
+
+        switch callback {
+        case .success:
+            Logger.info("Pubky Ring returned auth success callback", context: "PubkyProfileManager")
+        case .cancel:
+            Logger.info("Pubky Ring returned auth cancel callback", context: "PubkyProfileManager")
+            await cancelAuthentication()
+        case let .error(message, _):
+            Logger.warn("Pubky Ring returned auth error callback: \(message ?? "Unknown error")", context: "PubkyProfileManager")
+            await cancelAuthentication()
+            setAuthFlowError(message ?? t("profile__auth_error_title"))
+            return .trustedError(message: message)
+        }
+
+        return .handled
+    }
+
+    private func handleInvalidAuthCallback(_ callback: PubkyRingAuthCallback) async -> PubkyRingAuthCallbackHandlingResult {
+        switch callback {
+        case .success:
+            Logger.warn("Ignoring Pubky Ring auth success callback with missing or invalid nonce", context: "PubkyProfileManager")
+        case .cancel:
+            Logger.warn("Ignoring Pubky Ring auth cancel callback with missing or invalid nonce", context: "PubkyProfileManager")
+        case let .error(message, _):
+            Logger.warn(
+                "Ignoring Pubky Ring auth error callback with missing or invalid nonce: \(message ?? "Unknown error")",
+                context: "PubkyProfileManager"
+            )
+        }
+
+        return .ignored
+    }
+
     func startAuthentication() async throws {
+        let attemptID = UUID()
+        activeAuthAttemptID = attemptID
         authState = .authenticating
 
         guard Self.isRingAvailable() else {
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.ringNotInstalled
         }
 
@@ -401,27 +546,37 @@ class PubkyProfileManager: ObservableObject {
                 try await PubkyService.startAuth()
             }.value
         } catch {
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw error
         }
 
-        guard let url = URL(string: authUrl) else {
+        guard activeAuthAttemptID == attemptID else {
+            throw CancellationError()
+        }
+
+        let callbackAuthUrl = PubkyRingAuthURLBuilder.addingCallbacks(to: authUrl, nonce: attemptID) ?? authUrl
+
+        guard let url = URL(string: callbackAuthUrl) else {
             await cancelPendingAuthSetup()
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.invalidAuthUrl
         }
 
         let canOpen = UIApplication.shared.canOpenURL(url)
         guard canOpen else {
             await cancelPendingAuthSetup()
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.ringNotInstalled
         }
 
         let didOpen = await UIApplication.shared.open(url)
         guard didOpen else {
             await cancelPendingAuthSetup()
-            authState = .idle
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw PubkyServiceError.authFailed("Failed to open Pubky Ring")
         }
     }
@@ -429,32 +584,58 @@ class PubkyProfileManager: ObservableObject {
     /// Long-polls the relay, persists + imports the session, then loads the profile.
     @discardableResult
     func completeAuthentication() async throws -> String {
+        guard let attemptID = activeAuthAttemptID else {
+            throw CancellationError()
+        }
+
         do {
-            let pk = try await Task.detached {
-                let sessionSecret = try await PubkyService.completeAuth()
-                let pk = try await PubkyService.importSession(secret: sessionSecret)
+            let sessionSecret = try await PubkyService.completeAuth()
+            try Task.checkCancellation()
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
 
-                do {
-                    try Self.upsertKeychainString(.paykitSession, value: sessionSecret)
-                    Self.notifyAppStateBackupChanged()
-                } catch {
-                    await PubkyService.forceSignOut()
-                    throw error
-                }
+            let pk = try await PubkyService.importSession(secret: sessionSecret)
+            try Task.checkCancellation()
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
 
-                return pk
-            }.value
+            do {
+                try Self.upsertKeychainString(.paykitSession, value: sessionSecret)
+                Self.notifyAppStateBackupChanged()
+            } catch {
+                await PubkyService.forceSignOut()
+                throw error
+            }
 
+            activeAuthAttemptID = nil
             publicKey = pk
             authState = .completingAuthentication
             Logger.info("Pubky auth completed for \(pk)", context: "PubkyProfileManager")
             await loadProfile()
             return pk
+        } catch is CancellationError {
+            if activeAuthAttemptID == attemptID {
+                activeAuthAttemptID = nil
+                restoreAuthStateAfterAuthFlow()
+            }
+            throw CancellationError()
         } catch let serviceError as PubkyServiceError {
-            authState = .idle
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
+
+            activeAuthAttemptID = nil
+            restoreAuthStateAfterAuthFlow()
             throw serviceError
         } catch {
-            authState = .error(error.localizedDescription)
+            guard activeAuthAttemptID == attemptID else {
+                throw CancellationError()
+            }
+
+            activeAuthAttemptID = nil
+            setAuthFlowError(error.localizedDescription)
             throw error
         }
     }
@@ -463,6 +644,32 @@ class PubkyProfileManager: ObservableObject {
         guard case .completingAuthentication = authState else { return }
         authState = .authenticated
     }
+
+    private func restoreAuthStateAfterAuthFlow() {
+        authState = publicKey == nil ? .idle : .authenticated
+    }
+
+    private func setAuthFlowError(_ message: String) {
+        authState = publicKey == nil ? .error(message) : .authenticated
+    }
+
+    private func isCurrentAuthCallback(_ callback: PubkyRingAuthCallback) -> Bool {
+        guard let activeAuthAttemptID else {
+            return false
+        }
+
+        return callback.nonce == activeAuthAttemptID.uuidString
+    }
+
+    #if DEBUG
+        func setActiveAuthAttemptIDForTesting(_ attemptID: UUID?) {
+            activeAuthAttemptID = attemptID
+        }
+
+        var activeAuthAttemptIDForTesting: UUID? {
+            activeAuthAttemptID
+        }
+    #endif
 
     // MARK: - Profile
 
@@ -623,7 +830,7 @@ class PubkyProfileManager: ObservableObject {
     // MARK: - Session & Backup Helpers
 
     var isAuthenticated: Bool {
-        authState == .authenticated
+        publicKey != nil
     }
 
     nonisolated static func snapshotSessionBackupState(

--- a/Bitkit/Views/Profile/PubkyChoiceView.swift
+++ b/Bitkit/Views/Profile/PubkyChoiceView.swift
@@ -48,6 +48,13 @@ struct PubkyChoiceView: View {
                 // Ring returned to app — approval task handles completion
             }
         }
+        .onChange(of: pubkyProfile.authState) { _, authState in
+            authState.resetRingAuthViewStateIfNeeded(
+                isAuthenticating: $isAuthenticating,
+                isWaitingForRing: $isWaitingForRing,
+                isLoadingAfterAuth: $isLoadingAfterAuth
+            )
+        }
         .alert(t("profile__ring_not_installed_title"), isPresented: $showRingNotInstalledDialog) {
             Button(t("profile__ring_download")) {
                 if let url = URL(string: pubkyRingAppStoreUrl) {
@@ -62,7 +69,6 @@ struct PubkyChoiceView: View {
 
     // MARK: - Title Section
 
-    @ViewBuilder
     private var titleSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             DisplayText(
@@ -82,7 +88,6 @@ struct PubkyChoiceView: View {
 
     // MARK: - Option Cards
 
-    @ViewBuilder
     private var optionCards: some View {
         VStack(spacing: 8) {
             choiceCard(
@@ -110,7 +115,6 @@ struct PubkyChoiceView: View {
         }
     }
 
-    @ViewBuilder
     private func choiceCard(
         icon: String? = nil,
         systemIcon: String? = nil,
@@ -198,7 +202,6 @@ struct PubkyChoiceView: View {
 
     // MARK: - Ring Waiting Card
 
-    @ViewBuilder
     private var ringWaitingCard: some View {
         VStack(spacing: 12) {
             HStack(spacing: 16) {
@@ -234,7 +237,6 @@ struct PubkyChoiceView: View {
 
     // MARK: - Background Illustrations
 
-    @ViewBuilder
     private var backgroundIllustrations: some View {
         GeometryReader { geo in
             Image("tag-pubky")

--- a/Bitkit/Views/Profile/PubkyRingAuthView.swift
+++ b/Bitkit/Views/Profile/PubkyRingAuthView.swift
@@ -130,6 +130,13 @@ struct PubkyRingAuthView: View {
                 checkRingInstalled()
             }
         }
+        .onChange(of: pubkyProfile.authState) { _, authState in
+            authState.resetRingAuthViewStateIfNeeded(
+                isAuthenticating: $isAuthenticating,
+                isWaitingForRing: $isWaitingForRing,
+                isLoadingAfterAuth: $isLoadingAfterAuth
+            )
+        }
         .alert(t("profile__ring_not_installed_title"), isPresented: $showRingNotInstalledDialog) {
             Button(t("profile__ring_download")) {
                 if let url = URL(string: pubkyRingAppStoreUrl) {

--- a/BitkitTests/PubkyProfileManagerTests.swift
+++ b/BitkitTests/PubkyProfileManagerTests.swift
@@ -2,6 +2,118 @@
 import XCTest
 
 final class PubkyProfileManagerTests: XCTestCase {
+    // MARK: - Ring callbacks
+
+    func testPubkyRingAuthURLBuilderAddsXCallbackParams() throws {
+        let url = try XCTUnwrap(PubkyRingAuthURLBuilder.addingCallbacks(to: "pubkyauth://auth?relay=https%3A%2F%2Frelay.example"))
+        let components = try XCTUnwrap(URLComponents(string: url))
+        let queryItems = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+
+        XCTAssertEqual(queryItems["relay"], "https://relay.example")
+        XCTAssertEqual(queryItems["x-success"], PubkyRingAuthURLBuilder.successCallback)
+        XCTAssertEqual(queryItems["x-cancel"], PubkyRingAuthURLBuilder.cancelCallback)
+        XCTAssertEqual(queryItems["x-error"], PubkyRingAuthURLBuilder.errorCallback)
+        XCTAssertEqual(queryItems["x-source"], PubkyRingAuthURLBuilder.source)
+    }
+
+    func testPubkyRingAuthCallbackParsesSuccessCancelAndError() throws {
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/success"))),
+            .success(nonce: nil)
+        )
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/cancel"))),
+            .cancel(nonce: nil)
+        )
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/error?errorMessage=Denied"))),
+            .error(message: "Denied", nonce: nil)
+        )
+    }
+
+    func testPubkyRingAuthURLBuilderAddsNonceToCallbackParams() throws {
+        let nonce = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-123456789ABC"))
+        let url = try XCTUnwrap(PubkyRingAuthURLBuilder.addingCallbacks(to: "pubkyauth://auth", nonce: nonce))
+        let components = try XCTUnwrap(URLComponents(string: url))
+        let queryItems = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+
+        XCTAssertEqual(queryItems["x-success"], "bitkit://pubky-auth/success?nonce=12345678-1234-1234-1234-123456789ABC")
+        XCTAssertEqual(queryItems["x-cancel"], "bitkit://pubky-auth/cancel?nonce=12345678-1234-1234-1234-123456789ABC")
+        XCTAssertEqual(queryItems["x-error"], "bitkit://pubky-auth/error?nonce=12345678-1234-1234-1234-123456789ABC")
+    }
+
+    func testPubkyRingAuthCallbackParsesNonce() throws {
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/error?nonce=abc&errorMessage=Denied"))),
+            .error(message: "Denied", nonce: "abc")
+        )
+    }
+
+    func testPubkyRingAuthCallbackTreatsBareNonceAsMissing() throws {
+        XCTAssertEqual(
+            try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://pubky-auth/cancel?nonce"))),
+            .cancel(nonce: nil)
+        )
+    }
+
+    func testPubkyRingAuthCallbackRejectsOtherDeeplinks() throws {
+        XCTAssertNil(try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "bitkit://wallet/success"))))
+        XCTAssertNil(try PubkyRingAuthCallback.parse(url: XCTUnwrap(URL(string: "https://pubky-auth/success"))))
+    }
+
+    @MainActor
+    func testNonceMismatchedCancelCallbackDoesNotAbortActiveAuthAttempt() async {
+        let manager = PubkyProfileManager()
+        let attemptID = UUID()
+
+        manager.setActiveAuthAttemptIDForTesting(attemptID)
+        manager.authState = .authenticating
+
+        let result = await manager.handleAuthCallback(.cancel(nonce: UUID().uuidString))
+
+        XCTAssertEqual(result, .ignored)
+        XCTAssertEqual(manager.activeAuthAttemptIDForTesting, attemptID)
+        XCTAssertEqual(manager.authState, .authenticating)
+    }
+
+    @MainActor
+    func testNonceMismatchedErrorCallbackDoesNotAbortActiveAuthAttempt() async {
+        let manager = PubkyProfileManager()
+        let attemptID = UUID()
+
+        manager.setActiveAuthAttemptIDForTesting(attemptID)
+        manager.authState = .authenticating
+
+        let result = await manager.handleAuthCallback(.error(message: "Denied", nonce: UUID().uuidString))
+
+        XCTAssertEqual(result, .ignored)
+        XCTAssertEqual(manager.activeAuthAttemptIDForTesting, attemptID)
+        XCTAssertEqual(manager.authState, .authenticating)
+    }
+
+    @MainActor
+    func testIsAuthenticatedUsesRestoredPublicKeyDuringTransientAuthError() {
+        let manager = PubkyProfileManager()
+
+        manager.publicKey = "pubky_test"
+        manager.authState = .error("Gateway timeout")
+
+        XCTAssertTrue(manager.isAuthenticated)
+    }
+
+    @MainActor
+    func testIsAuthenticatedRequiresPublicKey() {
+        let manager = PubkyProfileManager()
+
+        manager.authState = .authenticated
+
+        XCTAssertFalse(manager.isAuthenticated)
+    }
+
     // MARK: - HomegateResponse Decoding
 
     private typealias HomegateResponse = PubkyProfileManager.HomegateResponse
@@ -10,25 +122,25 @@ final class PubkyProfileManagerTests: XCTestCase {
         let json = """
         {"signupCode":"abc-123","homeserverPubky":"z6MkPubkyTestKey"}
         """
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
         let response = try JSONDecoder().decode(HomegateResponse.self, from: data)
 
         XCTAssertEqual(response.signupCode, "abc-123")
         XCTAssertEqual(response.homeserverPubky, "z6MkPubkyTestKey")
     }
 
-    func testHomegateResponseRejectsIncompleteJson() {
+    func testHomegateResponseRejectsIncompleteJson() throws {
         let json = """
         {"signupCode":"abc-123"}
         """
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
 
         XCTAssertThrowsError(try JSONDecoder().decode(HomegateResponse.self, from: data))
     }
 
-    func testHomegateResponseRejectsEmptyJson() {
+    func testHomegateResponseRejectsEmptyJson() throws {
         let json = "{}"
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
 
         XCTAssertThrowsError(try JSONDecoder().decode(HomegateResponse.self, from: data))
     }
@@ -37,7 +149,7 @@ final class PubkyProfileManagerTests: XCTestCase {
         let json = """
         {"signupCode":"abc","homeserverPubky":"z6Mk","extra":"ignored"}
         """
-        let data = json.data(using: .utf8)!
+        let data = try XCTUnwrap(json.data(using: .utf8))
         let response = try JSONDecoder().decode(HomegateResponse.self, from: data)
 
         XCTAssertEqual(response.signupCode, "abc")

--- a/changelog.d/next/537.added.md
+++ b/changelog.d/next/537.added.md
@@ -1,0 +1,1 @@
+Add Pubky Ring auth callbacks and keep canceled auth attempts from disconnecting profiles.


### PR DESCRIPTION
## Summary

- Add Pubky Ring success, cancel, and error callback handling for auth deeplinks.
- Track active Ring auth attempts with nonces so stale callbacks are ignored safely.
- Keep an existing Pubky profile authenticated when a new Ring auth attempt is canceled or errors.
- Add focused tests for callback URL building/parsing and authenticated-state behavior.

## Validation

- Inspected diff against `origin/master` after rebasing: 1 commit, 6 files changed.
- Attempted focused `PubkyProfileManagerTests` locally. The first run failed due to sandbox/cache permissions, the unavailable `iPhone 16` simulator destination, and stale Rust FFI module artifacts. A clean DerivedData retry did not complete in this environment and was stopped, so CI should be treated as the source of truth for test status.

## Notes

This is the clean rebased slice from the old `codex/pr-527-contact-fixes` branch. The earlier Pubky/contact work is already in `master` via PR #527; this PR carries the remaining Pubky Ring callback work from #530.