### PR TITLE
fix: strip lnurl scheme prefixes before decode

### DIFF
--- a/Bitkit/Extensions/String+Utilities.swift
+++ b/Bitkit/Extensions/String+Utilities.swift
@@ -1,6 +1,25 @@
 import Foundation
 
 extension String {
+    private static let lightningSchemePrefixes = [
+        "lightning:",
+        "lnurl:",
+        "lnurlw:",
+        "lnurlc:",
+        "lnurlp:",
+    ]
+
+    /// Workaround until bitkit-core strips LNURL scheme prefixes (bitkit-core#70).
+    func removingLightningSchemes() -> String {
+        var value = trimmingCharacters(in: .whitespacesAndNewlines)
+        for prefix in Self.lightningSchemePrefixes {
+            if let range = value.range(of: prefix, options: [.anchored, .caseInsensitive]) {
+                value.removeSubrange(range)
+            }
+        }
+        return value
+    }
+
     enum EllipsisStyle {
         /// Ellipsis in the middle: "ab...de"
         case middle

--- a/Bitkit/ViewModels/AppViewModel.swift
+++ b/Bitkit/ViewModels/AppViewModel.swift
@@ -326,6 +326,8 @@ extension AppViewModel {
         // Reset send state before handling new data
         resetSendState()
 
+        let uri = uri.removingLightningSchemes()
+
         if let samRockSetup = SamRockSetupRequest.parse(uri) {
             handleBTCPayConnection(samRockSetup)
             return
@@ -687,7 +689,7 @@ extension AppViewModel {
     private func performValidation(_ rawValue: String, savingsBalanceSats: Int, spendingBalanceSats: Int) async {
         let currentSequence = manualEntryValidationSequence
 
-        let normalized = normalizeManualEntry(rawValue)
+        let normalized = normalizeManualEntry(rawValue).removingLightningSchemes()
 
         guard !normalized.isEmpty else {
             manualEntryValidationResult = .empty

--- a/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
+++ b/Bitkit/Views/Wallets/Send/SendEnterManuallyView.swift
@@ -77,7 +77,7 @@ struct SendEnterManuallyView: View {
     }
 
     func handleContinue() async {
-        let uri = app.normalizeManualEntry(app.manualEntryInput)
+        let uri = app.normalizeManualEntry(app.manualEntryInput).removingLightningSchemes()
 
         guard !uri.isEmpty, app.isManualEntryInputValid else { return }
 

--- a/BitkitTests/StringUtilitiesTests.swift
+++ b/BitkitTests/StringUtilitiesTests.swift
@@ -1,0 +1,24 @@
+@testable import Bitkit
+import XCTest
+
+final class StringUtilitiesTests: XCTestCase {
+    func testRemovingLightningSchemesStripsLnurlWithdrawPrefix() {
+        let bech32 = "lnurl1example"
+        XCTAssertEqual("lnurlw:\(bech32)".removingLightningSchemes(), bech32)
+    }
+
+    func testRemovingLightningSchemesIsCaseInsensitive() {
+        let bech32 = "lnurl1example"
+        XCTAssertEqual("LNURLW:\(bech32)".removingLightningSchemes(), bech32)
+        XCTAssertEqual("LIGHTNING:lnbc1example".removingLightningSchemes(), "lnbc1example")
+    }
+
+    func testRemovingLightningSchemesLeavesPlainBech32Untouched() {
+        let bech32 = "lnurl1dp68gcpwngkehj8atm6dza6wgx4crmuemh0kuy3ery9mg6venc6umjj0k7jr"
+        XCTAssertEqual(bech32.removingLightningSchemes(), bech32)
+    }
+
+    func testRemovingLightningSchemesTrimsWhitespace() {
+        XCTAssertEqual("  lnurlw:lnurl1example  ".removingLightningSchemes(), "lnurl1example")
+    }
+}

--- a/changelog.d/next/580.fixed.md
+++ b/changelog.d/next/580.fixed.md
@@ -1,0 +1,1 @@
+LNURL withdraw and other prefixed LNURL QR codes scan correctly on iOS.


### PR DESCRIPTION
### Description

Strip `lightning:`, `lnurl:`, `lnurlw:`, `lnurlc:`, and `lnurlp:` prefixes from scanned/pasted strings before decode on iOS — parity with Android's existing workaround.

Fixes LNURL withdraw QRs from sources like demo.lnbits.com that emit prefixed payloads (e.g. `lnurlw:lnurl1…`). Without this, bitkit-core decode fails with `InvalidFormat`.

Workaround until [bitkit-core#70](https://github.com/synonymdev/bitkit-core/issues/70) is fixed upstream.

### Linked Issues/Tasks

- Fixes https://github.com/synonymdev/bitkit-ios/issues/580
- Related: https://github.com/synonymdev/bitkit-core/issues/70

### Screenshot / Video

https://github.com/user-attachments/assets/08f1fa13-986a-47bc-83de-62046dfd41fc




### Test plan

- [x] Unit tests: `StringUtilitiesTests` (prefix strip, case-insensitive, plain bech32 untouched)
- [x] Manual: scan + paste demo.lnbits.com LNURL-withdraw QR on mainnet (Release build) — withdraw UI opens

Made with [Cursor](https://cursor.com)