### PR TITLE
feat(lightning): show route fee for probe results

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -1193,7 +1193,7 @@
 			repositoryURL = "https://github.com/synonymdev/ldk-node";
 			requirement = {
 				kind = exactVersion;
-				version = "0.7.0-rc.39";
+				version = "0.7.0-rc.53";
 			};
 		};
 		96DEA0382DE8BBA1009932BF /* XCRemoteSwiftPackageReference "bitkit-core" */ = {

--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/synonymdev/ldk-node",
       "state" : {
-        "revision" : "c3593aebb7efe2605c08e40fee7a72d382d44401",
-        "version" : "0.7.0-rc.39"
+        "revision" : "f53a13e11d74296bea82c4fb616bad79901969b5",
+        "version" : "0.7.0-rc.53"
       }
     },
     {

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -1249,12 +1249,14 @@ extension LightningService {
                     Logger.info(
                         "🫰 Payment claimable: paymentId: \(paymentId) paymentHash: \(paymentHash) claimableAmountMsat: \(claimableAmountMsat)"
                     )
-                case let .probeSuccessful(paymentId, paymentHash):
-                    Logger.info("🤑 Probe successful: paymentId: \(paymentId) paymentHash: \(paymentHash)")
-                case let .probeFailed(paymentId, paymentHash, shortChannelId):
+                case let .probeSuccessful(paymentId, paymentHash, routeFeeMsat):
+                    let routeFeeText = routeFeeMsat.map(String.init) ?? "unknown"
+                    Logger.info("🤑 Probe successful: paymentId: \(paymentId) paymentHash: \(paymentHash) routeFeeMsat: \(routeFeeText)")
+                case let .probeFailed(paymentId, paymentHash, shortChannelId, routeFeeMsat):
+                    let routeFeeText = routeFeeMsat.map(String.init) ?? "unknown"
                     Logger
                         .info(
-                            "❌ Probe failed: paymentId: \(paymentId) paymentHash: \(paymentHash) shortChannelId: \(String(describing: shortChannelId))"
+                            "❌ Probe failed: paymentId: \(paymentId) paymentHash: \(paymentHash) shortChannelId: \(String(describing: shortChannelId)) routeFeeMsat: \(routeFeeText)"
                         )
                 // Payment claimable doesn't need activity update - it's still pending
                 // The payment will be updated when it succeeds or fails via paymentSuccessful/paymentFailed events

--- a/Bitkit/ViewModels/AppViewModel.swift
+++ b/Bitkit/ViewModels/AppViewModel.swift
@@ -954,9 +954,9 @@ extension AppViewModel {
             break
         case .paymentForwarded:
             break
-        case .probeSuccessful(paymentId: _, paymentHash: _):
+        case .probeSuccessful(paymentId: _, paymentHash: _, routeFeeMsat: _):
             break
-        case .probeFailed(paymentId: _, paymentHash: _, shortChannelId: _):
+        case .probeFailed(paymentId: _, paymentHash: _, shortChannelId: _, routeFeeMsat: _):
             break
 
         // MARK: New Onchain Transaction Events

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -182,19 +182,21 @@ class WalletViewModel: ObservableObject {
 
                     // Handle specific events for targeted UI updates
                     switch event {
-                    case let .probeSuccessful(paymentId, paymentHash: paymentHash):
+                    case let .probeSuccessful(paymentId, paymentHash: paymentHash, routeFeeMsat: routeFeeMsat):
                         self.cacheProbeOutcome(
                             success: true,
                             paymentId: paymentId,
                             paymentHash: paymentHash,
-                            shortChannelId: nil
+                            shortChannelId: nil,
+                            routeFeeMsat: routeFeeMsat
                         )
-                    case let .probeFailed(paymentId, paymentHash: paymentHash, shortChannelId: shortChannelId):
+                    case let .probeFailed(paymentId, paymentHash: paymentHash, shortChannelId: shortChannelId, routeFeeMsat: routeFeeMsat):
                         self.cacheProbeOutcome(
                             success: false,
                             paymentId: paymentId,
                             paymentHash: paymentHash,
-                            shortChannelId: shortChannelId
+                            shortChannelId: shortChannelId,
+                            routeFeeMsat: routeFeeMsat
                         )
                     case let .paymentReceived(_, paymentHash, _, _):
                         self.bolt11 = ""
@@ -680,6 +682,7 @@ class WalletViewModel: ObservableObject {
         let paymentId: PaymentId
         let paymentHash: PaymentHash
         let shortChannelId: UInt64?
+        let routeFeeMsat: UInt64?
     }
 
     /// Waits for probe results that match one of the returned probe `paymentId`s.
@@ -704,7 +707,7 @@ class WalletViewModel: ObservableObject {
             addOnEvent(id: eventId) { event in
                 guard !resumed else { return }
                 switch event {
-                case let .probeSuccessful(paymentId, paymentHash: paymentHash):
+                case let .probeSuccessful(paymentId, paymentHash: paymentHash, routeFeeMsat: routeFeeMsat):
                     guard pendingPaymentIds.contains(paymentId) else { return }
                     resumed = true
                     self.removeOnEvent(id: eventId)
@@ -712,15 +715,17 @@ class WalletViewModel: ObservableObject {
                         success: true,
                         paymentId: paymentId,
                         paymentHash: paymentHash,
-                        shortChannelId: nil
+                        shortChannelId: nil,
+                        routeFeeMsat: routeFeeMsat
                     ))
-                case let .probeFailed(paymentId, paymentHash: paymentHash, shortChannelId: shortChannelId):
+                case let .probeFailed(paymentId, paymentHash: paymentHash, shortChannelId: shortChannelId, routeFeeMsat: routeFeeMsat):
                     guard pendingPaymentIds.remove(paymentId) != nil else { return }
                     lastFailure = .init(
                         success: false,
                         paymentId: paymentId,
                         paymentHash: paymentHash,
-                        shortChannelId: shortChannelId
+                        shortChannelId: shortChannelId,
+                        routeFeeMsat: routeFeeMsat
                     )
                     if pendingPaymentIds.isEmpty, let lastFailure {
                         resumed = true
@@ -734,12 +739,13 @@ class WalletViewModel: ObservableObject {
         }
     }
 
-    private func cacheProbeOutcome(success: Bool, paymentId: PaymentId, paymentHash: PaymentHash, shortChannelId: UInt64?) {
+    private func cacheProbeOutcome(success: Bool, paymentId: PaymentId, paymentHash: PaymentHash, shortChannelId: UInt64?, routeFeeMsat: UInt64?) {
         probeOutcomes[paymentId] = ProbeOutcome(
             success: success,
             paymentId: paymentId,
             paymentHash: paymentHash,
-            shortChannelId: shortChannelId
+            shortChannelId: shortChannelId,
+            routeFeeMsat: routeFeeMsat
         )
     }
 

--- a/Bitkit/Views/Settings/ProbingTool/ProbeResult.swift
+++ b/Bitkit/Views/Settings/ProbingTool/ProbeResult.swift
@@ -3,6 +3,6 @@ import Foundation
 struct ProbeResult {
     let success: Bool
     let durationMs: Int
-    let estimatedFeeSats: UInt64?
+    let routeFeeMsat: UInt64?
     let errorMessage: String?
 }

--- a/Bitkit/Views/Settings/ProbingTool/ProbeResultSectionView.swift
+++ b/Bitkit/Views/Settings/ProbingTool/ProbeResultSectionView.swift
@@ -27,13 +27,13 @@ struct ProbeResultSectionView: View {
             }
             .font(.subheadline)
 
-            if let fee = result.estimatedFeeSats {
+            if let fee = result.routeFeeMsat {
                 HStack {
                     Image(systemName: "bitcoinsign.circle")
                         .foregroundStyle(.secondary)
-                    Text("Estimated Fee")
+                    Text("Route Fee")
                     Spacer()
-                    Text("\(fee) sats")
+                    Text("\(fee) msat")
                         .foregroundStyle(.secondary)
                 }
                 .font(.subheadline)

--- a/Bitkit/Views/Settings/ProbingTool/ProbingToolScreen.swift
+++ b/Bitkit/Views/Settings/ProbingTool/ProbingToolScreen.swift
@@ -249,17 +249,11 @@ struct ProbingToolScreen: View {
             let durationMs = Int(Date().timeIntervalSince(start) * 1000)
 
             if resolved.success {
-                let estimatedFee: UInt64? = switch target {
-                case let .invoice(bolt11, _):
-                    try? await lightningService.estimateRoutingFees(bolt11: bolt11, amountSats: amountSatsValue)
-                case .nodeId:
-                    nil
-                }
                 await MainActor.run {
                     probeResult = ProbeResult(
                         success: true,
                         durationMs: durationMs,
-                        estimatedFeeSats: estimatedFee,
+                        routeFeeMsat: resolved.routeFeeMsat,
                         errorMessage: nil
                     )
                 }
@@ -271,7 +265,7 @@ struct ProbingToolScreen: View {
                     probeResult = ProbeResult(
                         success: false,
                         durationMs: durationMs,
-                        estimatedFeeSats: nil,
+                        routeFeeMsat: resolved.routeFeeMsat,
                         errorMessage: message
                     )
                 }
@@ -283,7 +277,7 @@ struct ProbingToolScreen: View {
                 probeResult = ProbeResult(
                     success: false,
                     durationMs: durationMs,
-                    estimatedFeeSats: nil,
+                    routeFeeMsat: nil,
                     errorMessage: error.localizedDescription
                 )
             }

--- a/changelog.d/next/622.fixed.md
+++ b/changelog.d/next/622.fixed.md
@@ -1,0 +1,1 @@
+Improved Lightning probe route fee reporting.


### PR DESCRIPTION
### Description

Updates Bitkit to use the route fee now exposed by `ldk-node` probe events.

Needs https://github.com/synonymdev/ldk-node/pull/88

- Bumps `ldk-node` to `0.7.0-rc.53`
- Handles `routeFeeMsat` on successful and failed probe events
- Displays the returned route fee in the probing tool
- Removes the follow-up fee estimation call after successful probes
- Logs probe route fees, or `unknown` when unavailable

### Screenshot / Video

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d54a749c-5ebd-4ec1-b1e8-3f934e16552f" />
