### PR TITLE
fix: tune lightning probe routing

### DIFF
--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -28,6 +28,13 @@ class LightningService {
 
     static var shared = LightningService()
 
+    private static let scoringBasePenaltyMsat: UInt64 = 50000
+    private static let scoringLiquidityPenaltyMultiplierMsat: UInt64 = 10000
+    private static let scoringLiquidityPenaltyAmountMultiplierMsat: UInt64 = 10000
+    private static let scoringHistoricalLiquidityPenaltyAmountMultiplierMsat: UInt64 = 20000
+    private static let scoringConsideredImpossiblePenaltyMsat: UInt64 = 1_000_000_000_000
+    private static let scoringProbingDiversityPenaltyMsat: UInt64 = 60000
+
     private init() {}
 
     /// Flag and lock to prevent concurrent setup calls
@@ -106,6 +113,8 @@ class LightningService {
             Logger.info("Setting pathfinding scores source from scorer url: \(scorerUrl)")
             builder.setPathfindingScoresSource(url: scorerUrl)
         }
+
+        builder.setScoringFeeParams(params: Self.scoringFeeParameters(config: config))
 
         // Configure gossip source from current settings
         configureGossipSource(builder: builder, rgsServerUrl: rgsServerUrl)
@@ -1574,6 +1583,22 @@ extension LightningService {
     }
 
     // MARK: - Probing
+
+    private static func scoringFeeParameters(config: Config) -> ScoringFeeParameters {
+        let defaultParameters = config.scoringFeeParams!
+        return ScoringFeeParameters(
+            basePenaltyMsat: scoringBasePenaltyMsat,
+            basePenaltyAmountMultiplierMsat: defaultParameters.basePenaltyAmountMultiplierMsat,
+            liquidityPenaltyMultiplierMsat: scoringLiquidityPenaltyMultiplierMsat,
+            liquidityPenaltyAmountMultiplierMsat: scoringLiquidityPenaltyAmountMultiplierMsat,
+            historicalLiquidityPenaltyMultiplierMsat: defaultParameters.historicalLiquidityPenaltyMultiplierMsat,
+            historicalLiquidityPenaltyAmountMultiplierMsat: scoringHistoricalLiquidityPenaltyAmountMultiplierMsat,
+            antiProbingPenaltyMsat: defaultParameters.antiProbingPenaltyMsat,
+            consideredImpossiblePenaltyMsat: scoringConsideredImpossiblePenaltyMsat,
+            linearSuccessProbability: defaultParameters.linearSuccessProbability,
+            probingDiversityPenaltyMsat: scoringProbingDiversityPenaltyMsat
+        )
+    }
 
     /// Sends a probe to test if a payment route exists for the given invoice.
     /// - Parameters:

--- a/Bitkit/Services/LightningService.swift
+++ b/Bitkit/Services/LightningService.swift
@@ -35,6 +35,19 @@ class LightningService {
     private static let scoringConsideredImpossiblePenaltyMsat: UInt64 = 1_000_000_000_000
     private static let scoringProbingDiversityPenaltyMsat: UInt64 = 60000
 
+    private static let defaultScoringFeeParameters = ScoringFeeParameters(
+        basePenaltyMsat: 1024,
+        basePenaltyAmountMultiplierMsat: 131_072,
+        liquidityPenaltyMultiplierMsat: 0,
+        liquidityPenaltyAmountMultiplierMsat: 0,
+        historicalLiquidityPenaltyMultiplierMsat: 10000,
+        historicalLiquidityPenaltyAmountMultiplierMsat: 1250,
+        antiProbingPenaltyMsat: 250,
+        consideredImpossiblePenaltyMsat: 100_000_000_000,
+        linearSuccessProbability: false,
+        probingDiversityPenaltyMsat: 0
+    )
+
     private init() {}
 
     /// Flag and lock to prevent concurrent setup calls
@@ -1585,7 +1598,8 @@ extension LightningService {
     // MARK: - Probing
 
     private static func scoringFeeParameters(config: Config) -> ScoringFeeParameters {
-        let defaultParameters = config.scoringFeeParams!
+        let defaultParameters = config.scoringFeeParams ?? defaultScoringFeeParameters
+
         return ScoringFeeParameters(
             basePenaltyMsat: scoringBasePenaltyMsat,
             basePenaltyAmountMultiplierMsat: defaultParameters.basePenaltyAmountMultiplierMsat,

--- a/Bitkit/ViewModels/WalletViewModel.swift
+++ b/Bitkit/ViewModels/WalletViewModel.swift
@@ -195,7 +195,7 @@ class WalletViewModel: ObservableObject {
                             success: false,
                             paymentId: paymentId,
                             paymentHash: paymentHash,
-                            shortChannelId: shortChannelId,
+                            shortChannelId: shortChannelId.map(String.init),
                             routeFeeMsat: routeFeeMsat
                         )
                     case let .paymentReceived(_, paymentHash, _, _):
@@ -681,7 +681,7 @@ class WalletViewModel: ObservableObject {
         let success: Bool
         let paymentId: PaymentId
         let paymentHash: PaymentHash
-        let shortChannelId: UInt64?
+        let shortChannelId: String?
         let routeFeeMsat: UInt64?
     }
 
@@ -724,7 +724,7 @@ class WalletViewModel: ObservableObject {
                         success: false,
                         paymentId: paymentId,
                         paymentHash: paymentHash,
-                        shortChannelId: shortChannelId,
+                        shortChannelId: shortChannelId.map(String.init),
                         routeFeeMsat: routeFeeMsat
                     )
                     if pendingPaymentIds.isEmpty, let lastFailure {
@@ -739,7 +739,7 @@ class WalletViewModel: ObservableObject {
         }
     }
 
-    private func cacheProbeOutcome(success: Bool, paymentId: PaymentId, paymentHash: PaymentHash, shortChannelId: UInt64?, routeFeeMsat: UInt64?) {
+    private func cacheProbeOutcome(success: Bool, paymentId: PaymentId, paymentHash: PaymentHash, shortChannelId: String?, routeFeeMsat: UInt64?) {
         probeOutcomes[paymentId] = ProbeOutcome(
             success: success,
             paymentId: paymentId,

--- a/Bitkit/Views/Settings/ProbingTool/ProbingToolScreen.swift
+++ b/Bitkit/Views/Settings/ProbingTool/ProbingToolScreen.swift
@@ -259,7 +259,7 @@ struct ProbingToolScreen: View {
                 }
                 app.toast(type: .success, title: "Probe Successful", description: "Route verified in \(durationMs) ms")
             } else {
-                let scidText = resolved.shortChannelId.map(String.init) ?? "unknown"
+                let scidText = resolved.shortChannelId ?? "unknown"
                 let message = "Hash: \(resolved.paymentHash), SCID: \(scidText)"
                 await MainActor.run {
                     probeResult = ProbeResult(

--- a/changelog.d/next/623.fixed.md
+++ b/changelog.d/next/623.fixed.md
@@ -1,0 +1,1 @@
+Improved Lightning payment route selection reliability.


### PR DESCRIPTION
### Description

Tunes Lightning scorer fee parameters to improve route selection reliability.

- Applies custom scorer fee parameters during LDK node setup.
- Keeps unspecified scorer fields from the default LDK config.
- Stores probe failure `shortChannelId` as a string for diagnostic display.

Android counterpart: https://github.com/synonymdev/bitkit-android/pull/1052