### PR TITLE
ci: add pubky paykit e2e shard

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -378,6 +378,7 @@ jobs:
       matrix:
         shard:
           - { name: multi_address_2_regtest, grep: "@multi_address_2" }
+          - { name: pubky_paykit, grep: "@pubky" }
 
     name: e2e-tests-staging - ${{ matrix.shard.name }}
 


### PR DESCRIPTION
### Description

This PR wires the new Pubky/Paykit E2E coverage into iOS CI.

It adds a dedicated `pubky_paykit` shard to the staging E2E matrix, running `--mochaOpts.grep "@pubky"` against the regtest/network build.

The E2E tests themselves were added in synonymdev/bitkit-e2e-tests#147. Keeping this as a separate staging shard isolates Pubky/Homegate/Paykit staging dependency failures from the local-regtest wallet checks.

### Linked Issues/Tasks

- synonymdev/bitkit-e2e-tests#147

### Screenshot / Video

N/A

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

- CI coverage added: iOS staging E2E now runs `@pubky`, which covers Pubky profile/contact flows and public Paykit on-chain contact payment from synonymdev/bitkit-e2e-tests#147 (after merge).
