### PR TITLE
fix: use core LNURL-pay validation

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -1201,7 +1201,7 @@
 			repositoryURL = "https://github.com/synonymdev/bitkit-core";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.64;
+				version = 0.1.74;
 			};
 		};
 		96E20CD22CB6D91A00C24149 /* XCRemoteSwiftPackageReference "CodeScanner" */ = {

--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/synonymdev/bitkit-core",
       "state" : {
-        "revision" : "a7577cc4572d581a0ab1d84f2792a1e6198110ef",
-        "version" : "0.1.64"
+        "revision" : "201e37b1951d9ec68e7c46d2534314afe5ccac3c",
+        "version" : "0.1.74"
       }
     },
     {

--- a/Bitkit/Utilities/Lnurl.swift
+++ b/Bitkit/Utilities/Lnurl.swift
@@ -1,12 +1,13 @@
 import BitkitCore
 import Foundation
 
-// MARK: - Response Models
-
-private struct LnurlPayResponse: Codable {
-    let pr: String
-    let routes: [String]
+struct LnurlPayInvoiceMismatchError: LocalizedError {
+    var errorDescription: String? {
+        return "The invoice did not match the requested payment. Payment cancelled."
+    }
 }
+
+// MARK: - Response Models
 
 private struct LnurlWithdrawResponse: Codable {
     let status: String
@@ -116,37 +117,42 @@ private extension LnurlHelper {
             throw NSError(domain: "LNURL", code: -1, userInfo: [NSLocalizedDescriptionKey: errorMessage])
         }
     }
+
+    static func mapLnurlPayInvoiceError(_ error: Error) -> Error {
+        if let lnurlError = error as? LnurlError {
+            switch lnurlError {
+            case .InvalidAmount, .AmountMismatch, .MetadataMismatch:
+                return LnurlPayInvoiceMismatchError()
+            default:
+                break
+            }
+        }
+
+        return error
+    }
 }
 
 @MainActor
 struct LnurlHelper {
-    /// Fetches a Lightning invoice from an LNURL pay callback
+    /// Fetches a Lightning invoice for an LNURL pay request
     /// - Parameters:
-    ///   - callbackUrl: The LNURL callback URL
+    ///   - data: The LNURL pay data
     ///   - amountMsats: The amount in millisatoshis to pay
     ///   - comment: Optional comment to include with the payment
     /// - Returns: The bolt11 invoice string
     /// - Throws: Network or parsing errors
     static func fetchLnurlInvoice(
-        callbackUrl: String,
+        data: LnurlPayData,
         amountMsats: UInt64,
         comment: String? = nil
     ) async throws -> String {
-        var queryItems = [
-            URLQueryItem(name: "amount", value: String(amountMsats)),
-        ]
-
-        // Add comment if provided
-        if let comment, !comment.isEmpty {
-            queryItems.append(URLQueryItem(name: "comment", value: comment))
+        do {
+            let invoice = try await getLnurlInvoiceForPayData(data: data, amountMsats: amountMsats, comment: comment)
+            Logger.debug("Fetched LNURL pay invoice")
+            return invoice
+        } catch {
+            throw mapLnurlPayInvoiceError(error)
         }
-
-        let callbackURL = try buildUrl(baseUrl: callbackUrl, queryItems: queryItems)
-        let responseString = try await makeHttpGetRequest(url: callbackURL)
-        let lnurlResponse = try parseJsonResponse(responseString, as: LnurlPayResponse.self)
-
-        Logger.debug("Extracted bolt11 invoice: \(lnurlResponse.pr)")
-        return lnurlResponse.pr
     }
 
     /// Handles LNURL Withdraw Requests

--- a/Bitkit/ViewModels/Trezor/TrezorViewModel.swift
+++ b/Bitkit/ViewModels/Trezor/TrezorViewModel.swift
@@ -951,6 +951,8 @@ class TrezorViewModel {
                 return "Invalid transaction ID: \(errorDetails)"
             case let .TransactionNotFound(errorDetails):
                 return "Transaction not found: \(errorDetails)"
+            case let .WatcherError(errorDetails):
+                return "Watcher error: \(errorDetails)"
             }
         }
         if let appError = error as? AppError,

--- a/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
+++ b/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
@@ -194,7 +194,7 @@ struct LnurlPayConfirm: View {
 
         // Fetch the Lightning invoice from LNURL
         let bolt11 = try await LnurlHelper.fetchLnurlInvoice(
-            callbackUrl: lnurlPayData.callback,
+            data: lnurlPayData,
             amountMsats: amountMsats,
             comment: comment.isEmpty ? nil : comment
         )

--- a/Bitkit/Views/Wallets/Send/SendQuickpay.swift
+++ b/Bitkit/Views/Wallets/Send/SendQuickpay.swift
@@ -48,7 +48,7 @@ struct SendQuickpay: View {
             wallet.sendAmountSats = lnurlPayData.minSendableSat
 
             bolt11Invoice = try await LnurlHelper.fetchLnurlInvoice(
-                callbackUrl: lnurlPayData.callback,
+                data: lnurlPayData,
                 amountMsats: lnurlPayData.callbackAmountMsats()
             )
         } else if let scannedInvoice = app.scannedLightningInvoice {

--- a/changelog.d/hotfix/607.fixed.md
+++ b/changelog.d/hotfix/607.fixed.md
@@ -1,0 +1,1 @@
+Improved LNURL-pay invoice validation.


### PR DESCRIPTION
### Description

This PR:
1. Updates the app from iOS release `v2.3.0` to `bitkit-core` `0.1.74`.
2. Routes LNURL-pay invoice fetching through generated core bindings with full `LnurlPayData`.
3. Removes local LNURL-pay invoice callback fetching while leaving withdraw/channel behavior unchanged.
4. Handles core invoice validation errors with a neutral payment-canceled message.

Patch commit: `c522b5cc3cc223bc87e0158cfe749129eac83844`
Core release: https://github.com/synonymdev/bitkit-core/releases/tag/v0.1.74

### Linked Issues/Tasks

Refs:
- synonymdev/bitkit-core#115
- synonymdev/bitkit-android#1048

### Screenshot / Video

N/A

### QA Notes

#### Manual Tests
- [ ] **1.** Send -> scan LNURL-pay request -> complete payment: invoice fetch and send behavior match the requested payment.
- [ ] **2.** `regression:` Send -> scan LNURL-withdraw or LNURL-channel request: existing withdraw/channel behavior still works.

#### Automated Checks
- Local verification: `swiftformat --lint` for touched Swift files, `xcodebuild build`.
- Runtime proof: Android and iOS before/after LNURL-pay validation recordings completed locally.
