### PR TITLE
fix: cap send amount pad at available balance

### DIFF
--- a/Bitkit/ViewModels/AmountInputViewModel.swift
+++ b/Bitkit/ViewModels/AmountInputViewModel.swift
@@ -48,12 +48,19 @@ class AmountInputViewModel: ObservableObject {
             maxDecimals: maxDecimals
         )
 
+        // Deletions must always apply, even when the amount is above the cap (e.g. a
+        // prefilled invoice amount over the available balance, or a cap that dropped
+        // after input). The cap only blocks growing the amount; without this, each
+        // delete still leaves the amount over the cap and gets rejected, trapping the
+        // user with an invalid amount they can't reduce.
+        let isDeletion = key == "delete"
+
         // For decimal input (classic Bitcoin and fiat), preserve the text as-is
         // For integer input (modern Bitcoin), format the final amount
         if currency.primaryDisplay == .bitcoin && currency.displayUnit == .modern {
             let newAmount = convertToSats(newText, currency: currency)
 
-            if newAmount <= effectiveMaxAmount {
+            if isDeletion || newAmount <= effectiveMaxAmount {
                 rawInputText = newText
                 displayText = formatDisplayTextFromAmount(newAmount, currency: currency)
                 amountSats = newAmount
@@ -69,7 +76,7 @@ class AmountInputViewModel: ObservableObject {
             // For decimal input, check limits before updating state
             if !newText.isEmpty {
                 let newAmount = convertToSats(newText, currency: currency)
-                if newAmount <= effectiveMaxAmount {
+                if isDeletion || newAmount <= effectiveMaxAmount {
                     // Update both raw input and display text
                     rawInputText = newText
                     // Format with grouping separators but not decimal formatting

--- a/Bitkit/ViewModels/AmountInputViewModel.swift
+++ b/Bitkit/ViewModels/AmountInputViewModel.swift
@@ -7,6 +7,10 @@ class AmountInputViewModel: ObservableObject {
     @Published var displayText: String = ""
     @Published var errorKey: String?
 
+    /// Optional per-screen cap (e.g. the max sendable balance in the send flow).
+    /// When set, input is additionally blocked above this value, on top of `maxAmount`.
+    var maxAmountOverride: UInt64?
+
     // MARK: - Constants
 
     private let maxAmount: UInt64 = 999_999_999
@@ -14,6 +18,12 @@ class AmountInputViewModel: ObservableObject {
     private let maxDecimalInputLength = 20
     private let classicBitcoinDecimals = 8
     private let fiatDecimals = 2
+
+    /// The active upper bound for input: the global `maxAmount`, further restricted by `maxAmountOverride` when set.
+    private var effectiveMaxAmount: UInt64 {
+        guard let maxAmountOverride else { return maxAmount }
+        return Swift.min(maxAmount, maxAmountOverride)
+    }
 
     // MARK: - Private Properties
 
@@ -43,7 +53,7 @@ class AmountInputViewModel: ObservableObject {
         if currency.primaryDisplay == .bitcoin && currency.displayUnit == .modern {
             let newAmount = convertToSats(newText, currency: currency)
 
-            if newAmount <= maxAmount {
+            if newAmount <= effectiveMaxAmount {
                 rawInputText = newText
                 displayText = formatDisplayTextFromAmount(newAmount, currency: currency)
                 amountSats = newAmount
@@ -59,7 +69,7 @@ class AmountInputViewModel: ObservableObject {
             // For decimal input, check limits before updating state
             if !newText.isEmpty {
                 let newAmount = convertToSats(newText, currency: currency)
-                if newAmount <= maxAmount {
+                if newAmount <= effectiveMaxAmount {
                     // Update both raw input and display text
                     rawInputText = newText
                     // Format with grouping separators but not decimal formatting

--- a/Bitkit/Views/Wallets/Send/SendAmountView.swift
+++ b/Bitkit/Views/Wallets/Send/SendAmountView.swift
@@ -163,6 +163,8 @@ struct SendAmountView: View {
                     await calculateRoutingFee()
                 }
             }
+
+            updateInputCap()
         }
         .onChange(of: app.selectedWalletToPayFrom) { _, newValue in
             // Recalculate max sendable amount when switching wallet types
@@ -185,6 +187,9 @@ struct SendAmountView: View {
                     await calculateMaxSendableAmount()
                 }
             }
+        }
+        .onChange(of: availableAmount) { _, _ in
+            updateInputCap()
         }
     }
 
@@ -250,6 +255,11 @@ struct SendAmountView: View {
             Logger.error(error, context: "Failed to set fee rate or send amount")
             app.toast(type: .error, title: "Send Error", description: error.localizedDescription)
         }
+    }
+
+    private func updateInputCap() {
+        // Don't cap when nothing is sendable, so the pad stays usable (Continue stays disabled instead).
+        amountViewModel.maxAmountOverride = availableAmount > 0 ? availableAmount : nil
     }
 
     private func calculateMaxSendableAmount() async {

--- a/BitkitTests/NumberPadTests.swift
+++ b/BitkitTests/NumberPadTests.swift
@@ -240,6 +240,35 @@ final class NumberPadTests: XCTestCase {
         XCTAssertEqual(viewModel.amountSats, 100_000)
     }
 
+    func testDeleteAllowedWhenAmountAboveCap() {
+        let viewModel = AmountInputViewModel()
+        let currency = mockCurrency(primaryDisplay: .bitcoin, displayUnit: .modern)
+
+        // A prefilled amount lands above a low cap (e.g. an invoice that exceeds the
+        // available balance, set via updateFromSats which does not enforce the cap).
+        viewModel.maxAmountOverride = 1000
+        viewModel.updateFromSats(123_456, currency: currency)
+        XCTAssertEqual(viewModel.amountSats, 123_456)
+
+        // Adding a digit is still blocked: it would grow the amount further above the cap.
+        viewModel.handleNumberPadInput("7", currency: currency)
+        XCTAssertEqual(viewModel.amountSats, 123_456) // unchanged
+        XCTAssertNotNil(viewModel.errorKey)
+
+        // Deleting is allowed even though the result is still above the cap, so the user
+        // can reduce an over-cap amount instead of being stuck.
+        viewModel.handleNumberPadInput("delete", currency: currency)
+        XCTAssertEqual(viewModel.displayText, "12 345")
+        XCTAssertEqual(viewModel.amountSats, 12345)
+        XCTAssertNil(viewModel.errorKey)
+
+        // Keep deleting down below the cap.
+        viewModel.handleNumberPadInput("delete", currency: currency) // 1 234
+        viewModel.handleNumberPadInput("delete", currency: currency) // 123
+        XCTAssertEqual(viewModel.amountSats, 123)
+        XCTAssertNil(viewModel.errorKey)
+    }
+
     // MARK: - Leading Zero Tests
 
     func testLeadingZeroBehavior() {

--- a/BitkitTests/NumberPadTests.swift
+++ b/BitkitTests/NumberPadTests.swift
@@ -53,6 +53,40 @@ final class NumberPadTests: XCTestCase {
         XCTAssertNotNil(viewModel.errorKey)
     }
 
+    func testMaxAmountOverrideBlocksInputAboveBalance() {
+        let viewModel = AmountInputViewModel()
+        let currency = mockCurrency(primaryDisplay: .bitcoin, displayUnit: .modern)
+        viewModel.maxAmountOverride = 50000
+
+        // Up to the cap is allowed
+        for digit in "50000" {
+            viewModel.handleNumberPadInput(String(digit), currency: currency)
+        }
+        XCTAssertEqual(viewModel.amountSats, 50000)
+
+        // Next keystroke would make 500_000 > 50_000 and is blocked
+        viewModel.handleNumberPadInput("0", currency: currency)
+        XCTAssertEqual(viewModel.amountSats, 50000) // Should not change
+        XCTAssertNotNil(viewModel.errorKey)
+    }
+
+    func testClearingMaxAmountOverrideRestoresGlobalCap() {
+        let viewModel = AmountInputViewModel()
+        let currency = mockCurrency(primaryDisplay: .bitcoin, displayUnit: .modern)
+
+        // With a low override, input is blocked above it
+        viewModel.maxAmountOverride = 100
+        viewModel.handleNumberPadInput("9", currency: currency)
+        viewModel.handleNumberPadInput("9", currency: currency)
+        viewModel.handleNumberPadInput("9", currency: currency) // 999 > 100 -> blocked
+        XCTAssertEqual(viewModel.amountSats, 99)
+
+        // Clearing the override lets input grow again, up to the global cap
+        viewModel.maxAmountOverride = nil
+        viewModel.handleNumberPadInput("9", currency: currency)
+        XCTAssertEqual(viewModel.amountSats, 999)
+    }
+
     // MARK: - Classic Bitcoin Tests
 
     func testClassicBitcoinDecimalInput() {

--- a/changelog.d/next/346.fixed.md
+++ b/changelog.d/next/346.fixed.md
@@ -1,0 +1,1 @@
+The send amount number pad now caps entry at your available balance, so you can no longer enter more than you can send.


### PR DESCRIPTION
Fixes #346

### Description

This PR makes the send amount number pad refuse entry above your available balance. Before, you could type any amount and the screen only disabled the Continue button once you went over; now the number pad itself stops you at the maximum you can send, using the same haptic and error flash it already shows at its upper input limit.

The cap follows the selected wallet: spendable on-chain balance minus the network fee for savings, or outbound capacity minus the routing-fee estimate for spending. Tapping the Available label still fills the exact maximum, and the Continue-button validation stays in place as a backstop.

### Linked Issues/Tasks

Fixes #346

### Screenshot / Video



https://github.com/user-attachments/assets/c67f408a-0dc4-4c16-84be-e2bfd6d87ade





### QA Notes
#### Manual Tests
- [ ] **1.** Send -> paste/scan on-chain invoice -> Amount: type past the displayed Available: amount freezes at the max, haptic + error flash, can't exceed.
  - [ ] **1b.** tap the Available label: fills exactly the max, Continue enabled.
  - [ ] **1c.** `regression:` enter a normal under-balance amount: Continue enabled, proceeds to Confirm.
- [ ] **2.** Spending selected -> Amount: type past Available: capped at outbound max minus the routing-fee estimate.
- [ ] **3.** `regression:` zero available balance -> Amount: pad still accepts input (not frozen), Continue stays disabled.
#### Automated Checks
- Unit tests added: dynamic input cap in `BitkitTests/NumberPadTests.swift` (`testMaxAmountOverrideBlocksInputAboveBalance`, `testClearingMaxAmountOverrideRestoresGlobalCap`).
- Built for iOS Simulator (Debug) locally; `BitkitTests/NumberPadTests` passes (24 tests).
- Verified on-device (iOS 26.4 simulator, regtest): on-chain Send number pad froze at the available balance and rejected over-max input (see recording).
- CI: standard build/test checks run by the PR bot.

