### PR TITLE
fix: align error toast color with brand

### DIFF
--- a/Bitkit/Components/ToastView.swift
+++ b/Bitkit/Components/ToastView.swift
@@ -92,7 +92,7 @@ struct ToastView: View {
         case .info: return .blueAccent
         case .lightning: return .purpleAccent
         case .warning: return .brandAccent
-        case .error: return .redAccent
+        case .error: return .brandAccent
         }
     }
 }

--- a/changelog.d/next/594.changed.md
+++ b/changelog.d/next/594.changed.md
@@ -1,0 +1,1 @@
+Error toasts now use Bitkit's brand color instead of a separate red accent, matching the design across all toast types.


### PR DESCRIPTION
Fixes #593

### Description

This PR changes error toasts to use Bitkit's brand color (#FF4400) in place of the red accent (#E95164), following the design direction in #593. The design prototype renders all of its failure toasts in the brand color, and per John it is close enough to the red accent that using one color is the cleaner choice. Error and warning toasts now share the brand accent.

### Linked Issues/Tasks

Fixes #593 (spun out of the color-alignment review on #592)

### Screenshot / Video

<img width="900" height="1062" alt="pr593-error-toast-comparison" src="https://github.com/user-attachments/assets/45fc53bd-0672-456f-abde-19ed114afa38" />


### QA Notes
#### Manual Tests
- [ ] **1.** Send → Paste Invoice with invalid clipboard text: Unable To Read QR toast renders with the brand orange title and tint, not crimson.
- [ ] **2.** `regression:` Settings → Advanced → Address Viewer → long-press an address: Copied To Clipboard toast is still green.
#### Automated Checks
N/A (one-line palette change; verified visually on the iOS simulator)
