### PR TITLE
fix(lightning): closed channel short channel ID

### DIFF
--- a/Bitkit/Extensions/ShortChannelId.swift
+++ b/Bitkit/Extensions/ShortChannelId.swift
@@ -11,3 +11,28 @@ extension UInt64 {
         return "\(blockHeight)x\(txIndex)x\(outputIndex)"
     }
 }
+
+/// Whether the string is a Core Lightning `block x tx x output` short channel id (e.g. `792906x599x1`):
+/// exactly three non-empty, all-digit components separated by `x`.
+private func isClnShortChannelId(_ value: String) -> Bool {
+    let parts = value.split(separator: "x", omittingEmptySubsequences: false)
+    return parts.count == 3 && parts.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+}
+
+/// Resolves the short channel id to display, formatted as `block x tx x output`. Uses the channel's
+/// own scid (open channels, a numeric BOLT scid) and, for closed channels which carry none, the scid
+/// from the confidently-linked Blocktank order. Blocktank delivers it already in `block x tx x output`
+/// form, so an `x`-formatted value is kept as-is and only a numeric value is decoded. Nil when unavailable.
+func resolveDisplayShortChannelId(channelScid: UInt64?, linkedOrderScid: String?) -> String? {
+    if let channelScid {
+        return channelScid.formattedAsShortChannelId
+    }
+
+    guard let orderScid = linkedOrderScid, !orderScid.isEmpty else { return nil }
+
+    if let numeric = UInt64(orderScid) {
+        return numeric.formattedAsShortChannelId
+    }
+
+    return isClnShortChannelId(orderScid) ? orderScid : nil
+}

--- a/Bitkit/Extensions/ShortChannelId.swift
+++ b/Bitkit/Extensions/ShortChannelId.swift
@@ -16,7 +16,7 @@ extension UInt64 {
 /// exactly three non-empty, all-digit components separated by `x`.
 private func isClnShortChannelId(_ value: String) -> Bool {
     let parts = value.split(separator: "x", omittingEmptySubsequences: false)
-    return parts.count == 3 && parts.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+    return parts.count == 3 && parts.allSatisfy { !$0.isEmpty && $0.allSatisfy { $0.isASCII && $0.isNumber } }
 }
 
 /// Resolves the short channel id to display, formatted as `block x tx x output`. Uses the channel's

--- a/Bitkit/ViewModels/ChannelDetailsViewModel.swift
+++ b/Bitkit/ViewModels/ChannelDetailsViewModel.swift
@@ -76,13 +76,8 @@ class ChannelDetailsViewModel: ObservableObject {
     /// scid (open channels) and, for closed channels (which are not stored with one), the scid from
     /// a confidently linked Blocktank order. Hidden otherwise rather than showing a guessed value.
     var displayShortChannelId: String? {
-        if let scid = foundChannel?.shortChannelIdValue {
-            return scid.formattedAsShortChannelId
-        }
-        if isLinkedOrderConfident, let scidString = linkedOrder?.channel?.shortChannelId, let scid = UInt64(scidString) {
-            return scid.formattedAsShortChannelId
-        }
-        return nil
+        let linkedOrderScid = isLinkedOrderConfident ? linkedOrder?.channel?.shortChannelId : nil
+        return resolveDisplayShortChannelId(channelScid: foundChannel?.shortChannelIdValue, linkedOrderScid: linkedOrderScid)
     }
 
     /// Find a channel by ID, checking open channels, pending channels, pending orders, then closed channels

--- a/BitkitTests/ChannelDetailsViewModelTests.swift
+++ b/BitkitTests/ChannelDetailsViewModelTests.swift
@@ -49,6 +49,20 @@ final class ChannelDetailsViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testDisplayShortChannelIdKeepsClnFormLinkedOrderScidForClosedChannel() {
+        let vm = ChannelDetailsViewModel.shared
+        // Blocktank delivers the order scid already in `block x tx x output` form; it is kept as-is.
+        vm.foundChannel = makeClosedChannel(fundingTxoTxid: "fundingtxid")
+        var channel = IBtChannel.mock()
+        channel.fundingTx = FundingTx(id: "fundingtxid", vout: 0)
+        channel.shortChannelId = "792906x599x1"
+        vm.linkedOrder = IBtOrder.mock(channel: channel)
+        defer { resetDisplayState(vm) }
+
+        XCTAssertEqual(vm.displayShortChannelId, "792906x599x1")
+    }
+
+    @MainActor
     func testDisplayIgnoresWeaklyLinkedOrder() {
         let vm = ChannelDetailsViewModel.shared
         // Funding txids differ, so the order is only a loose counterparty match and could belong to

--- a/BitkitTests/ShortChannelIdTests.swift
+++ b/BitkitTests/ShortChannelIdTests.swift
@@ -44,5 +44,7 @@ final class ShortChannelIdTests: XCTestCase {
         XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "not-a-scid"))
         XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "792906x599"))
         XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "792906xx1"))
