### PR TITLE
chore: avoid redundant comments in agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,7 @@ Ensure accessibility modifiers and labels are added to custom components.
 - Swift version: 5.10
 - Use descriptive names: `isLoadingUsers` not `loading`
 - Follow Apple's SwiftUI best practices
+- AVOID code comments on private functions, types, etc — PREFER self-documenting names that make intent obvious without explanation; only add a comment when the rationale is genuinely non-obvious (e.g. a workaround, an edge case, or a "why" the code itself can't convey)
 
 ### Changelog
 


### PR DESCRIPTION
### Description

This PR adds an agent rule to reduce code pollution from redundant comments. Ported from the bitkit-android conventions, it instructs agents to avoid code comments on private functions and types and to prefer self-documenting names that make intent obvious. The rule keeps a deliberate escape hatch: a comment is still warranted when the rationale is genuinely non-obvious, such as a workaround, an edge case, or a "why" the code itself can't convey.

The intent is to keep generated Swift code clean by favoring clear naming over explanatory comments, while still allowing comments where they add real value.

### Linked Issues/Tasks

N/A

### QA Notes
#### Manual Tests
N/A
#### Automated Checks
N/A — documentation-only change to `AGENTS.md` (no code, tests, or build impact).