### PR TITLE
fix: reset suggestions widget when re-added empty

### DIFF
--- a/Bitkit/Components/Widgets/Suggestions.swift
+++ b/Bitkit/Components/Widgets/Suggestions.swift
@@ -164,6 +164,10 @@ struct Suggestions: View {
     /// When true, show a fixed set of static cards and ignore taps (e.g. widget preview).
     var isPreview: Bool = false
 
+    /// When editing the home grid, keep the widget visible (and reorderable/removable) by falling
+    /// back to the static preview set when there are no live cards to show.
+    var isEditing: Bool = false
+
     var previewCardIds: [String]?
 
     static let previewSheetCardIds = ["backupSeedPhrase", "pin", "transferToSpending", "support"]
@@ -250,8 +254,30 @@ struct Suggestions: View {
         )
     }
 
+    private var isEditingFallback: Bool {
+        isEditing && !isPreview && visibleCards.isEmpty
+    }
+
+    private var cardsToShow: [SuggestionCardData] {
+        guard isEditingFallback else { return visibleCards }
+        return Self.visibleCards(
+            wallet: wallet,
+            app: app,
+            settings: settings,
+            suggestionsManager: suggestionsManager,
+            pubkyProfile: pubkyProfile,
+            isPaykitUIEnabled: isPaykitUIActive,
+            isPreview: true,
+            previewCardIds: Self.previewSheetCardIds
+        )
+    }
+
+    private var renderStatic: Bool {
+        isPreview || isEditingFallback
+    }
+
     var body: some View {
-        if visibleCards.isEmpty {
+        if cardsToShow.isEmpty {
             EmptyView()
         } else {
             LazyVGrid(
@@ -261,17 +287,17 @@ struct Suggestions: View {
                 ],
                 spacing: 16
             ) {
-                ForEach(visibleCards) { card in
+                ForEach(cardsToShow) { card in
                     SuggestionCard(
                         title: card.title,
                         description: card.description,
                         imageName: card.imageName,
                         accentColor: card.color,
-                        onTap: { if !isPreview { onItemTap(card) } },
+                        onTap: { if !renderStatic { onItemTap(card) } },
                         onDismiss: { dismissCard(card) }
                     )
                     .background {
-                        if isPreview {
+                        if renderStatic {
                             RoundedRectangle(cornerRadius: 16).fill(Color.black)
                         }
                     }
@@ -279,7 +305,7 @@ struct Suggestions: View {
                     .accessibilityIdentifier("Suggestion-\(card.accessibilityId)")
                 }
             }
-            .allowsHitTesting(!isPreview)
+            .allowsHitTesting(!renderStatic)
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: [
                     t(

--- a/Bitkit/Components/Widgets/SuggestionsWidget.swift
+++ b/Bitkit/Components/Widgets/SuggestionsWidget.swift
@@ -13,7 +13,7 @@ struct SuggestionsWidget: View {
             hasBackground: false,
             onEditingEnd: onEditingEnd
         ) {
-            Suggestions(isPreview: isPreview)
+            Suggestions(isPreview: isPreview, isEditing: isEditing)
         }
     }
 }

--- a/Bitkit/Views/Widgets/WidgetPreviewSheetView.swift
+++ b/Bitkit/Views/Widgets/WidgetPreviewSheetView.swift
@@ -9,8 +9,13 @@ struct WidgetPreviewSheetView: View {
     @EnvironmentObject private var app: AppViewModel
     @EnvironmentObject private var currency: CurrencyViewModel
     @EnvironmentObject private var navigation: NavigationViewModel
+    @EnvironmentObject private var settings: SettingsViewModel
     @EnvironmentObject private var sheets: SheetViewModel
+    @EnvironmentObject private var suggestionsManager: SuggestionsManager
+    @EnvironmentObject private var wallet: WalletViewModel
     @EnvironmentObject private var widgets: WidgetsViewModel
+
+    @AppStorage(PaykitFeatureFlags.uiEnabledKey) private var isPaykitUIEnabled = false
 
     @State private var carouselPage: Int
     @State private var showDeleteAlert = false
@@ -53,6 +58,21 @@ struct WidgetPreviewSheetView: View {
 
     private var chosenSize: WidgetSize {
         carouselPage == 0 && supportsSmall ? .small : .wide
+    }
+
+    private var isPaykitUIActive: Bool {
+        PaykitFeatureFlags.isUIAvailable && isPaykitUIEnabled
+    }
+
+    /// Whether the Suggestions widget would currently show no cards (mirrors `HomeWidgetsView`'s filter).
+    private var suggestionsAreEmpty: Bool {
+        Suggestions.visibleCards(
+            wallet: wallet,
+            app: app,
+            settings: settings,
+            suggestionsManager: suggestionsManager,
+            isPaykitUIEnabled: isPaykitUIActive
+        ).isEmpty
     }
 
     var body: some View {
@@ -261,6 +281,9 @@ struct WidgetPreviewSheetView: View {
     // MARK: - Actions
 
     private func onSave() {
+        if type == .suggestions, suggestionsAreEmpty {
+            suggestionsManager.resetDismissed()
+        }
         widgets.saveWidget(type, size: chosenSize)
         sheets.hideSheet()
         navigation.reset()

--- a/Bitkit/Views/Widgets/WidgetPreviewSheetView.swift
+++ b/Bitkit/Views/Widgets/WidgetPreviewSheetView.swift
@@ -9,6 +9,7 @@ struct WidgetPreviewSheetView: View {
     @EnvironmentObject private var app: AppViewModel
     @EnvironmentObject private var currency: CurrencyViewModel
     @EnvironmentObject private var navigation: NavigationViewModel
+    @EnvironmentObject private var pubkyProfile: PubkyProfileManager
     @EnvironmentObject private var settings: SettingsViewModel
     @EnvironmentObject private var sheets: SheetViewModel
     @EnvironmentObject private var suggestionsManager: SuggestionsManager
@@ -64,13 +65,15 @@ struct WidgetPreviewSheetView: View {
         PaykitFeatureFlags.isUIAvailable && isPaykitUIEnabled
     }
 
-    /// Whether the Suggestions widget would currently show no cards (mirrors `HomeWidgetsView`'s filter).
+    /// Whether the Suggestions widget would currently show no cards (mirrors what the live
+    /// `Suggestions` view renders, including the `pubkyProfile` completion check).
     private var suggestionsAreEmpty: Bool {
         Suggestions.visibleCards(
             wallet: wallet,
             app: app,
             settings: settings,
             suggestionsManager: suggestionsManager,
+            pubkyProfile: pubkyProfile,
             isPaykitUIEnabled: isPaykitUIActive
         ).isEmpty
     }

--- a/changelog.d/next/596.fixed.md
+++ b/changelog.d/next/596.fixed.md
@@ -1,0 +1,1 @@
+Re-adding the Suggestions widget now restores the default suggestion cards when all of them had been dismissed.


### PR DESCRIPTION
Fixes #596

This PR fixes the Suggestions widget disappearing after every card is dismissed, both when the widget is re-added and while editing the home grid.

### Description

When every suggestion card is dismissed with the [x] button, the Suggestions widget removes itself from the home grid, which is expected. Two follow-on problems remained, both caused by the dismissed cards being persisted so the widget kept resolving to an empty set of cards:

1. Re-adding the widget (after deleting it in edit mode) never brought it back visually — it only appeared while editing. Re-adding now clears the dismissed cards when the widget would otherwise show nothing, restoring the default set of suggestions. This reuses the same reset as the "Reset Suggestions" action in Settings, and only runs when the suggestions are empty, so re-adding while some cards are still visible leaves those dismissals untouched.

2. With all cards dismissed, the widget was kept in the grid while editing but rendered nothing, leaving an invisible row that could not be reordered or removed. When editing an empty Suggestions widget it now falls back to the static preview set (the same cards shown in the widget preview), so it stays visible and removable. This fallback only happens in edit mode when the suggestions are empty; live cards and other widget types are unaffected.

### Linked Issues/Tasks

Fixes #596 - Suggestion widget bug when empty and re-adding

### Screenshot / Video


https://github.com/user-attachments/assets/3a95638b-4877-4195-903d-c4d08315048e

https://github.com/user-attachments/assets/d1f348c5-757d-48ee-bb03-b9d927b79591



### QA Notes
#### Manual Tests
- [x] **1.** Home → dismiss every Suggestions card with [x]: widget hides once the last card is dismissed.
- [x] **2.** edit mode → remove the Suggestions widget → add it back via Widgets list → preview → Save Widget: widget reappears showing the default suggestion cards.
- [x] **3.** dismiss every card (do not remove widget) → enter edit mode: widget shows the static preview set and can be reordered/removed, instead of an invisible row.
- [x] **4a.** `regression:` dismiss only some cards → remove and re-add the Suggestions widget: remaining cards stay as-is, dismissed ones are not restored.
  - [x] **4b.** `regression:` some cards still visible → enter edit mode: live cards show as normal (no preview fallback).

#### Automated Checks
N/A (no automated coverage changed; verified by code inspection and SwiftFormat)