+        // Non-ASCII numeric glyphs (e.g. superscripts) are not valid scid digits.
+        XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "²x³x¹"))
     }
 }

--- a/BitkitTests/ShortChannelIdTests.swift
+++ b/BitkitTests/ShortChannelIdTests.swift
@@ -21,4 +21,28 @@ final class ShortChannelIdTests: XCTestCase {
         let scid = (UInt64(0xFFFFFF) << 40) | (UInt64(0xFFFFFF) << 16) | UInt64(0xFFFF)
         XCTAssertEqual(scid.formattedAsShortChannelId, "16777215x16777215x65535")
     }
+
+    func testResolveDisplayShortChannelIdDecodesOpenChannelScid() {
+        XCTAssertEqual(resolveDisplayShortChannelId(channelScid: 854_845_001_888_432_128, linkedOrderScid: nil), "777477x916x0")
+    }
+
+    func testResolveDisplayShortChannelIdKeepsClnFormLinkedOrderScidForClosedChannel() {
+        // Blocktank delivers the order scid already in `block x tx x output` form.
+        XCTAssertEqual(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "792906x599x1"), "792906x599x1")
+    }
+
+    func testResolveDisplayShortChannelIdDecodesNumericLinkedOrderScid() {
+        XCTAssertEqual(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "854845001888432128"), "777477x916x0")
+    }
+
+    func testResolveDisplayShortChannelIdReturnsNilWhenBothUnavailable() {
+        XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: nil))
+        XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: ""))
+    }
+
+    func testResolveDisplayShortChannelIdReturnsNilForMalformedOrderScid() {
+        XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "not-a-scid"))
+        XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "792906x599"))
+        XCTAssertNil(resolveDisplayShortChannelId(channelScid: nil, linkedOrderScid: "792906xx1"))
+    }
 }


### PR DESCRIPTION
This PR fixes the Channel ID shown on the Lightning Connection Detail screen for closed channels. Connection Details falls back to a confidently linked Blocktank order's short channel ID when a closed channel carries none, but Blocktank delivers that value already in Core Lightning `block x tx x output` form (for example `792906x599x1`). The previous code only accepted a numeric value, so the conversion failed and the Channel ID row was hidden even when the order supplied one.

The display now keeps an already-formatted `block x tx x output` value as-is and still decodes a numeric value as a safeguard. The Channel ID row stays hidden only when no value is available.

This is a port of the Android fix in synonymdev/bitkit-android#1002 and a follow-up to the iOS Connection Details work in #587.

### Linked Issues/Tasks

- Follow-up to #587
- Android port: synonymdev/bitkit-android#1002

### Screenshot / Video

https://mempool.bitkit.stag0.blocktank.to/tx/043a0c37888ed1f6be2057c1eb5357c2049b92b64a561ca837cc9f6e2a790807#vout=0


https://github.com/user-attachments/assets/252ec644-8809-4917-80d6-01d398310fe1


https://github.com/user-attachments/assets/1141635c-51ad-4e70-a898-596c1ea1c0b7



### QA Notes

#### Manual Tests
- [x] **1.** Settings → Advanced → Lightning Connections → Show Closed & Failed → tap a closed connection opened through Blocktank → Connection Detail: Channel ID shows the short channel ID (block x tx x output), not hidden.
- [x] **2.** Connection Detail → tap Channel ID row: copies the short channel ID.
- [x] **3.** `regression:` Lightning Connections → tap an open connection → Connection Detail: Channel ID still shows the short channel ID from the node.


#### Automated Checks
- Unit tests added: cover the short channel id resolver in `BitkitTests/ShortChannelIdTests.swift` — a CLN-form order scid is kept as-is (`792906x599x1`), a numeric order scid is decoded (`854845001888432128` → `777477x916x0`), and empty/malformed values return nothing.
- Unit tests added: cover the closed-channel CLN-form case end-to-end through the confident-link gating in `BitkitTests/ChannelDetailsViewModelTests.swift`.
- Local: `swiftformat` clean; `xcodebuild ... build-for-testing` on the iOS Simulator succeeds.
- CI: standard build and test checks run by the PR bot.
