### PR TITLE
[codex] Prevent dust change from triggering send-all

### DIFF
--- a/Bitkit/Utilities/DustChangeHelper.swift
+++ b/Bitkit/Utilities/DustChangeHelper.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-/// Helper for determining when to use sendAll to avoid creating dust change outputs.
+/// Helper for detecting dust change during on-chain sends.
 enum DustChangeHelper {
-    /// Returns true if the expected change would be dust (below dust limit), so sendAll should be used.
+    /// Returns true if the expected change would be dust (below dust limit).
     /// - Parameters:
     ///   - totalInput: Total sats from selected UTXOs (or spendable balance)
     ///   - amountSats: Amount to send to recipient
     ///   - normalFee: Fee for a normal send (recipient + change outputs)
     ///   - dustLimit: Minimum non-dust amount (default: Env.dustLimit)
-    /// - Returns: true when change would be dust and sendAll should be used
-    static func shouldUseSendAllToAvoidDust(
+    /// - Returns: true when change would be dust
+    static func wouldCreateDustChange(
         totalInput: UInt64,
         amountSats: UInt64,
         normalFee: UInt64,
@@ -17,5 +17,21 @@ enum DustChangeHelper {
     ) -> Bool {
         let expectedChange = Int64(totalInput) - Int64(amountSats) - Int64(normalFee)
         return expectedChange >= 0 && expectedChange < Int64(dustLimit)
+    }
+
+    /// Returns true only when the caller is allowed to use sendAll to avoid dust change.
+    static func shouldUseSendAllToAvoidDust(
+        totalInput: UInt64,
+        amountSats: UInt64,
+        normalFee: UInt64,
+        isMaxAmount: Bool,
+        dustLimit: UInt64 = UInt64(Env.dustLimit)
+    ) -> Bool {
+        isMaxAmount && wouldCreateDustChange(
+            totalInput: totalInput,
+            amountSats: amountSats,
+            normalFee: normalFee,
+            dustLimit: dustLimit
+        )
     }
 }

--- a/Bitkit/Views/Transfer/SpendingConfirm.swift
+++ b/Bitkit/Views/Transfer/SpendingConfirm.swift
@@ -212,7 +212,8 @@ struct SpendingConfirm: View {
                 useSendAll = DustChangeHelper.shouldUseSendAllToAvoidDust(
                     totalInput: totalInput,
                     amountSats: currentOrder.feeSat,
-                    normalFee: normalFee
+                    normalFee: normalFee,
+                    isMaxAmount: true
                 )
             } catch {
                 Logger.info("Normal coin selection failed, using sendAll: \(error)")

--- a/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
+++ b/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
@@ -17,7 +17,6 @@ struct SendConfirmationView: View {
     @State private var showingBiometricError = false
     @State private var biometricErrorMessage = ""
     @State private var transactionFee: Int = 0
-    @State private var shouldUseSendAll: Bool = false
     @State private var currentWarning: WarningType?
     @State private var pendingWarnings: [WarningType] = []
     @State private var warningContinuation: CheckedContinuation<Bool, Error>?
@@ -482,8 +481,7 @@ struct SendConfirmationView: View {
                 }
             } else if app.selectedWalletToPayFrom == .onchain, let invoice = app.scannedOnchainInvoice {
                 let amount = wallet.sendAmountSats ?? invoice.amountSatoshis
-                // Use sendAll if explicitly MAX or if change would be dust
-                let useMaxAmount = wallet.isMaxAmountSend || shouldUseSendAll
+                let useMaxAmount = await shouldUseMaxOnchainSend(address: invoice.address, amountSats: amount)
                 let txid = try await wallet.send(address: invoice.address, sats: amount, isMaxAmount: useMaxAmount)
 
                 // Create pre-activity metadata for tags and activity address
@@ -601,6 +599,28 @@ struct SendConfirmationView: View {
         }
 
         return true
+    }
+
+    private func shouldUseMaxOnchainSend(address: String, amountSats: UInt64, feeRate: UInt32? = nil) async -> Bool {
+        guard wallet.isMaxAmountSend else { return false }
+        guard let rate = feeRate ?? wallet.selectedFeeRateSatsPerVByte else { return false }
+
+        do {
+            let currentMaxSendable = try await wallet.calculateMaxSendableAmount(address: address, satsPerVByte: rate)
+            let matchesCurrentMax = amountSats == currentMaxSendable
+
+            if !matchesCurrentMax {
+                Logger.warn(
+                    "Ignoring stale max on-chain send flag: amount=\(amountSats), currentMaxSendable=\(currentMaxSendable)",
+                    context: "SendConfirmationView"
+                )
+            }
+
+            return matchesCurrentMax
+        } catch {
+            Logger.error("Failed to verify max on-chain send amount: \(error)", context: "SendConfirmationView")
+            return false
+        }
     }
 
     private func createPreActivityMetadata(
@@ -723,43 +743,31 @@ struct SendConfirmationView: View {
         }
 
         do {
-            // Fee for normal send (recipient + change outputs) - used to check if change would be dust
-            let normalFee = try await wallet.calculateTotalFee(
-                address: address,
-                amountSats: amountSats,
-                satsPerVByte: feeRate,
-                utxosToSpend: wallet.selectedUtxos
-            )
-            let totalInput = wallet.selectedUtxos?.reduce(0) { $0 + $1.valueSats }
-                ?? UInt64(wallet.spendableOnchainBalanceSats)
-            let useSendAll = DustChangeHelper.shouldUseSendAllToAvoidDust(
-                totalInput: totalInput,
-                amountSats: amountSats,
-                normalFee: normalFee
-            )
-
-            if useSendAll {
-                // Change would be dust - use sendAll and add dust to fee
+            if await shouldUseMaxOnchainSend(address: address, amountSats: amountSats, feeRate: feeRate) {
                 let sendAllFee = try await wallet.estimateSendAllFee(
                     address: address,
                     satsPerVByte: feeRate
                 )
                 await MainActor.run {
                     transactionFee = Int(sendAllFee)
-                    shouldUseSendAll = true
                 }
-            } else {
-                // Normal send with change output
-                await MainActor.run {
-                    transactionFee = Int(normalFee)
-                    shouldUseSendAll = false
-                }
+                return
+            }
+
+            // Fee for normal send (recipient + change outputs).
+            let normalFee = try await wallet.calculateTotalFee(
+                address: address,
+                amountSats: amountSats,
+                satsPerVByte: feeRate,
+                utxosToSpend: wallet.selectedUtxos
+            )
+            await MainActor.run {
+                transactionFee = Int(normalFee)
             }
         } catch {
             Logger.error("Failed to calculate actual fee: \(error)")
             await MainActor.run {
                 transactionFee = 0
-                shouldUseSendAll = false
                 app.toast(type: .error, title: t("other__try_again"))
             }
         }

--- a/BitkitTests/DustChangeHelperTests.swift
+++ b/BitkitTests/DustChangeHelperTests.swift
@@ -4,14 +4,32 @@ import XCTest
 final class DustChangeHelperTests: XCTestCase {
     private let dustLimit: UInt64 = 547
 
-    // MARK: - Change would be dust -> use sendAll
+    // MARK: - Change would be dust
+
+    func testReportedNonMaxDustChange_ShouldNotUseSendAll() {
+        XCTAssertTrue(DustChangeHelper.wouldCreateDustChange(
+            totalInput: 5450,
+            amountSats: 5000,
+            normalFee: 181,
+            dustLimit: dustLimit
+        ))
+
+        XCTAssertFalse(DustChangeHelper.shouldUseSendAllToAvoidDust(
+            totalInput: 5450,
+            amountSats: 5000,
+            normalFee: 181,
+            isMaxAmount: false,
+            dustLimit: dustLimit
+        ))
+    }
 
     func testChangeBelowDustLimit_ShouldUseSendAll() {
-        // totalInput: 100_000, amount: 99_500, fee: 500 -> change = 0
+        // totalInput: 100_000, amount: 99_500, fee: 500 -> change = 0 (explicit max case)
         XCTAssertTrue(DustChangeHelper.shouldUseSendAllToAvoidDust(
             totalInput: 100_000,
             amountSats: 99500,
             normalFee: 500,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
 
@@ -20,6 +38,7 @@ final class DustChangeHelperTests: XCTestCase {
             totalInput: 100_000,
             amountSats: 99000,
             normalFee: 500,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
 
@@ -28,6 +47,7 @@ final class DustChangeHelperTests: XCTestCase {
             totalInput: 100_000,
             amountSats: 98954,
             normalFee: 500,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
     }
@@ -39,6 +59,7 @@ final class DustChangeHelperTests: XCTestCase {
             totalInput: 100_000,
             amountSats: 98953,
             normalFee: 500,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
     }
@@ -49,6 +70,7 @@ final class DustChangeHelperTests: XCTestCase {
             totalInput: 100_000,
             amountSats: 98000,
             normalFee: 500,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
 
@@ -57,6 +79,7 @@ final class DustChangeHelperTests: XCTestCase {
             totalInput: 100_000,
             amountSats: 98954,
             normalFee: 495,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
     }
@@ -67,6 +90,7 @@ final class DustChangeHelperTests: XCTestCase {
             totalInput: 100_000,
             amountSats: 99500,
             normalFee: 500,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
     }
@@ -77,6 +101,7 @@ final class DustChangeHelperTests: XCTestCase {
             totalInput: 100_000,
             amountSats: 100_000,
             normalFee: 500,
+            isMaxAmount: true,
             dustLimit: dustLimit
         ))
     }
@@ -86,7 +111,8 @@ final class DustChangeHelperTests: XCTestCase {
         XCTAssertTrue(DustChangeHelper.shouldUseSendAllToAvoidDust(
             totalInput: 100_000,
             amountSats: 99454,
-            normalFee: 0
+            normalFee: 0,
+            isMaxAmount: true
             // dustLimit omitted -> uses Env.dustLimit
         ))
     }

--- a/changelog.d/next/536.fixed.md
+++ b/changelog.d/next/536.fixed.md
@@ -1,0 +1,1 @@
+Fixed on-chain sends so dust change can no longer turn a partial payment into a max-balance send.


### PR DESCRIPTION
## Summary

- prevent dust-change detection from turning a normal on-chain send into a send-all transaction
- require max sends to still match the freshly calculated max-send amount before using `sendAllToAddress`
- keep transfer send-all behavior explicit and add a regression test for the reported dust-change values

## Root Cause

The iOS send confirmation flow treated dust-change handling as equivalent to an explicit max send. When selected UTXOs left dust change, `shouldUseSendAll` could become true and the send path called `sendAllToAddress`, draining the wallet instead of sending the requested amount.

## Validation

- `swiftformat Bitkit/Utilities/DustChangeHelper.swift Bitkit/Views/Transfer/SpendingConfirm.swift Bitkit/Views/Wallets/Send/SendConfirmationView.swift BitkitTests/DustChangeHelperTests.swift`
- `git diff --check`
- `xcrun swiftc -parse Bitkit/Utilities/DustChangeHelper.swift BitkitTests/DustChangeHelperTests.swift`

Fixes #536
