### PR TITLE
fix: keep Receive tab selection after editing

### DIFF
--- a/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
@@ -11,6 +11,7 @@ struct ReceiveQr: View {
 
     @State private var selectedTab: ReceiveTab
     @State private var showDetails = false
+    @State private var hasAppliedDefaultTab = false
 
     init(navigationPath: Binding<[ReceiveRoute]>, cjitInvoice: String? = nil, tab: ReceiveTab? = nil) {
         _navigationPath = navigationPath
@@ -113,9 +114,11 @@ struct ReceiveQr: View {
                 .padding(.horizontal, 16)
             }
             .onAppear {
-                // Set default tab to unified if we have a Lightning invoice and no tab was provided
-                if tab == nil && !wallet.bolt11.isEmpty {
+                // Default to the unified ("Auto") tab the first time a Lightning invoice is available.
+                // Guarded so it does not override the tab the user picked (e.g. after returning from Edit).
+                if !hasAppliedDefaultTab && tab == nil && !wallet.bolt11.isEmpty {
                     selectedTab = .unified
+                    hasAppliedDefaultTab = true
                 }
             }
         }

--- a/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
@@ -114,11 +114,15 @@ struct ReceiveQr: View {
                 .padding(.horizontal, 16)
             }
             .onAppear {
-                // Default to the unified ("Auto") tab the first time a Lightning invoice is available.
-                // Guarded so it does not override the tab the user picked (e.g. after returning from Edit).
-                if !hasAppliedDefaultTab && tab == nil && !wallet.bolt11.isEmpty {
-                    selectedTab = .unified
+                // Apply the default-tab choice at most once, on the first appearance. The flag is set
+                // unconditionally here (even before bolt11 is ready) so a later reappearance — e.g.
+                // returning from Edit once the invoice has loaded — can never override the tab the user picked.
+                if !hasAppliedDefaultTab {
                     hasAppliedDefaultTab = true
+                    // Default to the unified ("Auto") tab when a Lightning invoice is already available.
+                    if tab == nil && !wallet.bolt11.isEmpty {
+                        selectedTab = .unified
+                    }
                 }
             }
         }

--- a/changelog.d/next/599.fixed.md
+++ b/changelog.d/next/599.fixed.md
@@ -1,0 +1,1 @@
+The Receive screen now keeps your selected Savings or Spending tab after editing the invoice amount, instead of resetting to Auto.


### PR DESCRIPTION
Fixes #332

### Description

This PR keeps the Receive screen on the Savings or Spending tab you selected after you edit the invoice amount, instead of resetting to the Auto tab.

With an open channel, selecting a tab, tapping Edit, entering an amount, and tapping Show QR used to return to the QR screen with the Auto tab selected. The Receive QR screen re-applied its "default to Auto" behaviour every time it reappeared, including when coming back from the Edit screen, which overwrote the tab you had chosen. It now applies that default only once, on first open, so a tab you pick afterwards is preserved. Opening Receive still defaults to Auto as before.

### Linked Issues/Tasks

Fixes #332 ([Bug]: Edit invoice not remembering savings/spending)

### Screenshot / Video

Same flow on both builds (Savings selected, Edit, enter amount, Show QR). Before the fix the tab resets to Auto; after the fix the selected tab is kept.

<img width="700" alt="bitkit-332-before-after" src="https://github.com/user-attachments/assets/d98e6e09-3ea6-4f48-b629-0302cb07ad13" />

### QA Notes

#### Manual Tests
- [ ] **1.** With an open channel: Receive → tap Savings → Edit → enter amount → Show QR: returns on Savings, not Auto.
- [ ] **2.** With an open channel: Receive → tap Spending → Edit → enter amount → Show QR: returns on Spending.
- [ ] **3.** `regression:` With an open channel: Receive on first open: still defaults to Auto.
- [ ] **4.** `regression:` With no channel: only Savings and Spending tabs show (no Auto); Savings → Edit → Show QR stays on Savings.

#### Automated Checks
- None added. This is a SwiftUI `@State`/view-lifecycle fix with no existing receive-flow unit or UI harness, so it is covered by manual verification rather than a new automated test.
- Verified on the regtest simulator with an open Lightning channel by building the unfixed and fixed binaries and diffing behaviour through the exact repro steps (before resets to Auto, after keeps the selected tab). Geoblock-off Debug builds: BUILD SUCCEEDED.
