### PR TITLE
fix: polish widget edit & preview screens

### DIFF
--- a/Bitkit/Components/Widgets/BaseWidget.swift
+++ b/Bitkit/Components/Widgets/BaseWidget.swift
@@ -85,7 +85,6 @@ struct BaseWidget<Content: View>: View {
     @EnvironmentObject private var navigation: NavigationViewModel
     @EnvironmentObject private var widgets: WidgetsViewModel
     @EnvironmentObject private var currency: CurrencyViewModel
-    @EnvironmentObject private var settings: SettingsViewModel
 
     /// Widget metadata computed from type
     private var metadata: WidgetMetadata {
@@ -127,7 +126,7 @@ struct BaseWidget<Content: View>: View {
     var body: some View {
         Button {} label: {
             VStack(spacing: 0) {
-                if type == .suggestions ? isEditing : (settings.showWidgetTitles || isEditing) {
+                if isEditing {
                     HStack {
                         HStack(spacing: 16) {
                             Image(metadata.icon)
@@ -184,12 +183,6 @@ struct BaseWidget<Content: View>: View {
                                     .accessibilityIdentifier("\(metadata.name)_WidgetActionReorder")
                             }
                         }
-                    }
-
-                    // Add spacer only when showing title and not editing
-                    if settings.showWidgetTitles && !isEditing {
-                        Spacer()
-                            .frame(height: 16)
                     }
                 }
 

--- a/Bitkit/Models/SettingsBackupConfig.swift
+++ b/Bitkit/Models/SettingsBackupConfig.swift
@@ -45,7 +45,6 @@ enum SettingsBackupConfig {
         "addressTypesToMonitor": .string(optional: true),
         "enableQuickpay": .bool,
         "showWidgets": .bool,
-        "showWidgetTitles": .bool,
         "swipeBalanceToHide": .bool,
         "hideBalance": .bool,
         "hideBalanceOnOpen": .bool,

--- a/Bitkit/Resources/Localization/ar.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/ar.lproj/Localizable.strings
@@ -34,7 +34,6 @@
 "widgets__widget__edit" = "موجز الأداة";
 "widgets__widget__edit_default" = "افتراضي";
 "widgets__widget__edit_custom" = "مخصص";
-"widgets__widget__edit_description" = "يرجى اختيار الحقول التي تريد عرضها في أداة {name}.";
 "widgets__widget__source" = "المصدر";
 "widgets__add" = "إضافة أداة";
 "widgets__delete__title" = "حذف الأداة؟";

--- a/Bitkit/Resources/Localization/ca.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/ca.lproj/Localizable.strings
@@ -551,7 +551,6 @@
 "settings__general__language_other" = "Idioma de la interfície";
 "settings__widgets__nav_title" = "Ginys";
 "settings__widgets__showWidgets" = "Ginys";
-"settings__widgets__showWidgetTitles" = "Mostra títols dels ginys";
 "settings__notifications__nav_title" = "Pagaments en segon pla";
 "settings__notifications__intro__title" = "Rep pagaments\n<accent>passivament</accent>";
 "settings__notifications__intro__text" = "Activa les notificacions per rebre pagaments, fins i tot quan l\'aplicació Bitkit està tancada.";

--- a/Bitkit/Resources/Localization/ca.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/ca.lproj/Localizable.strings
@@ -983,7 +983,6 @@
 "widgets__widget__edit" = "Feed del giny";
 "widgets__widget__edit_default" = "Predeterminat";
 "widgets__widget__edit_custom" = "Personalitzat";
-"widgets__widget__edit_description" = "Si us plau, selecciona quins camps vols mostrar al giny {name}.";
 "widgets__widget__source" = "Font";
 "widgets__add" = "Afegir giny";
 "widgets__delete__title" = "Eliminar giny?";

--- a/Bitkit/Resources/Localization/cs.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/cs.lproj/Localizable.strings
@@ -619,7 +619,6 @@
 "settings__general__language_other" = "Jazyk rozhraní";
 "settings__widgets__nav_title" = "Widgety";
 "settings__widgets__showWidgets" = "Widgety";
-"settings__widgets__showWidgetTitles" = "Zobrazit názvy widgetů";
 "settings__notifications__nav_title" = "Platby na pozadí";
 "settings__notifications__intro__title" = "Přijímat platby\n<accent>pasivně</accent>";
 "settings__notifications__intro__text" = "Zapněte oznámení, abyste mohli přijímat platby, i když je vaše aplikace Bitkit zavřená.";

--- a/Bitkit/Resources/Localization/cs.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/cs.lproj/Localizable.strings
@@ -1141,7 +1141,6 @@
 "widgets__widget__edit" = "Widget Feed";
 "widgets__widget__edit_default" = "Výchozí";
 "widgets__widget__edit_custom" = "Vlastní";
-"widgets__widget__edit_description" = "Vyberte, která pole chcete zobrazit ve widgetu {name}.";
 "widgets__widget__source" = "Zdroj";
 "widgets__add" = "Přidat widget";
 "widgets__delete__title" = "Smazat Widget?";

--- a/Bitkit/Resources/Localization/de.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/de.lproj/Localizable.strings
@@ -1137,7 +1137,6 @@
 "widgets__widget__edit" = "Widget Feed";
 "widgets__widget__edit_default" = "Standard";
 "widgets__widget__edit_custom" = "Benutzerdefiniert";
-"widgets__widget__edit_description" = "Bitte wähle die Felder aus, die du im {name} Widget anzeigen möchtest.";
 "widgets__widget__source" = "Quelle";
 "widgets__add" = "Widget hinzufügen";
 "widgets__delete__title" = "Widget löschen?";

--- a/Bitkit/Resources/Localization/de.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/de.lproj/Localizable.strings
@@ -617,7 +617,6 @@
 "settings__general__language_other" = "Oberflächensprache";
 "settings__widgets__nav_title" = "Widgets";
 "settings__widgets__showWidgets" = "Widgets";
-"settings__widgets__showWidgetTitles" = "Titel anzeigen";
 "settings__notifications__nav_title" = "Hintergrundzahlungen";
 "settings__notifications__intro__title" = "Passiv\n<accent>bezahlt werden</accent>";
 "settings__notifications__intro__text" = "Aktiviere Benachrichtigungen, um Zahlungen zu erhalten, auch wenn Bitkit geschlossen ist.";

--- a/Bitkit/Resources/Localization/el.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/el.lproj/Localizable.strings
@@ -845,7 +845,6 @@
 "widgets__widget__edit" = "Ροή Widget";
 "widgets__widget__edit_default" = "Προεπιλεγμένο";
 "widgets__widget__edit_custom" = "Προσαρμοσμένο";
-"widgets__widget__edit_description" = "Παρακαλώ επιλέξτε ποια πεδία θέλετε να εμφανίζονται στο widget {name}.";
 "widgets__widget__source" = "Πηγή";
 "widgets__add" = "Προσθήκη Widget";
 "widgets__delete__title" = "Διαγραφή Widget;";

--- a/Bitkit/Resources/Localization/el.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/el.lproj/Localizable.strings
@@ -499,7 +499,6 @@
 "settings__general__language_other" = "Γλώσσα διεπαφής";
 "settings__widgets__nav_title" = "Widgets";
 "settings__widgets__showWidgets" = "Widgets";
-"settings__widgets__showWidgetTitles" = "Εμφάνιση Τίτλων Widget";
 "settings__notifications__nav_title" = "Πληρωμές Παρασκηνίου";
 "settings__notifications__intro__title" = "Λάβετε Πληρωμή\n<accent>Παθητικά</accent>";
 "settings__notifications__intro__text" = "Ενεργοποιήστε τις ειδοποιήσεις για να λαμβάνετε πληρωμές, ακόμα και όταν η εφαρμογή Bitkit είναι κλειστή.";

--- a/Bitkit/Resources/Localization/en.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/en.lproj/Localizable.strings
@@ -669,7 +669,6 @@
 "settings__widgets__section_display" = "Display";
 "settings__widgets__section_reset" = "Reset To Defaults";
 "settings__widgets__showWidgets" = "Show Widgets";
-"settings__widgets__showWidgetTitles" = "Show Widget Titles";
 "settings__widgets__reset_widgets" = "Reset Widgets";
 "settings__widgets__reset_widgets_dialog_title" = "Reset Widgets?";
 "settings__widgets__reset_widgets_dialog_description" = "Are you sure you want to reset the widgets? The default widget set with default configurations will be displayed.";

--- a/Bitkit/Resources/Localization/en.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/en.lproj/Localizable.strings
@@ -1382,7 +1382,6 @@
 "widgets__widget__edit" = "Widget Feed";
 "widgets__widget__edit_default" = "Default";
 "widgets__widget__edit_custom" = "Custom";
-"widgets__widget__edit_description" = "Please choose the fields you would like to see in the {name} widget.";
 "widgets__widget__source" = "Source";
 "widgets__add" = "Add Widget";
 "widgets__list__button" = "Enable In Settings";

--- a/Bitkit/Resources/Localization/es-419.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/es-419.lproj/Localizable.strings
@@ -626,7 +626,6 @@
 "settings__general__language_other" = "Lenguaje de interfaz";
 "settings__widgets__nav_title" = "Widgets";
 "settings__widgets__showWidgets" = "Widgets";
-"settings__widgets__showWidgetTitles" = "Mostrar títulos de widgets";
 "settings__notifications__nav_title" = "Pagos en segundo plano";
 "settings__notifications__intro__title" = "Cobrar\n<accent>Pasivamente</accent>";
 "settings__notifications__intro__text" = "Active las notificaciones para cobrar, incluso cuando su aplicación Bitkit esté cerrada.";

--- a/Bitkit/Resources/Localization/es-419.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/es-419.lproj/Localizable.strings
@@ -1153,7 +1153,6 @@
 "widgets__widget__edit" = "Feed de widgets";
 "widgets__widget__edit_default" = "Default";
 "widgets__widget__edit_custom" = "personalizado";
-"widgets__widget__edit_description" = "Seleccione los campos que desea mostrar en el widget {name}.";
 "widgets__widget__source" = "Fuente";
 "widgets__add" = "Añadir Widget";
 "widgets__delete__title" = "¿Borrar Widget?";

--- a/Bitkit/Resources/Localization/es.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/es.lproj/Localizable.strings
@@ -1012,7 +1012,6 @@
 "widgets__widget__edit" = "Feed del Widget";
 "widgets__widget__edit_default" = "Predeterminado";
 "widgets__widget__edit_custom" = "Personalizar";
-"widgets__widget__edit_description" = "Por favor, seleccione cuales campos quiere mostrar en el widget {name}.";
 "widgets__widget__source" = "Fuente";
 "widgets__add" = "Añadir Widget";
 "widgets__delete__title" = "¿Borrar Widget?";

--- a/Bitkit/Resources/Localization/es.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/es.lproj/Localizable.strings
@@ -566,7 +566,6 @@
 "settings__general__language_other" = "Idioma de la interfaz";
 "settings__widgets__nav_title" = "Widgets";
 "settings__widgets__showWidgets" = "Widgets";
-"settings__widgets__showWidgetTitles" = "Mostrar Títulos de Widgets";
 "settings__notifications__nav_title" = "Pagos en Segundo Plano";
 "settings__notifications__intro__title" = "Recibe Pagos\n<accent>Pasivamente</accent>";
 "settings__notifications__intro__text" = "Activa las notificaciones para recibir pagos, incluso cuando tu app Bitkit esté cerrada.";

--- a/Bitkit/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/fr.lproj/Localizable.strings
@@ -630,7 +630,6 @@
 "settings__general__language_other" = "Langue de l'interface";
 "settings__widgets__nav_title" = "Widgets";
 "settings__widgets__showWidgets" = "Widgets";
-"settings__widgets__showWidgetTitles" = "Afficher les titres des widgets";
 "settings__notifications__nav_title" = "Paiements en arrière-plan";
 "settings__notifications__intro__title" = "Soyez rémunéré\n<accent>de manière passive</accent>";
 "settings__notifications__intro__text" = "Activez les notifications pour être payé, même lorsque votre application Bitkit est fermée.";

--- a/Bitkit/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/fr.lproj/Localizable.strings
@@ -1167,7 +1167,6 @@
 "widgets__widget__edit" = "Widget de Flux";
 "widgets__widget__edit_default" = "Défaut";
 "widgets__widget__edit_custom" = "Personnalisé";
-"widgets__widget__edit_description" = "Veuillez sélectionner les champs que vous souhaitez afficher dans le widget {name}.";
 "widgets__widget__source" = "Source";
 "widgets__add" = "Ajouter un widget";
 "widgets__delete__title" = "Supprimer le widget ?";

--- a/Bitkit/Resources/Localization/it.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/it.lproj/Localizable.strings
@@ -608,7 +608,6 @@
 "settings__general__language_other" = "Lingua dell'interfaccia";
 "settings__widgets__nav_title" = "Widget";
 "settings__widgets__showWidgets" = "Widget";
-"settings__widgets__showWidgetTitles" = "Mostra titoli dei widget";
 "settings__notifications__nav_title" = "Pagamenti in Background";
 "settings__notifications__intro__title" = "Ricevi Pagamenti\n<accent>Passivamente</accent>";
 "settings__notifications__intro__text" = "Attiva le notifiche per ricevere pagamenti, anche quando l'app Bitkit è chiusa.";

--- a/Bitkit/Resources/Localization/it.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/it.lproj/Localizable.strings
@@ -1121,7 +1121,6 @@
 "widgets__widget__edit" = "Feed Widget";
 "widgets__widget__edit_default" = "Predefinito";
 "widgets__widget__edit_custom" = "Custom";
-"widgets__widget__edit_description" = "Seleziona quali campi desideri visualizzare nel widget {name}.";
 "widgets__widget__source" = "Fonte";
 "widgets__add" = "Aggiungi Widget";
 "widgets__delete__title" = "Eliminare Widget?";

--- a/Bitkit/Resources/Localization/nl.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/nl.lproj/Localizable.strings
@@ -627,7 +627,6 @@
 "settings__general__language_other" = "Interface taal";
 "settings__widgets__nav_title" = "Widgets";
 "settings__widgets__showWidgets" = "Widgets";
-"settings__widgets__showWidgetTitles" = "Widget titels tonen";
 "settings__notifications__nav_title" = "Achtergrondbetalingen";
 "settings__notifications__intro__title" = "Ontvang\n<accent>Passief</accent>";
 "settings__notifications__intro__text" = "Schakel notificaties in om betaald te worden, zelfs wanneer uw Bitkit app gesloten is.";

--- a/Bitkit/Resources/Localization/nl.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/nl.lproj/Localizable.strings
@@ -1161,7 +1161,6 @@
 "widgets__widget__edit" = "Widget Feed";
 "widgets__widget__edit_default" = "Standaard";
 "widgets__widget__edit_custom" = "Op maat";
-"widgets__widget__edit_description" = "Selecteer welke velden u wilt weergeven in de {name} widget.";
 "widgets__widget__source" = "Bron";
 "widgets__add" = "Widget Toevoegen";
 "widgets__delete__title" = "Widget Verwijderen?";

--- a/Bitkit/Resources/Localization/pl.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/pl.lproj/Localizable.strings
@@ -631,7 +631,6 @@
 "settings__general__language_other" = "Język interfejsu";
 "settings__widgets__nav_title" = "Widgety";
 "settings__widgets__showWidgets" = "Widgety";
-"settings__widgets__showWidgetTitles" = "Pokazuj tytuły widgetów";
 "settings__notifications__nav_title" = "Płatności w tle";
 "settings__notifications__intro__title" = "Otrzymuj płatności\n<accent>pasywnie</accent>";
 "settings__notifications__intro__text" = "Włącz powiadomienia, aby otrzymywać płatności, nawet gdy aplikacja Bitkit jest zamknięta.";

--- a/Bitkit/Resources/Localization/pl.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/pl.lproj/Localizable.strings
@@ -1168,7 +1168,6 @@
 "widgets__widget__edit" = "Panel widgetów";
 "widgets__widget__edit_default" = "Domyślne";
 "widgets__widget__edit_custom" = "Własna";
-"widgets__widget__edit_description" = "Wybierz pola, które chcesz wyświetlić w widgecie {name}.";
 "widgets__widget__source" = "Źródło";
 "widgets__add" = "Dodaj widget";
 "widgets__delete__title" = "Usunąć widget?";

--- a/Bitkit/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -1169,7 +1169,6 @@
 "widgets__widget__edit" = "Widget Feed";
 "widgets__widget__edit_default" = "Padrão";
 "widgets__widget__edit_custom" = "Personalizada";
-"widgets__widget__edit_description" = "Por favor, selecione quais campos você deseja exibir no widget {name}.";
 "widgets__widget__source" = "Fonte";
 "widgets__add" = "Adicionar Widget";
 "widgets__delete__title" = "Excluir o Widget?";

--- a/Bitkit/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -631,7 +631,6 @@
 "settings__general__language_other" = "Idioma da interface";
 "settings__widgets__nav_title" = "Widgets";
 "settings__widgets__showWidgets" = "Widgets";
-"settings__widgets__showWidgetTitles" = "Mostrar Títulos dos Widgets";
 "settings__notifications__nav_title" = "Pagamentos em Segundo Plano";
 "settings__notifications__intro__title" = "Receba\n<accent>Passivamente</accent>";
 "settings__notifications__intro__text" = "Ative as notificações para receber pagamentos, mesmo quando o Bitkit estiver fechado.";

--- a/Bitkit/Resources/Localization/pt.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/pt.lproj/Localizable.strings
@@ -12,7 +12,6 @@
 "widgets__widget__edit" = "Widget Feed";
 "widgets__widget__edit_default" = "Padrão";
 "widgets__widget__edit_custom" = "Personalizada";
-"widgets__widget__edit_description" = "Por favor, selecione quais campos você deseja exibir no widget {name}.";
 "widgets__widget__source" = "Fonte";
 "widgets__add" = "Adicionar Widget";
 "widgets__delete__title" = "Excluir o Widget?";

--- a/Bitkit/Resources/Localization/ru.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/ru.lproj/Localizable.strings
@@ -1155,7 +1155,6 @@
 "widgets__widget__edit" = "Фид Виджета";
 "widgets__widget__edit_default" = "По умолчанию";
 "widgets__widget__edit_custom" = "Другое";
-"widgets__widget__edit_description" = "Пожалуйста, выберите, какие поля вы хотите отображать в виджете {name}.";
 "widgets__widget__source" = "Источник";
 "widgets__add" = "Добавить Виджет";
 "widgets__delete__title" = "Удалить виджет?";

--- a/Bitkit/Resources/Localization/ru.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/ru.lproj/Localizable.strings
@@ -631,7 +631,6 @@
 "settings__general__language_other" = "Язык интерфейса";
 "settings__widgets__nav_title" = "Виджеты";
 "settings__widgets__showWidgets" = "Виджеты";
-"settings__widgets__showWidgetTitles" = "Показывать Заголовки Виджетов";
 "settings__notifications__nav_title" = "Фоновые Платежи";
 "settings__notifications__intro__title" = "Получайте Платежи\n<accent>Пассивно</accent>";
 "settings__notifications__intro__text" = "Включите уведомления, чтобы получать платежи, даже когда приложение Bitkit закрыто.";

--- a/Bitkit/Services/MigrationsService.swift
+++ b/Bitkit/Services/MigrationsService.swift
@@ -102,7 +102,6 @@ struct RNSettings: Codable {
     var enableQuickpay: Bool?
     var quickpayAmount: Int?
     var showWidgets: Bool?
-    var showWidgetTitles: Bool?
     var transactionSpeed: String?
     var customFeeRate: Int?
     var hideBalance: Bool?
@@ -1247,9 +1246,6 @@ extension MigrationsService {
         }
         if let showWidgets = settings.showWidgets {
             defaults.set(showWidgets, forKey: "showWidgets")
-        }
-        if let showWidgetTitles = settings.showWidgetTitles {
-            defaults.set(showWidgetTitles, forKey: "showWidgetTitles")
         }
         if let speed = settings.transactionSpeed {
             defaults.set(speed, forKey: "defaultTransactionSpeed")

--- a/Bitkit/ViewModels/SettingsViewModel.swift
+++ b/Bitkit/ViewModels/SettingsViewModel.swift
@@ -215,7 +215,6 @@ class SettingsViewModel: NSObject, ObservableObject {
         requirePinForPayments = false
         useBiometrics = false
         showWidgets = true
-        showWidgetTitles = false
         _coinSelectionMethod = CoinSelectionMethod.autopilot.rawValue
         _coinSelectionAlgorithm = CoinSelectionAlgorithm.branchAndBound.stringValue
         _selectedAddressType = "nativeSegwit"
@@ -260,9 +259,8 @@ class SettingsViewModel: NSObject, ObservableObject {
         return formUrl != defaultUrl
     }
 
-    // Widget Settings
+    /// Widget Settings
     @AppStorage("showWidgets") var showWidgets: Bool = true
-    @AppStorage("showWidgetTitles") var showWidgetTitles: Bool = false
 
     // Coin Selection Settings
     @AppStorage("coinSelectionMethod") private var _coinSelectionMethod: String = CoinSelectionMethod.autopilot.rawValue
@@ -779,7 +777,6 @@ class SettingsViewModel: NSObject, ObservableObject {
         requirePinForPayments = defaults.bool(forKey: "requirePinForPayments")
         useBiometrics = defaults.bool(forKey: "useBiometrics")
         showWidgets = defaults.object(forKey: "showWidgets") as? Bool ?? true
-        showWidgetTitles = defaults.bool(forKey: "showWidgetTitles")
         _coinSelectionMethod = defaults.string(forKey: "coinSelectionMethod") ?? CoinSelectionMethod.autopilot.rawValue
         _coinSelectionAlgorithm = defaults.string(forKey: "coinSelectionAlgorithm") ?? CoinSelectionAlgorithm.branchAndBound.stringValue
         _selectedAddressType = defaults.string(forKey: "selectedAddressType") ?? "nativeSegwit"

--- a/Bitkit/Views/Settings/General/WidgetsSettingsScreen.swift
+++ b/Bitkit/Views/Settings/General/WidgetsSettingsScreen.swift
@@ -24,12 +24,6 @@ struct WidgetsSettingsScreen: View {
                         testIdentifier: "ShowWidgets"
                     )
 
-                    SettingsRow(
-                        title: t("settings__widgets__showWidgetTitles"),
-                        toggle: $settings.showWidgetTitles,
-                        testIdentifier: "ShowWidgetTitles"
-                    )
-
                     SettingsSectionHeader(t("settings__widgets__section_reset"))
                         .padding(.top, 16)
 

--- a/Bitkit/Views/Widgets/FactsWidgetPreviewView.swift
+++ b/Bitkit/Views/Widgets/FactsWidgetPreviewView.swift
@@ -29,7 +29,12 @@ struct FactsWidgetPreviewView: View {
         VStack(alignment: .leading, spacing: 16) {
             NavigationBar(title: widgetName, showMenuButton: false)
 
-            BodyMText(widgetDescription, textColor: .textSecondary)
+            VStack(alignment: .leading, spacing: 0) {
+                BodyMText(widgetDescription, textColor: .textSecondary)
+                    .padding(.bottom, 16)
+
+                Divider().background(Color.white.opacity(0.1))
+            }
 
             VStack(spacing: 16) {
                 carousel

--- a/Bitkit/Views/Widgets/WidgetEditModels.swift
+++ b/Bitkit/Views/Widgets/WidgetEditModels.swift
@@ -93,7 +93,7 @@ enum WidgetEditItemFactory {
                         .renderingMode(.template)
                         .foregroundColor(.brandAccent)
                         .frame(width: 20, height: 20)
-                    BodySSBText(field.label, textColor: .textSecondary)
+                    BodyMText(field.label, textColor: .white80)
                 }
             )
             items.append(
@@ -101,7 +101,7 @@ enum WidgetEditItemFactory {
                     key: field.rawValue,
                     type: .toggleItem,
                     titleView: titleView,
-                    valueView: AnyView(BodySSBText(value, textColor: .textSecondary)),
+                    valueView: AnyView(BodyMSBText(value)),
                     isChecked: field.isEnabled(in: blocksOptions)
                 )
             )

--- a/Bitkit/Views/Widgets/WidgetEditView.swift
+++ b/Bitkit/Views/Widgets/WidgetEditView.swift
@@ -66,14 +66,6 @@ struct WidgetEditView: View {
             )
             .padding(.bottom, 16)
 
-            if !usesV61Header {
-                BodyMText(
-                    t("widgets__widget__edit_description", variables: ["name": widget.name]),
-                    textColor: .textSecondary
-                )
-                .padding(.bottom, 16)
-            }
-
             ScrollView(showsIndicators: false) {
                 LazyVStack(spacing: 0) {
                     ForEach(getItems(), id: \.key) { item in


### PR DESCRIPTION
### Description

This PR:
1. Removes the Show Widget Titles setting end-to-end
2. Removes the legacy description text from the widget edit screens
3. Restyles the Blocks widget edit rows to match Figma v61
4. Adds a divider to the Facts widget preview screen

A set of small follow-up fixes on top of the widgets foundation work, bringing the iOS widget screens in line with Figma v61 and the equivalent Android polish.

The Show Widget Titles setting is removed from the Widgets settings screen and its underlying storage, backup config, and migration mapping. The widget title header (icon + name) now shows only while editing the dashboard, which matches the previous default behavior. Existing persisted values are ignored safely on read.

The widget edit screens no longer show the legacy description paragraph above the options. The Blocks edit rows now use the correct text styles and colors per Figma: regular labels at 80% white and semibold values in full white. The Facts preview screen gains a divider below its description, consistent with the other widget preview screens.

### Linked Issues/Tasks

N/A

### Screenshot / Video


https://github.com/user-attachments/assets/0d9c1468-f687-411e-86ba-c4787fe50d77



### QA Notes
#### Manual Tests
- [x] **1.** Settings → Widgets: no "Show Widget Titles" toggle is shown.
- [x] **2.** Blocks widget → edit: row labels render regular at 80% white, values semibold in full white, icons orange, checkboxes orange when selected / gray when not.
- [x] **3.** Facts widget → preview: a divider appears below the description.
#### Automated Checks
- N/A — copy, color, layout, and dead-code removal only; no automated coverage added or changed. SwiftFormat run locally on the touched files.
