### PR TITLE
chore: upgrade vss-rust-client

### DIFF
--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -61,7 +61,7 @@
       "location" : "https://github.com/synonymdev/vss-rust-client-ffi",
       "state" : {
         "branch" : "master",
-        "revision" : "9f01c135c7e22e594bb1dee749130b82b505ab5e"
+        "revision" : "a004f6ed0fa9f02c52f43bd4bb9bf6217f2be0ed"
       }
     }
   ],


### PR DESCRIPTION
### Description

Upgrades `vss-rust-client-ffi` to version v0.5.13 to fix a build issue with Xcode 26.5

Related: https://github.com/synonymdev/vss-rust-client-ffi/pull/10
