### PR TITLE
chore: update fx rates endpoint

### DIFF
--- a/Bitkit/Constants/Env.swift
+++ b/Bitkit/Constants/Env.swift
@@ -291,7 +291,7 @@ enum Env {
 
     static var btcRatesServer: String {
         switch network {
-        case .bitcoin: "https://blocktank.synonym.to/fx/rates/btc"
+        case .bitcoin: "https://api1.blocktank.to/api/fx/rates/btc"
         case .signet: "https://bitkit.stag0.blocktank.to/fx/rates/btc"
         case .testnet: "https://bitkit.stag0.blocktank.to/fx/rates/btc"
         case .regtest: "https://bitkit.stag0.blocktank.to/fx/rates/btc"

--- a/changelog.d/next/624.changed.md
+++ b/changelog.d/next/624.changed.md
@@ -1,0 +1,1 @@
+Update FX rates endpoint to no longer use old Blocktank service.


### PR DESCRIPTION
### Description

Update FX rates endpoint to no longer use old Blocktank service.

See https://synonymworkspace.slack.com/archives/C07BJ7DNPCG/p1784012810894369