### PR TITLE
fix: disable widget settings only for suggestions

### DIFF
--- a/Bitkit/Components/Widgets/BaseWidget.swift
+++ b/Bitkit/Components/Widgets/BaseWidget.swift
@@ -87,10 +87,7 @@ struct BaseWidget<Content: View>: View {
     }
 
     private var isSettingsDisabled: Bool {
-        switch type {
-        case .suggestions, .facts, .calculator: return true
-        default: return false
-        }
+        type == .suggestions
     }
 
     init(
@@ -256,7 +253,9 @@ struct BaseWidget<Content: View>: View {
     }
 
     private func onEdit() {
-        sheets.showSheet(.widgets, data: WidgetsConfig(initialRoute: .edit(type)))
+        // Widgets without configurable options have nothing to edit, so jump straight to the preview.
+        let route: WidgetsRoute = type.hasOptions ? .edit(type) : .preview(type)
+        sheets.showSheet(.widgets, data: WidgetsConfig(initialRoute: route))
         onEditingEnd?()
     }
 }

--- a/Bitkit/ViewModels/WidgetsViewModel.swift
+++ b/Bitkit/ViewModels/WidgetsViewModel.swift
@@ -189,6 +189,16 @@ enum WidgetType: String, CaseIterable, Codable {
     case weather
     case calculator
     case suggestions
+
+    /// Whether the widget exposes configurable options in the edit sheet.
+    var hasOptions: Bool {
+        switch self {
+        case .blocks, .news, .price, .weather:
+            return true
+        case .calculator, .suggestions, .facts:
+            return false
+        }
+    }
 }
 
 // MARK: - WidgetsViewModel

--- a/Bitkit/Views/Widgets/WidgetEditLogic.swift
+++ b/Bitkit/Views/Widgets/WidgetEditLogic.swift
@@ -22,12 +22,7 @@ class WidgetEditLogic: ObservableObject {
     // MARK: - Computed Properties
 
     var hasOptions: Bool {
-        switch widgetType {
-        case .blocks, .news, .price, .weather:
-            return true
-        case .calculator, .suggestions, .facts:
-            return false
-        }
+        widgetType.hasOptions
     }
 
     var hasEnabledOption: Bool {

--- a/changelog.d/next/disable-only-suggestions-settings.fixed.md
+++ b/changelog.d/next/disable-only-suggestions-settings.fixed.md
@@ -1,0 +1,1 @@
+In widget edit mode, the settings button is now disabled only for the suggestions widget, and opening settings for widgets without options goes straight to the preview.


### PR DESCRIPTION
### Description

This PR narrows the widget edit-mode settings button so it is disabled only for the suggestions widget, and sends widgets without options straight to their preview.

Previously the gear button was disabled for suggestions, facts, and calculator. Facts and calculator have no configurable options, so their button is now enabled again but routes to the widget preview instead of opening an empty edit sheet.

A `hasOptions` property is added to `WidgetType` as the single source of truth for which widgets expose edit options, and the existing edit logic now delegates to it.

### Linked Issues/Tasks

Design: https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ?node-id=40364-130669&m=dev#1785339966

https://github.com/synonymdev/bitkit-ios/pull/577#issuecomment-4624454753

### QA Notes
#### Manual Tests
- [x] **1.** Home → tap edit (pencil) → suggestions widget: gear button is dimmed and not tappable.
- [x] **2.** Home edit → facts widget → tap gear: opens the widget preview sheet (not an empty edit sheet).
- [x] **3.** Home edit → calculator widget → tap gear: opens the widget preview sheet.
- [x] **4a.** `regression:` Home edit → price widget → tap gear: opens the edit sheet with options.
  - [x] **4b.** `regression:` news / blocks / weather → tap gear: opens the edit sheet with options.
#### Automated Checks
- N/A

### Screenshot / Video


https://github.com/user-attachments/assets/9cbd316c-2c98-4a2c-8721-2f3c9d462b77


https://github.com/user-attachments/assets/87e5f0f0-fea5-43bd-88a0-596d877f4ace


