### PR TITLE
fix: update bitkit core

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -1201,7 +1201,7 @@
 			repositoryURL = "https://github.com/synonymdev/bitkit-core";
 			requirement = {
 				kind = exactVersion;
-				version = 0.1.74;
+				version = 0.1.75;
 			};
 		};
 		96E20CD22CB6D91A00C24149 /* XCRemoteSwiftPackageReference "CodeScanner" */ = {

--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/synonymdev/bitkit-core",
       "state" : {
-        "revision" : "201e37b1951d9ec68e7c46d2534314afe5ccac3c",
-        "version" : "0.1.74"
+        "revision" : "496c08423885b211300a973dad9675df5ecdbaa6",
+        "version" : "0.1.75"
       }
     },
     {

--- a/changelog.d/hotfix/610.fixed.md
+++ b/changelog.d/hotfix/610.fixed.md
@@ -1,0 +1,1 @@
+Improved LNURL-pay payment handling.


### PR DESCRIPTION
### Description

This PR updates Bitkit Core to v0.1.75 for LNURL-pay payment handling.

### Linked Issues/Tasks

N/A

### Screenshot / Video

N/A

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

- `xcodebuild -resolvePackageDependencies -project Bitkit.xcodeproj -scheme Bitkit`
- `git diff --check`
- CI: standard checks run on this PR.
