### PR TITLE
refactor: spring-in, fade-out toast motion

### DIFF
--- a/Bitkit/Components/ToastView.swift
+++ b/Bitkit/Components/ToastView.swift
@@ -21,7 +21,7 @@ struct ToastView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
         .background(accentColor.opacity(0.32))
-        .background(.ultraThinMaterial)
+        .background(BlurView())
         .cornerRadius(16)
         .shadow(color: .black.opacity(0.4), radius: 10, x: 0, y: 25)
         .accessibilityIdentifierIfPresent(toast.accessibilityIdentifier)

--- a/Bitkit/Components/ToastView.swift
+++ b/Bitkit/Components/ToastView.swift
@@ -78,7 +78,7 @@ struct ToastView: View {
                         }
                     } else {
                         // Snap back to original position
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                        withAnimation(ToastMotion.entrance) {
                             dragOffset = 0
                         }
                     }

--- a/Bitkit/Managers/ToastWindowManager.swift
+++ b/Bitkit/Managers/ToastWindowManager.swift
@@ -5,9 +5,11 @@ import UIKit
 /// gets out of the way (a quick fade), mirroring Apple's system banner pattern.
 enum ToastMotion {
     static let entrance: Animation = .snappy(duration: 0.4)
-    static let exit: Animation = .easeOut(duration: 0.2)
-    /// Hit-test frame cleanup waits for the exit to finish.
-    static let exitSettleTime: Double = 0.3
+    static let exit: Animation = .easeOut(duration: exitDuration)
+    /// Hit-test frame cleanup waits for the exit to finish, with a small buffer.
+    static let exitSettleTime: Double = exitDuration + 0.1
+
+    private static let exitDuration: Double = 0.2
 }
 
 @MainActor
@@ -253,9 +255,10 @@ struct ToastWindowView: View {
                         .allowsHitTesting(false) // Spacer doesn't intercept touches
                 }
                 .id(toast.id)
