### PR TITLE
feat: add network graph reset to recovery

### DIFF
--- a/Bitkit/Components/Button/Button.swift
+++ b/Bitkit/Components/Button/Button.swift
@@ -166,7 +166,8 @@ struct CustomButton: View {
                 size: size,
                 icon: icon,
                 isDisabled: effectiveIsDisabled,
-                isPressed: isPressed
+                isPressed: isPressed,
+                isLoading: isLoading
             ))
         case .tertiary:
             AnyView(TertiaryButtonView(

--- a/Bitkit/Components/Button/SecondaryButtonView.swift
+++ b/Bitkit/Components/Button/SecondaryButtonView.swift
@@ -6,14 +6,19 @@ struct SecondaryButtonView: View {
     let icon: AnyView?
     let isDisabled: Bool
     let isPressed: Bool
+    var isLoading: Bool = false
 
     var body: some View {
         HStack(spacing: 8) {
-            if let icon {
+            if let icon, !isLoading {
                 icon
             }
 
-            if size == .small {
+            if isLoading {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: textColor))
+                    .frame(width: 20, height: 20)
+            } else if size == .small {
                 CaptionBText(title, textColor: textColor)
             } else {
                 BodySSBText(title, textColor: textColor)

--- a/Bitkit/Resources/Localization/en.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/en.lproj/Localizable.strings
@@ -569,6 +569,13 @@
 "security__reset_dialog_title" = "Reset Bitkit?";
 "security__reset_dialog_desc" = "Are you sure you want to reset your Bitkit Wallet? Do you have a backup of your recovery phrase and wallet data?";
 "security__reset_confirm" = "Yes, Reset";
+"security__reset_graph_button" = "Reset Network Graph";
+"security__reset_graph_confirm" = "Yes, Reset";
+"security__reset_graph_dialog_desc" = "This clears the cached Lightning network graph so it is downloaded again from scratch. It can fix \"route not found\" errors. Bitkit will restart automatically.";
+"security__reset_graph_dialog_title" = "Reset Network Graph?";
+"security__reset_graph_error" = "Could not reset the network graph. Please try again.";
+"security__reset_graph_success_description" = "Bitkit will restart in a few seconds to download a fresh network graph.";
+"security__reset_graph_success_title" = "Network Graph Reset";
 "security__recovery" = "Recovery";
 "security__recovery_text" = "You\'ve entered Bitkit\'s recovery mode. Here are some actions to perform when running into issues that prevent the app from fully functioning. Restart the app for a normal startup.";
 "security__display_seed" = "Show Seed Phrase";

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -975,6 +975,10 @@ extension LightningService {
         node?.nodeId()
     }
 
+    var hasNode: Bool {
+        node != nil
+    }
+
     /// Use cached values to avoid blocking LDK calls on main thread
     @MainActor var balances: BalanceDetails? {
         cachedBalances

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -885,7 +885,8 @@ class WalletViewModel: ObservableObject {
     /// since a reset that leaves the graph in VSS is ineffective. Caller should restart afterwards.
     func resetNetworkGraph() async throws {
         Logger.warn("Resetting network graph (manual)", context: "WalletViewModel")
-        if nodeLifecycleState == .starting || nodeLifecycleState == .running {
+        await waitForNodeToRun(timeoutSeconds: 5.0)
+        if lightningService.hasNode {
             try await stopLightningNode()
         }
         try await clearNetworkGraph()

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -897,8 +897,8 @@ class WalletViewModel: ObservableObject {
     }
 
     /// Clears the cached Lightning network graph: the local cache file and the VSS backup copy.
-    /// Shared by the legacy one-time startup cleanup and the manual recovery reset.
-    private func clearNetworkGraph() async throws {
+    /// Shared by the legacy one-time startup cleanup, the manual recovery reset, and the LDK debug screen.
+    func clearNetworkGraph() async throws {
         try await lightningService.deleteNetworkGraph()
         _ = try await VssBackupClient.shared.deleteKey("network_graph")
         Logger.info("Cleared network graph from VSS", context: "WalletViewModel")

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -885,7 +885,11 @@ class WalletViewModel: ObservableObject {
     /// since a reset that leaves the graph in VSS is ineffective. Caller should restart afterwards.
     func resetNetworkGraph() async throws {
         Logger.warn("Resetting network graph (manual)", context: "WalletViewModel")
-        await waitForNodeToRun(timeoutSeconds: 5.0)
+        // Let any in-progress startup settle so a node assigned mid-setup isn't missed.
+        let settled = await waitForNodeToRun(timeoutSeconds: 5.0)
+        if !settled, nodeLifecycleState == .starting {
+            throw AppError(message: "Node still starting", debugMessage: "resetNetworkGraph aborted: startup in flight")
+        }
         if lightningService.hasNode {
             try await stopLightningNode()
         }

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -873,16 +873,30 @@ class WalletViewModel: ObservableObject {
         guard !legacyNetworkGraphCleanupDone else { return }
         Logger.info("Running legacy network graph cleanup", context: "WalletViewModel")
         do {
-            _ = try await VssBackupClient.shared.deleteKey("network_graph")
+            try await clearNetworkGraph()
         } catch {
-            Logger.debug("VSS deleteKey(network_graph): \(error)", context: "WalletViewModel")
-        }
-        do {
-            try await lightningService.deleteNetworkGraph()
-        } catch {
-            Logger.debug("Local network graph cache cleanup: \(error)", context: "WalletViewModel")
+            Logger.debug("Legacy network graph cleanup: \(error)", context: "WalletViewModel")
         }
         legacyNetworkGraphCleanupDone = true
+    }
+
+    /// Manual recovery action: stop the node and clear the cached network graph so a fresh full
+    /// snapshot is downloaded on the next startup. Non-destructive to funds. Propagates failures
+    /// since a reset that leaves the graph in VSS is ineffective. Caller should restart afterwards.
+    func resetNetworkGraph() async throws {
+        Logger.warn("Resetting network graph (manual)", context: "WalletViewModel")
+        if nodeLifecycleState == .starting || nodeLifecycleState == .running {
+            try await stopLightningNode()
+        }
+        try await clearNetworkGraph()
+    }
+
+    /// Clears the cached Lightning network graph: the local cache file and the VSS backup copy.
+    /// Shared by the legacy one-time startup cleanup and the manual recovery reset.
+    private func clearNetworkGraph() async throws {
+        try await lightningService.deleteNetworkGraph()
+        _ = try await VssBackupClient.shared.deleteKey("network_graph")
+        Logger.info("Cleared network graph from VSS", context: "WalletViewModel")
     }
 
     /// Refreshes cache and syncs all UI state including balance

--- a/Bitkit/Views/Recovery/RecoveryScreen.swift
+++ b/Bitkit/Views/Recovery/RecoveryScreen.swift
@@ -10,7 +10,12 @@ struct RecoveryScreen: View {
     @State private var locked = true
     @State private var showPinCheck = false
     @State private var showWipeAlert = false
+    @State private var showResetGraphAlert = false
+    @State private var isResettingGraph = false
     @State private var pendingAction: PendingAction?
+
+    /// Delay before restarting so the success toast is visible.
+    private let resetGraphRestartDelay: Duration = .seconds(3)
 
     enum PendingAction {
         case showSeed
@@ -21,6 +26,14 @@ struct RecoveryScreen: View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBar(title: t("security__recovery"), showBackButton: false, showMenuButton: false)
                 .padding(.bottom, 16)
+                .alert(t("security__reset_graph_dialog_title"), isPresented: $showResetGraphAlert) {
+                    Button(t("common__cancel"), role: .cancel) {}
+                    Button(t("security__reset_graph_confirm"), role: .destructive) {
+                        onResetGraphConfirmed()
+                    }
+                } message: {
+                    Text(t("security__reset_graph_dialog_desc"))
+                }
 
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
@@ -50,6 +63,15 @@ struct RecoveryScreen: View {
                             isDisabled: locked
                         ) {
                             onContactSupport()
+                        }
+
+                        CustomButton(
+                            title: t("security__reset_graph_button"),
+                            variant: .secondary,
+                            isDisabled: locked || wallet.walletExists != true,
+                            isLoading: isResettingGraph
+                        ) {
+                            showResetGraphAlert = true
                         }
 
                         CustomButton(
@@ -222,5 +244,34 @@ struct RecoveryScreen: View {
         }
 
         showWipeAlert = false
+    }
+
+    private func onResetGraphConfirmed() {
+        isResettingGraph = true
+
+        Task {
+            do {
+                try await wallet.resetNetworkGraph()
+
+                app.toast(
+                    type: .success,
+                    title: t("security__reset_graph_success_title"),
+                    description: t("security__reset_graph_success_description")
+                )
+
+                // Keep the loading state and restart so the graph is re-downloaded on next launch.
+                try? await Task.sleep(for: resetGraphRestartDelay)
+                session.skipSplashOnce = true
+                session.bump()
+            } catch {
+                Logger.error("Failed to reset network graph: \(error)", context: "RecoveryScreen")
+                app.toast(
+                    type: .error,
+                    title: t("common__error"),
+                    description: t("security__reset_graph_error")
+                )
+                isResettingGraph = false
+            }
+        }
     }
 }

--- a/Bitkit/Views/Settings/LdkDebugScreen.swift
+++ b/Bitkit/Views/Settings/LdkDebugScreen.swift
@@ -135,17 +135,8 @@ struct LdkDebugScreen: View {
     }
 
     func deleteNetworkGraph() async {
-        // Delete network graph from VSS
         do {
-            _ = try await VssBackupClient.shared.deleteKey("network_graph")
-        } catch {
-            Logger.debug("VSS deleteKey(network_graph): \(error)", context: "LdkDebugScreen")
-        }
-
-        // Delete local network graph cache
-        do {
-            let lightningService = LightningService.shared
-            try await lightningService.deleteNetworkGraph()
+            try await wallet.clearNetworkGraph()
             app.toast(type: .success, title: "Network Graph Deleted", description: "Network graph deleted successfully")
         } catch {
             Logger.error("Failed to delete network graph: \(error)")

--- a/changelog.d/next/600.fixed.md
+++ b/changelog.d/next/600.fixed.md
@@ -1,0 +1,1 @@
+Recovery mode now has a Reset Network Graph option that re-downloads the Lightning network graph to fix "route not found" errors.


### PR DESCRIPTION
This PR adds a manual "Reset Network Graph" option to the Recovery Mode screen as a safe recovery path for a rare "route not found" issue.

In an observed support case (on the React Native app), a wallet with healthy channels and outbound liquidity could not route payments ("route not found") because its local Lightning network graph had decayed (far fewer channels than a full snapshot). The exact root cause is not yet confirmed — the leading hypothesis is an interaction between LDK pruning stale channels and Rapid Gossip Sync only applying forward deltas without ever re-downloading a full snapshot, but that is not conclusive. The issue appears to be infrequent.

What is clear is that the decayed-graph state breaks routing, and that wiping the cached graph reliably resolves it by forcing a fresh full download. This PR adds that as a manual, low-risk recovery path so support and users can fix an affected wallet without reinstalling, independent of the eventual root-cause fix. This is the iOS port of synonymdev/bitkit-android#1020.

### Description

- Adds a "Reset Network Graph" action to Recovery Mode that clears the cached network graph (the local cache file and the VSS backup copy) so a fresh full snapshot is downloaded on the next launch.
- After a successful reset, the app automatically restarts (~3s later): it cleanly stops the LDK node, then recreates the app scene so startup re-downloads the graph from scratch. The user no longer has to restart manually. Since iOS apps cannot relaunch their own process, this reuses the existing session-bump mechanism (the same one used after a wallet wipe) rather than killing the process.
- Before clearing, it waits for any in-progress startup to settle and stops the node whenever one actually exists — covering the `.stopping`, `.errorStarting`, and `.starting` states as well — so a node can't survive the restart and re-persist the graph after it's cleared.
- Extracts the existing graph-clear logic (local cache + VSS delete) into a shared helper reused by both the automatic startup cleanup and the new manual action.
- The button is enabled only when a wallet exists, is non-destructive to funds, and is behind a confirmation dialog. A success or error toast is shown, the loading spinner is kept through the restart, and the action is clearly logged for support.
- The secondary button variant now renders a loading spinner (it previously only greyed out), so the in-progress reset is visible to the user.

This is a workaround, not a root-cause fix: it does not change the gossip/pruning behaviour and does not try to detect or auto-trigger the reset.

### Linked Issues/Tasks

Ports synonymdev/bitkit-android#1020.

### Screenshot / Video


https://github.com/user-attachments/assets/045c3d5e-2301-432c-8828-15a1cc876de1



```
16:32:20.762  Resetting network graph (manual)
16:32:21.220  Node stopped
16:32:21.224  Deleted network graph cache at: …/regtest/wallet0/ldk/network_graph_cache
16:32:21.930  VSS 'deleteKey' success for 'network_graph': true
16:32:21.932  Cleared network graph from VSS

16:32:25.243  Using gossip source rgs url: …/rgs/snapshot       (fresh setup after restart)
16:32:29.394  No network graph found, creating empty graph      (confirms the wipe took)

16:32:51.101  Searching for a route … overriding the network graph of 0 nodes and 0 channels with 1 first hops
16:32:56.853  Successfully sent payment of 114000msat (fee 1000 msat) … preimage "08df9431…"
```


https://github.com/user-attachments/assets/d0779142-b6b0-4613-a638-b9aadc0facc7


### QA Notes

#### Manual Tests
- [x] **1.** Recovery → tap Reset Network Graph → confirm: spinner shows on the button, success toast appears, then the app automatically restarts after a few seconds.
- [x] **2.** After the auto-restart → perform a Lightning payment: payment succeeds.
- [x] **3.** `regression:` Recovery with no wallet: Reset Network Graph button is disabled.

#### Automated Checks
- Local: `xcodebuild` (Debug, iPhone 17 simulator) build passes; SwiftFormat reports no changes.
- CI: standard build and test checks run by the PR bot.
