### PR TITLE
feat: hide in-app compact widget preview

### DIFF
--- a/Bitkit/Views/Widgets/BlocksWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/BlocksWidgetPreviewView.swift
@@ -7,7 +7,8 @@ struct BlocksWidgetPreviewView: View {
 
     @StateObject private var viewModel = BlocksViewModel.shared
 
-    @State private var carouselPage: Int = 0
+    // TODO: revert to 0 to re-enable the compact widget preview
+    @State private var carouselPage: Int = 1
     @State private var showDeleteAlert = false
 
     private let widgetType: WidgetType = .blocks
@@ -51,8 +52,10 @@ struct BlocksWidgetPreviewView: View {
                 carousel
 
                 sizeLabel
+                    .padding(.bottom, 16)
 
-                pageIndicator
+                // Page indicator hidden while only the wide widget is shown
+                // pageIndicator
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -111,7 +114,8 @@ struct BlocksWidgetPreviewView: View {
 
     private var carousel: some View {
         TabView(selection: $carouselPage) {
-            compactPage.tag(0)
+            // Compact preview temporarily hidden — only the wide widget can be added for now
+            // compactPage.tag(0)
             widePage.tag(1)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))

--- a/Bitkit/Views/Widgets/BlocksWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/BlocksWidgetPreviewView.swift
@@ -51,8 +51,8 @@ struct BlocksWidgetPreviewView: View {
             VStack(spacing: 16) {
                 carousel
 
-                sizeLabel
-                    .padding(.bottom, 16)
+                // Size label hidden while only the wide widget is shown
+                // sizeLabel
 
                 // Page indicator hidden while only the wide widget is shown
                 // pageIndicator

--- a/Bitkit/Views/Widgets/FactsWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/FactsWidgetPreviewView.swift
@@ -7,7 +7,8 @@ struct FactsWidgetPreviewView: View {
 
     @StateObject private var viewModel = FactsViewModel.shared
 
-    @State private var carouselPage: Int = 0
+    // TODO: revert to 0 to re-enable the compact widget preview
+    @State private var carouselPage: Int = 1
     @State private var showDeleteAlert = false
 
     private let widgetType: WidgetType = .facts
@@ -34,8 +35,10 @@ struct FactsWidgetPreviewView: View {
                 carousel
 
                 sizeLabel
+                    .padding(.bottom, 16)
 
-                pageIndicator
+                // Page indicator hidden while only the wide widget is shown
+                // pageIndicator
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -60,7 +63,8 @@ struct FactsWidgetPreviewView: View {
 
     private var carousel: some View {
         TabView(selection: $carouselPage) {
-            compactPage.tag(0)
+            // Compact preview temporarily hidden — only the wide widget can be added for now
+            // compactPage.tag(0)
             widePage.tag(1)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))

--- a/Bitkit/Views/Widgets/FactsWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/FactsWidgetPreviewView.swift
@@ -34,8 +34,8 @@ struct FactsWidgetPreviewView: View {
             VStack(spacing: 16) {
                 carousel
 
-                sizeLabel
-                    .padding(.bottom, 16)
+                // Size label hidden while only the wide widget is shown
+                // sizeLabel
 
                 // Page indicator hidden while only the wide widget is shown
                 // pageIndicator

--- a/Bitkit/Views/Widgets/NewsWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/NewsWidgetPreviewView.swift
@@ -7,7 +7,8 @@ struct NewsWidgetPreviewView: View {
 
     @StateObject private var viewModel = NewsViewModel.shared
 
-    @State private var carouselPage: Int = 0
+    // TODO: revert to 0 to re-enable the compact widget preview
+    @State private var carouselPage: Int = 1
     @State private var showDeleteAlert = false
 
     private let widgetType: WidgetType = .news
@@ -51,8 +52,10 @@ struct NewsWidgetPreviewView: View {
                 carousel
 
                 sizeLabel
+                    .padding(.bottom, 16)
 
-                pageIndicator
+                // Page indicator hidden while only the wide widget is shown
+                // pageIndicator
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -111,8 +114,9 @@ struct NewsWidgetPreviewView: View {
 
     private var carousel: some View {
         TabView(selection: $carouselPage) {
-            compactPage
-                .tag(0)
+            // Compact preview temporarily hidden — only the wide widget can be added for now
+            // compactPage
+            //     .tag(0)
 
             widePage
                 .tag(1)

--- a/Bitkit/Views/Widgets/NewsWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/NewsWidgetPreviewView.swift
@@ -51,8 +51,8 @@ struct NewsWidgetPreviewView: View {
             VStack(spacing: 16) {
                 carousel
 
-                sizeLabel
-                    .padding(.bottom, 16)
+                // Size label hidden while only the wide widget is shown
+                // sizeLabel
 
                 // Page indicator hidden while only the wide widget is shown
                 // pageIndicator

--- a/Bitkit/Views/Widgets/PriceWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/PriceWidgetPreviewView.swift
@@ -60,8 +60,8 @@ struct PriceWidgetPreviewView: View {
             VStack(spacing: 16) {
                 carousel
 
-                sizeLabel
-                    .padding(.bottom, 16)
+                // Size label hidden while only the wide widget is shown
+                // sizeLabel
 
                 // Page indicator hidden while only the wide widget is shown
                 // pageIndicator

--- a/Bitkit/Views/Widgets/PriceWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/PriceWidgetPreviewView.swift
@@ -7,7 +7,8 @@ struct PriceWidgetPreviewView: View {
 
     @StateObject private var viewModel = PriceViewModel.shared
 
-    @State private var carouselPage: Int = 0
+    // TODO: revert to 0 to re-enable the compact widget preview
+    @State private var carouselPage: Int = 1
     @State private var showDeleteAlert = false
 
     private let widgetType: WidgetType = .price
@@ -60,8 +61,10 @@ struct PriceWidgetPreviewView: View {
                 carousel
 
                 sizeLabel
+                    .padding(.bottom, 16)
 
-                pageIndicator
+                // Page indicator hidden while only the wide widget is shown
+                // pageIndicator
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -121,8 +124,9 @@ struct PriceWidgetPreviewView: View {
 
     private var carousel: some View {
         TabView(selection: $carouselPage) {
-            compactPage
-                .tag(0)
+            // Compact preview temporarily hidden — only the wide widget can be added for now
+            // compactPage
+            //     .tag(0)
 
             widePage
                 .tag(1)

--- a/Bitkit/Views/Widgets/WeatherWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/WeatherWidgetPreviewView.swift
@@ -52,8 +52,8 @@ struct WeatherWidgetPreviewView: View {
             VStack(spacing: 16) {
                 carousel
 
-                sizeLabel
-                    .padding(.bottom, 16)
+                // Size label hidden while only the wide widget is shown
+                // sizeLabel
 
                 // Page indicator hidden while only the wide widget is shown
                 // pageIndicator

--- a/Bitkit/Views/Widgets/WeatherWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/WeatherWidgetPreviewView.swift
@@ -8,7 +8,8 @@ struct WeatherWidgetPreviewView: View {
 
     @StateObject private var viewModel = WeatherViewModel.shared
 
-    @State private var carouselPage: Int = 0
+    // TODO: revert to 0 to re-enable the compact widget preview
+    @State private var carouselPage: Int = 1
     @State private var showDeleteAlert = false
 
     private let widgetType: WidgetType = .weather
@@ -52,8 +53,10 @@ struct WeatherWidgetPreviewView: View {
                 carousel
 
                 sizeLabel
+                    .padding(.bottom, 16)
 
-                pageIndicator
+                // Page indicator hidden while only the wide widget is shown
+                // pageIndicator
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -113,7 +116,8 @@ struct WeatherWidgetPreviewView: View {
 
     private var carousel: some View {
         TabView(selection: $carouselPage) {
-            compactPage.tag(0)
+            // Compact preview temporarily hidden — only the wide widget can be added for now
+            // compactPage.tag(0)
             widePage.tag(1)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))


### PR DESCRIPTION
### Description

This PR hides the compact (small) widget size from the in-app widget preview screens. The small home-screen variant cannot be added yet, so showing it in the size carousel was misleading. Each preview (Blocks, Facts, Headlines, Price, Weather) now defaults to and shows only the wide preview, with the carousel's second page and the page-indicator dots hidden. The compact code is left in place (commented) so it can be re-enabled later, and the "WIDE" label spacing above the action buttons was adjusted to compensate for the removed page indicator.

This mirrors the Android change in synonymdev/bitkit-android#952.

### Linked Issues/Tasks

Closes #559 

### QA Notes
#### Manual Tests
- [x] **1.** Widgets → add widget → open each preview (Blocks, Facts, Headlines, Price, Weather): only the wide card shows, label reads "WIDE", no page-indicator dots, swiping reveals no small variant.
- [x] **2.** Any widget preview → spacing between the "WIDE" label and the Save/Delete buttons: comfortable gap, not cramped.
- [x] **3.** Any widget preview → tap Save widget: widget saves and appears in the list.
#### Automated Checks
N/A

### Screenshot / Video



https://github.com/user-attachments/assets/40a096c7-390e-4159-b2e6-d03654f4d08d




