### PR TITLE
fix: restore Explore button on transfers

### DIFF
--- a/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
@@ -566,26 +566,22 @@ struct ActivityItemView: View {
                 }
                 .accessibilityIdentifier(boostButtonIdentifier)
 
-                if isTransfer, let channelId = transferChannelId {
-                    CustomButton(
-                        title: t("lightning__connection"), size: .small,
-                        icon: Image("bolt-hollow")
-                            .foregroundColor(accentColor),
-                        shouldExpand: true
-                    ) {
-                        navigation.navigate(.connectionDetail(channelId: channelId))
-                    }
-                    .accessibilityIdentifier("ChannelButton")
-                } else {
-                    exploreButton
-                }
+                exploreButton
             }
             .frame(maxWidth: .infinity)
 
-            // Transfers replace the Explore button above with Connection, so give them their own
-            // Explore row to reach the on-chain details (tx id, block explorer) of the channel transaction.
-            if isTransfer, transferChannelId != nil {
-                exploreButton
+            // Transfers get a dedicated full-width Connection row to their channel, keeping the Explore
+            // button in the same slot as every other on-chain activity (tx id, block explorer) for consistency.
+            if isTransfer, let channelId = transferChannelId {
+                CustomButton(
+                    title: t("lightning__connection"), size: .small,
+                    icon: Image("bolt-hollow")
+                        .foregroundColor(accentColor),
+                    shouldExpand: true
+                ) {
+                    navigation.navigate(.connectionDetail(channelId: channelId))
+                }
+                .accessibilityIdentifier("ChannelButton")
             }
         }
         .frame(maxWidth: .infinity)

--- a/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
@@ -570,8 +570,6 @@ struct ActivityItemView: View {
             }
             .frame(maxWidth: .infinity)
 
-            // Transfers get a dedicated full-width Connection row to their channel, keeping the Explore
-            // button in the same slot as every other on-chain activity (tx id, block explorer) for consistency.
             if isTransfer, let channelId = transferChannelId {
                 CustomButton(
                     title: t("lightning__connection"), size: .small,

--- a/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
+++ b/Bitkit/Views/Wallets/Activity/ActivityItemView.swift
@@ -577,20 +577,30 @@ struct ActivityItemView: View {
                     }
                     .accessibilityIdentifier("ChannelButton")
                 } else {
-                    CustomButton(
-                        title: t("wallet__activity_explore"), size: .small,
-                        icon: Image("branch")
-                            .foregroundColor(accentColor),
-                        shouldExpand: true
-                    ) {
-                        navigation.navigate(.activityExplorer(viewModel.activity))
-                    }
-                    .accessibilityIdentifier("ActivityTxDetails")
+                    exploreButton
                 }
             }
             .frame(maxWidth: .infinity)
+
+            // Transfers replace the Explore button above with Connection, so give them their own
+            // Explore row to reach the on-chain details (tx id, block explorer) of the channel transaction.
+            if isTransfer, transferChannelId != nil {
+                exploreButton
+            }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var exploreButton: some View {
+        CustomButton(
+            title: t("wallet__activity_explore"), size: .small,
+            icon: Image("branch")
+                .foregroundColor(accentColor),
+            shouldExpand: true
+        ) {
+            navigation.navigate(.activityExplorer(viewModel.activity))
+        }
+        .accessibilityIdentifier("ActivityTxDetails")
     }
 
     private func detachContact() async {

--- a/changelog.d/next/361.fixed.md
+++ b/changelog.d/next/361.fixed.md
@@ -1,0 +1,1 @@
+Channel close and transfer activities, including force closes, now offer an Explore button so the on-chain transaction ID and block explorer details are accessible.


### PR DESCRIPTION
Fixes #361

This PR restores access to the on-chain details for transfer activities, including force closes.

### Description

A force close, like any channel close, settles on-chain, so Bitkit already stores it as an on-chain activity with a transaction id, inputs, outputs, and a block explorer link. Those details had become unreachable from the activity screen: the transfer detail layout replaced the "Explore" button with a "Connection" button, and "Connection" only opens the channel, not the transaction. Issue #361 shows a force close where there is no way to see the transaction id.

This adds a dedicated full-width "Explore" row for transfer activities, shown alongside the existing "Connection" button, so the on-chain transaction details are reachable again. Regular on-chain and Lightning activities are unchanged. The behavior applies to every transfer because a stored on-chain activity does not record whether a close was cooperative or forced, and both are real on-chain transactions with a transaction id worth surfacing.

### Linked Issues/Tasks

#361 - [Bug] Force Close TX showing in the LN activity template

### Screenshot / Video

Before (issue #361) on the left, after on the right:

<img width="1520" height="1650" alt="issue361-before-after" src="https://github.com/user-attachments/assets/5b9a9017-9d68-4c2d-886f-2694f2ce68c9" />

### QA Notes
#### Manual Tests
- [ ] **1.** open a connection → close it → Activity → tap the From Spending transfer → Activity Item: shows Boost, Connection, and a new full-width Explore button.
- [ ] **2.** Activity Item (transfer) → Explore → Activity Explorer: shows transaction id, inputs, outputs, and Open Block Explorer.
- [ ] **3.** Activity Item (transfer) → Connection: still opens the connection detail.
- [ ] **4.** `regression:` received on-chain activity → Activity Item: Explore appears in its usual slot, with no extra row.
- [ ] **5.** `regression:` LN payment → Activity Item: unchanged; Explore opens preimage and invoice details.
#### Automated Checks
- BitkitTests unit suite passes locally (activity storage and the other unit suites, 0 failures). Two `AddressTypeIntegrationTests` fail only because the live Blocktank regtest deposit endpoint returns 404; they depend on that external service and are unrelated to this change.
- Verified the full flow live on the iOS simulator against regtest: opened a connection, closed it, and confirmed the From Spending activity now reaches the transaction details through Explore.
