### PR TITLE
fix: show app update prompt during onboarding

### DIFF
--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -100,8 +100,6 @@ struct AppScene: View {
             ) {
                 config in ForgotPinSheet(config: config)
             }
-            // Presented at the root (not in MainNavView) so the non-critical update prompt
-            // can also surface during onboarding, before a wallet exists (issue #460).
             .sheet(
                 item: $sheets.appUpdateSheetItem,
                 onDismiss: {
@@ -214,9 +212,6 @@ struct AppScene: View {
                 handleBackupFailure(intervalMinutes: intervalMinutes)
             }
             .onReceive(AppUpdateService.shared.$availableUpdate) { update in
-                // The update check finishes asynchronously. If it lands after the initial settle
-                // check (common on a fresh first launch), re-run the evaluation so the non-critical
-                // prompt still surfaces instead of waiting for the next primary-screen entry (issue #460).
                 guard update != nil else { return }
                 TimedSheetManager.shared.reevaluate()
             }
@@ -353,9 +348,8 @@ struct AppScene: View {
             walletIsInitializing = nil
             walletInitShouldFinish = false
 
-            // Let the non-critical update prompt reach the onboarding flow too (issue #460).
-            // Only the app-update sheet can pass shouldShow() without a wallet, so this won't
-            // surface wallet-related timed sheets here.
+            // Only the app-update sheet qualifies without a wallet, so onboarding
+            // won't surface the other (wallet-gated) timed sheets.
             TimedSheetManager.shared.onPrimaryScreenEntered()
         }
         .onDisappear {

--- a/Bitkit/AppScene.swift
+++ b/Bitkit/AppScene.swift
@@ -100,6 +100,17 @@ struct AppScene: View {
             ) {
                 config in ForgotPinSheet(config: config)
             }
+            // Presented at the root (not in MainNavView) so the non-critical update prompt
+            // can also surface during onboarding, before a wallet exists (issue #460).
+            .sheet(
+                item: $sheets.appUpdateSheetItem,
+                onDismiss: {
+                    sheets.hideSheet()
+                    app.ignoreAppUpdate()
+                }
+            ) {
+                config in AppUpdateSheet(config: config)
+            }
             .task(priority: .userInitiated, setupTask)
             .onChange(of: currency.hasStaleData) { _, newValue in handleCurrencyStaleData(newValue) }
             .onChange(of: wallet.walletExists) { _, newValue in handleWalletExistsChange(newValue) }
@@ -201,6 +212,13 @@ struct AppScene: View {
             }
             .onReceive(BackupService.shared.backupFailurePublisher) { intervalMinutes in
                 handleBackupFailure(intervalMinutes: intervalMinutes)
+            }
+            .onReceive(AppUpdateService.shared.$availableUpdate) { update in
+                // The update check finishes asynchronously. If it lands after the initial settle
+                // check (common on a fresh first launch), re-run the evaluation so the non-critical
+                // prompt still surfaces instead of waiting for the next primary-screen entry (issue #460).
+                guard update != nil else { return }
+                TimedSheetManager.shared.reevaluate()
             }
     }
 
@@ -334,6 +352,14 @@ struct AppScene: View {
             // Reset these values if the wallet is wiped
             walletIsInitializing = nil
             walletInitShouldFinish = false
+
+            // Let the non-critical update prompt reach the onboarding flow too (issue #460).
+            // Only the app-update sheet can pass shouldShow() without a wallet, so this won't
+            // surface wallet-related timed sheets here.
+            TimedSheetManager.shared.onPrimaryScreenEntered()
+        }
+        .onDisappear {
+            TimedSheetManager.shared.onPrimaryScreenExited()
         }
     }
 

--- a/Bitkit/MainNavView.swift
+++ b/Bitkit/MainNavView.swift
@@ -47,15 +47,6 @@ struct MainNavView: View {
             config in BoostSheet(config: config)
         }
         .sheet(
-            item: $sheets.appUpdateSheetItem,
-            onDismiss: {
-                sheets.hideSheet()
-                app.ignoreAppUpdate()
-            }
-        ) {
-            config in AppUpdateSheet(config: config)
-        }
-        .sheet(
             item: $sheets.backupSheetItem,
             onDismiss: {
                 sheets.hideSheet()

--- a/Bitkit/Managers/TimedSheets/AppUpdateTimedSheet.swift
+++ b/Bitkit/Managers/TimedSheets/AppUpdateTimedSheet.swift
@@ -11,7 +11,7 @@ struct AppUpdateTimedSheet: TimedSheetItem {
     private let appUpdateService = AppUpdateService.shared
 
     /// App update constants
-    private static let ASK_INTERVAL: TimeInterval = 12 * 60 * 60 // 12 hours - how long this prompt will not show after user dismisses
+    static let ASK_INTERVAL: TimeInterval = 12 * 60 * 60 // 12 hours - how long this prompt will not show after user dismisses
 
     init(appViewModel: AppViewModel) {
         self.appViewModel = appViewModel
@@ -19,31 +19,33 @@ struct AppUpdateTimedSheet: TimedSheetItem {
 
     @MainActor
     func shouldShow() async -> Bool {
+        Self.shouldShow(
+            update: appUpdateService.availableUpdate,
+            ignoreTimestamp: appViewModel.appUpdateIgnoreTimestamp,
+            now: Date().timeIntervalSince1970,
+            isE2E: Env.isE2E
+        )
+    }
+
+    /// Pure eligibility check, extracted so it can be unit-tested without an `AppViewModel` or the shared service.
+    static func shouldShow(update: AppUpdateInfo?, ignoreTimestamp: TimeInterval, now: TimeInterval, isE2E: Bool) -> Bool {
         // Don't show in e2e test environment
-        guard !Env.isE2E else {
+        guard !isE2E else {
             return false
         }
 
-        // Check if enough time has passed since last ignore
-        let currentTime = Date().timeIntervalSince1970
-        let isTimeoutOver = currentTime - appViewModel.appUpdateIgnoreTimestamp > Self.ASK_INTERVAL
-
-        // Don't show if timeout hasn't passed
-        guard isTimeoutOver else {
+        // Don't show until enough time has passed since the user last ignored the prompt
+        guard now - ignoreTimestamp > ASK_INTERVAL else {
             return false
         }
 
         // Don't show if no update is available
-        guard let update = appUpdateService.availableUpdate else {
+        guard let update else {
             return false
         }
 
-        // Don't show critical updates through timed sheets (they should be handled differently)
-        guard !update.critical else {
-            return false
-        }
-
-        return true
+        // Don't show critical updates through timed sheets; they're handled at the top level in AppScene
+        return !update.critical
     }
 
     func onShown() {

--- a/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
+++ b/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
@@ -112,9 +112,9 @@ class TimedSheetManager: ObservableObject {
 
     /// Re-check the timed-sheet queue after async state changes that may have made a sheet newly
     /// eligible (for example, the app-update info arriving after the initial settle check). No-ops
-    /// unless currently on a primary screen.
+    /// unless on a primary screen with no sheet already open.
     func reevaluate() {
-        guard isOnPrimaryScreen else { return }
+        guard isOnPrimaryScreen, !(sheetViewModel?.isAnySheetOpen ?? false) else { return }
         Logger.debug("Re-evaluating timed sheets after external state change")
         scheduleSettleCheck()
     }

--- a/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
+++ b/Bitkit/Managers/TimedSheets/TimedSheetManager.swift
@@ -30,9 +30,9 @@ class TimedSheetManager: ObservableObject {
     static let shared = TimedSheetManager()
 
     private let checkDelay: TimeInterval = 2.0 // 2 seconds delay
-    private var homeScreenTimer: Timer?
+    private var settleTimer: Timer?
     private var queuedSheets: [any TimedSheetItem] = []
-    private var isOnHomeScreen = false
+    private var isOnPrimaryScreen = false
     private var currentlyShowingSheet: (any TimedSheetItem)?
 
     private weak var sheetViewModel: SheetViewModel?
@@ -95,41 +95,47 @@ class TimedSheetManager: ObservableObject {
         Logger.debug("Removed timed sheet: \(id.rawValue)")
     }
 
-    /// Call this when user enters the home screen
-    func onHomeScreenEntered() {
-        guard !isOnHomeScreen else { return }
+    /// Call this when a primary screen appears.
+    ///
+    /// A primary screen is a top-level screen where timed sheets are allowed to surface:
+    /// the home screen (wallet flow) or the onboarding root (no wallet yet). The app-update
+    /// prompt is the only registered sheet whose `shouldShow()` can pass without a wallet, so
+    /// onboarding only ever surfaces that one (see issue #460).
+    func onPrimaryScreenEntered() {
+        guard !isOnPrimaryScreen else { return }
 
-        isOnHomeScreen = true
-        Logger.debug("User entered home screen, starting timer")
+        isOnPrimaryScreen = true
+        Logger.debug("Entered primary screen, starting timer")
 
-        // Cancel any existing timer
-        homeScreenTimer?.invalidate()
-
-        // Start timer to check for sheets after delay
-        homeScreenTimer = Timer.scheduledTimer(withTimeInterval: checkDelay, repeats: false) { [weak self] _ in
-            Task { @MainActor in
-                await self?.checkAndShowNextSheet()
-            }
-        }
+        scheduleSettleCheck()
     }
 
-    /// Call this when user leaves the home screen
-    func onHomeScreenExited() {
-        guard isOnHomeScreen else { return }
+    /// Re-check the timed-sheet queue after async state changes that may have made a sheet newly
+    /// eligible (for example, the app-update info arriving after the initial settle check). No-ops
+    /// unless currently on a primary screen.
+    func reevaluate() {
+        guard isOnPrimaryScreen else { return }
+        Logger.debug("Re-evaluating timed sheets after external state change")
+        scheduleSettleCheck()
+    }
 
-        isOnHomeScreen = false
-        Logger.debug("User exited home screen, cancelling timer")
+    /// Call this when the primary screen disappears.
+    func onPrimaryScreenExited() {
+        guard isOnPrimaryScreen else { return }
+
+        isOnPrimaryScreen = false
+        Logger.debug("Exited primary screen, cancelling timer")
 
         // Cancel timer
-        homeScreenTimer?.invalidate()
-        homeScreenTimer = nil
+        settleTimer?.invalidate()
+        settleTimer = nil
     }
 
     /// Call this when any sheet is shown (to prevent showing timed sheets)
     func onSheetShown() {
         // If a sheet is shown, cancel any pending timed sheet checks
-        homeScreenTimer?.invalidate()
-        homeScreenTimer = nil
+        settleTimer?.invalidate()
+        settleTimer = nil
     }
 
     /// Call this when a sheet is dismissed
@@ -138,6 +144,19 @@ class TimedSheetManager: ObservableObject {
         if let currentSheet = currentlyShowingSheet {
             currentSheet.onDismissed()
             currentlyShowingSheet = nil
+        }
+    }
+
+    /// (Re)start the settle timer that runs the queue check after a short delay.
+    private func scheduleSettleCheck() {
+        // Cancel any existing timer
+        settleTimer?.invalidate()
+
+        // Start timer to check for sheets after delay
+        settleTimer = Timer.scheduledTimer(withTimeInterval: checkDelay, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                await self?.checkAndShowNextSheet()
+            }
         }
     }
 
@@ -154,9 +173,9 @@ class TimedSheetManager: ObservableObject {
             return
         }
 
-        // Don't show if not on home screen anymore
-        guard isOnHomeScreen else {
-            Logger.debug("No longer on home screen, skipping timed sheet check")
+        // Don't show if no longer on a primary screen
+        guard isOnPrimaryScreen else {
+            Logger.debug("No longer on a primary screen, skipping timed sheet check")
             return
         }
 

--- a/Bitkit/Views/HomeScreen.swift
+++ b/Bitkit/Views/HomeScreen.swift
@@ -87,11 +87,11 @@ struct HomeScreen: View {
         }
         .navigationBarHidden(true)
         .onAppear {
-            TimedSheetManager.shared.onHomeScreenEntered()
+            TimedSheetManager.shared.onPrimaryScreenEntered()
             consumeRequestedHomePage()
         }
         .onDisappear {
-            TimedSheetManager.shared.onHomeScreenExited()
+            TimedSheetManager.shared.onPrimaryScreenExited()
         }
         .onChange(of: app.requestedHomePage) { _, _ in
             consumeRequestedHomePage()

--- a/BitkitTests/AppUpdateTimedSheetTests.swift
+++ b/BitkitTests/AppUpdateTimedSheetTests.swift
@@ -1,0 +1,79 @@
+@testable import Bitkit
+import XCTest
+
+final class AppUpdateTimedSheetTests: XCTestCase {
+    private let askInterval = AppUpdateTimedSheet.ASK_INTERVAL
+
+    private func makeUpdate(critical: Bool) -> AppUpdateInfo {
+        AppUpdateInfo(buildNumber: 200, version: "1.2.3", url: "https://example.com/app", notes: nil, critical: critical)
+    }
+
+    func testShownWhenNonCriticalUpdateAndIntervalElapsed() {
+        XCTAssertTrue(
+            AppUpdateTimedSheet.shouldShow(
+                update: makeUpdate(critical: false),
+                ignoreTimestamp: 0,
+                now: askInterval + 1,
+                isE2E: false
+            )
+        )
+    }
+
+    func testHiddenWhenNoUpdateAvailable() {
+        XCTAssertFalse(
+            AppUpdateTimedSheet.shouldShow(
+                update: nil,
+                ignoreTimestamp: 0,
+                now: askInterval + 1,
+                isE2E: false
+            )
+        )
+    }
+
+    func testHiddenForCriticalUpdate() {
+        // Critical updates are handled by the full-screen takeover in AppScene, not this sheet.
+        XCTAssertFalse(
+            AppUpdateTimedSheet.shouldShow(
+                update: makeUpdate(critical: true),
+                ignoreTimestamp: 0,
+                now: askInterval + 1,
+                isE2E: false
+            )
+        )
+    }
+
+    func testHiddenWithinAskInterval() {
+        // Ignored one hour ago, still inside the 12h quiet window.
+        XCTAssertFalse(
+            AppUpdateTimedSheet.shouldShow(
+                update: makeUpdate(critical: false),
+                ignoreTimestamp: 0,
+                now: 60 * 60,
+                isE2E: false
+            )
+        )
+    }
+
+    func testIntervalBoundaryIsExclusive() {
+        // Exactly 12h elapsed is not strictly greater than the interval, so still hidden.
+        XCTAssertFalse(
+            AppUpdateTimedSheet.shouldShow(
+                update: makeUpdate(critical: false),
+                ignoreTimestamp: 0,
+                now: askInterval,
+                isE2E: false
+            )
+        )
+    }
+
+    func testHiddenInE2EEnvironment() {
+        XCTAssertFalse(
+            AppUpdateTimedSheet.shouldShow(
+                update: makeUpdate(critical: false),
+                ignoreTimestamp: 0,
+                now: askInterval + 1,
+                isE2E: true
+            )
+        )
+    }
+}

--- a/changelog.d/next/601.fixed.md
+++ b/changelog.d/next/601.fixed.md
@@ -1,0 +1,1 @@
+Bitkit now shows the optional update prompt during onboarding too, so it is no longer missed on a fresh first launch.


### PR DESCRIPTION
Fixes #460

### Description

This PR makes the non-critical app update prompt appear during onboarding, not only on the home screen.

The problem: the prompt was both evaluated and presented only from the home screen, which exists only after a wallet is loaded. On a fresh first launch (onboarding, no wallet yet) nothing triggered the check and there was nowhere to present the prompt, so the update could be missed. Critical updates were not affected, they are already handled at the app root and cover every screen.

The fix keeps the prompt inside the existing timed-sheet queue, so it still coordinates by priority with the backup and high balance prompts, and makes three changes:

1. Presents the update prompt at the app root, so it can appear during onboarding and the wallet flow alike. This matches where the critical update screen and the forgot PIN sheet already live.
2. Evaluates the timed-sheet queue from the onboarding screen as well. Every other timed prompt requires a wallet balance to qualify, so onboarding only ever surfaces the update prompt.
3. Re-checks when the update result arrives. The update check runs asynchronously at launch, and on a fresh first launch its result can land after the first check has already run, so reacting to its arrival keeps the prompt from being missed.

| Where | Before | After |
| --- | --- | --- |
| Onboarding (no wallet) | not checked | checked |
| Home screen (wallet) | checked | checked |
| Critical update (any screen) | shown | shown (unchanged) |

The shared "home screen entered" hook used by the timed-sheet queue was renamed to a neutral "primary screen" name, since both the home screen and the onboarding screen now use it.

### Linked Issues/Tasks

Fixes #460

### Screenshot / Video

https://github.com/user-attachments/assets/fa6a5f46-1d1c-4a20-83d6-7969e58711ff


### QA Notes

Setup: a non-critical update must be available (point the updater feed at a release with a higher iOS build number, or temporarily lower the app's build number).

#### Manual Tests
- [x] **1.** Fresh install (no wallet) → launch → wait on Terms: the App Update prompt appears.
- [x] **2.** `regression:` existing wallet → Home: the App Update prompt still appears.
- [x] **3.** Update prompt → Cancel (or Update): dismisses and does not reappear for 12 hours.
- [x] **4a.** Critical update available → fresh install → launch: full-screen critical update screen shows (unchanged).
  - [x] **4b.** `regression:` critical update available → existing wallet → launch: full-screen critical update screen shows (unchanged).
- [x] **5.** `regression:` existing wallet with a backup or high balance prompt due → Home: the correct single prompt still shows (no double prompt).

#### Automated Checks
- Unit tests added: `BitkitTests/AppUpdateTimedSheetTests.swift` covers the prompt eligibility rules (ask-interval boundary, no update available, critical excluded, E2E suppressed). The eligibility decision was extracted into a pure function to make it testable.
- Local: `swiftformat` clean; Debug build for the iOS Simulator passes; the new unit tests pass.
- Verified before and after on the simulator with a simulated update (see the side-by-side), including the late-arrival case where the result lands after the initial check.
- CI: standard build and test checks run by the PR bot.