-                // Materialize in place: a short rise with a fade and a slight scale-up reads as
-                // "arriving" without sweeping the whole banner across the screen. Departure is a
-                // plain fade; the toast has been read by then, so any exit motion is just noise.
+                // Materialize in place: the toast settles down from 12pt above its resting
+                // position with a fade and a slight scale-up, reading as "arriving" without
+                // sweeping the whole banner across the screen. Departure is a plain fade; the
+                // toast has been read by then, so any exit motion is just noise.
                 .transition(
                     .asymmetric(
                         insertion: .offset(y: -12).combined(with: .opacity).combined(with: .scale(scale: 0.98)),

--- a/Bitkit/Managers/ToastWindowManager.swift
+++ b/Bitkit/Managers/ToastWindowManager.swift
@@ -1,6 +1,15 @@
 import SwiftUI
 import UIKit
 
+/// Motion for toast show/hide. Arrival is physical (a gentle spring settle); departure just
+/// gets out of the way (a quick fade), mirroring Apple's system banner pattern.
+enum ToastMotion {
+    static let entrance: Animation = .snappy(duration: 0.4)
+    static let exit: Animation = .easeOut(duration: 0.2)
+    /// Hit-test frame cleanup waits for the exit to finish.
+    static let exitSettleTime: Double = 0.3
+}
+
 @MainActor
 class ToastWindowManager: ObservableObject {
     static let shared = ToastWindowManager()
@@ -53,7 +62,7 @@ class ToastWindowManager: ObservableObject {
         window.hasToast = true
 
         // Show the toast with animation
-        withAnimation(.easeInOut(duration: 0.4)) {
+        withAnimation(ToastMotion.entrance) {
             currentToast = toast
         }
 
@@ -66,12 +75,12 @@ class ToastWindowManager: ObservableObject {
     func hideToast() {
         cancelAutoHide()
         toastWindow?.hasToast = false
-        withAnimation(.easeInOut(duration: 0.4)) {
+        withAnimation(ToastMotion.exit) {
             currentToast = nil
         }
         // Clear frame after animation completes to avoid race conditions during animation
         Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(0.4 * 1_000_000_000))
+            try? await Task.sleep(nanoseconds: UInt64(ToastMotion.exitSettleTime * 1_000_000_000))
             self?.toastWindow?.toastFrame = .zero
         }
     }
@@ -112,12 +121,12 @@ class ToastWindowManager: ObservableObject {
             // Atomically update both hasToast and toastFrame
             toastWindow?.hasToast = false
 
-            withAnimation(.easeInOut(duration: 0.4)) {
+            withAnimation(ToastMotion.exit) {
                 self.currentToast = nil
             }
 
             // Clear frame after animation completes to avoid race conditions during animation
-            try? await Task.sleep(nanoseconds: UInt64(0.4 * 1_000_000_000))
+            try? await Task.sleep(nanoseconds: UInt64(ToastMotion.exitSettleTime * 1_000_000_000))
             guard !Task.isCancelled else { return }
             toastWindow?.toastFrame = .zero
 
@@ -244,7 +253,15 @@ struct ToastWindowView: View {
                         .allowsHitTesting(false) // Spacer doesn't intercept touches
                 }
                 .id(toast.id)
-                .transition(.move(edge: .top).combined(with: .opacity))
+                // Materialize in place: a short rise with a fade and a slight scale-up reads as
+                // "arriving" without sweeping the whole banner across the screen. Departure is a
+                // plain fade; the toast has been read by then, so any exit motion is just noise.
+                .transition(
+                    .asymmetric(
+                        insertion: .offset(y: -12).combined(with: .opacity).combined(with: .scale(scale: 0.98)),
+                        removal: .opacity
+                    )
+                )
             }
         }
         .onPreferenceChange(ToastFramePreferenceKey.self) { frame in
@@ -252,7 +269,9 @@ struct ToastWindowView: View {
             guard !frame.isEmpty else { return }
             toastManager.updateToastFrame(globalFrame: frame)
         }
-        .animation(.easeInOut(duration: 0.4), value: toastManager.currentToast)
+        // No .animation(_:value:) here: it would override the withAnimation transactions in
+        // ToastWindowManager and force both directions onto one curve. Show and hide set their
+        // own (asymmetric) animations.
         .preferredColorScheme(.dark) // Force dark color scheme
     }
 }

--- a/changelog.d/next/592.changed.md
+++ b/changelog.d/next/592.changed.md
@@ -1,1 +1,1 @@
-Toast notifications now arrive with a gentle spring settle and fade out quickly, replacing the previous flat slide animation.
+Toast notifications now arrive with a gentle spring settle, fade out quickly, and render their accent colors true to the design instead of washed out.

--- a/changelog.d/next/592.changed.md
+++ b/changelog.d/next/592.changed.md
@@ -1,0 +1,1 @@
+Toast notifications now arrive with a gentle spring settle and fade out quickly, replacing the previous flat slide animation.


### PR DESCRIPTION
### Description

This PR aims to establish a more-polished motion design for the app's toast show/hide motion, which previously animated with a flat ease (`easeInOut`, 0.4s) that felt a tad mechanical compared to the spring motion used across the rest of the app (including the toast's own drag-to-dismiss snap-back).

I went with a behavior that's asymmetric, mirroring Apple's system banner pattern:

1. **Arrival is physical**: the toast materializes in place, settling down from 12pt above its resting position with an opacity fade, and a slight 0.98 → 1.0 scale, driven by `.snappy(duration: 0.4)` (a gently damped spring preset). This replaces the full slide-in from offscreen, which swept the whole banner across the top of the screen.
2. **Departure gets out of the way**: a quick fade (`easeOut`, 0.2s). By dismissal time the toast has been read, so exit motion is kept to a minimum.
3. The drag-to-dismiss snap-back now uses the same entrance curve, so the component speaks one motion dialect.

The motion constants live in a single `ToastMotion` namespace. And I wanted to make them a convenient starting point for any feedback from the design team:

| Knob | Value |
| --- | --- |
| Entrance curve | `.snappy(duration: 0.4)` |
| Settle distance (from above) | 12pt |
| Entrance scale | 0.98 → 1.0 |
| Exit curve | `.easeOut(duration: 0.2)` |

**Note on cross-platform consistency:** Android currently slides the full toast in and out from the top edge with a fade, symmetric in both directions (`fadeIn() + slideInVertically` / `fadeOut() + slideOutVertically` in `ToastView.kt`), and its drag snap-back uses a 0.7-damping spring, the same entrance/gesture mismatch this PR addresses on iOS. If this PR goes forward, a counterpart Android PR maps 1:1 (`fadeIn + slideInVertically(-12dp) + scaleIn(0.98)` in, `fadeOut` out, snap-back damping aligned), and I can take that on as a follow-up.

### Linked Issues/Tasks

Follow-up to the motion conversation in #585: https://github.com/synonymdev/bitkit-ios/pull/585#issuecomment-4673702300

### Screenshot / Video

https://github.com/user-attachments/assets/d652e597-e06c-4a44-a32b-0418823d11e1

Feels a bit less like the toast is being rammed into your face, IMO 😂 ... also plays nicely with "standard", informational toast messages:

https://github.com/user-attachments/assets/7d3804e4-e573-4a43-ad14-0a3d657fbfed


### QA Notes
#### Manual Tests
- [ ] **1.** Settings → Advanced → Address Viewer → long-press an address: Copied toast settles in from just above, auto-hides after 4s with a quick fade.
- [ ] **2.** `regression:` toast visible → tap content beneath the toast: taps pass through, and the area is tappable again after dismiss.
- [ ] **3a.** `regression:` drag the toast upward: dismisses.
  - [ ] **3b.** small downward drag → release: snaps back and auto-hide resumes.
#### Automated Checks
- No automated coverage exists for toast animation; verified by simulator recording (before/after videos above).
- CI: standard build and test checks run by the PR bot.

