### PR TITLE
fix: match qr detail button with design

### DIFF
--- a/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
+++ b/Bitkit/Views/Wallets/Receive/ReceiveQr.swift
@@ -104,11 +104,22 @@ struct ReceiveQr: View {
                                 navigationPath.append(.cjitGeoBlocked)
                             }
                         }
-                    } else {
-                        CustomButton(title: showDetails ? t("common__qr_code") : t("common__show_details")) {
+                    } else if showDetails {
+                        CustomButton(
+                            title: t("wallet__receive_show_qr"),
+                            icon: Image("qr")
+                                .resizable()
+                                .frame(width: 16, height: 16)
+                                .foregroundColor(.textPrimary)
+                        ) {
                             showDetails.toggle()
                         }
-                        .accessibilityIdentifier(showDetails ? "QRCode" : "ShowDetails")
+                        .accessibilityIdentifier("QRCode")
+                    } else {
+                        CustomButton(title: t("common__show_details"), variant: .tertiary) {
+                            showDetails.toggle()
+                        }
+                        .accessibilityIdentifier("ShowDetails")
                     }
                 }
                 .padding(.horizontal, 16)

--- a/changelog.d/next/635.fixed.md
+++ b/changelog.d/next/635.fixed.md
@@ -1,0 +1,1 @@
+Updated the Receive screen's QR and details toggle to match the intended design, so "Show Details" is now a tertiary button and "Show QR Code" a primary button with a QR icon.


### PR DESCRIPTION
This PR updates the QR/details toggle on the Receive screen to match the design, so the two states no longer look identical.

### Description

- Shows "Show Details" as a tertiary button while the QR code is displayed, instead of a primary button.
- Shows "Show QR Code" as a primary button with a QR icon while the invoice details are displayed, replacing the previous "QR Code" title.
- Leaves the Receive Lightning Funds button on the spending onboarding state untouched, including its disabled state while the node is starting and its CJIT and geo-blocked navigation.

Both states reuse the existing QR icon asset and the existing "Show QR Code" string, so no new assets or translation keys were needed. This brings iOS in line with the equivalent Android implementation, which already uses a tertiary button for details and a primary button with a QR icon for the QR state.

### Linked Issues/Tasks

Designs:
- Receive Auto (QR state): https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=40364-128769&m=dev
- Show QR Code button (details state): https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=40364-134432&m=dev

Related Android: `ReceiveQrScreen.kt` already implements the same two variants.

### Screenshot / Video


https://github.com/user-attachments/assets/25e366e1-c710-4d30-aae3-abc18b5a10fe


https://github.com/user-attachments/assets/40e8aa37-d93d-4a0b-a05f-af122e843538



### QA Notes

#### Manual Tests
- [x] **1a.** Receive → Savings tab: bottom button reads Show Details and renders as tertiary, with no filled background or border.
  - [x] **1b.** Tap Show Details: details show and the button becomes a filled primary reading Show QR Code with a QR icon to the left of the title.
  - [x] **1c.** Tap Show QR Code: returns to the QR code and the button reverts to the tertiary Show Details.
- [x] **2.** Repeat on the Auto and Spending tabs (Spending with a ready channel): same two states in both.
- [x] **3.** `regression:` Spending tab with no channels → button still reads Receive Lightning Funds as a primary with the purple bolt icon.
  - [x] **3b.** `regression:` Tap it: nav to Receive CJIT Amount as before.
  - [x] **3c.** `regression:` While the node is still starting: the button stays disabled.
- [x] **4.** `regression:` E2E identifiers still resolve, with QRCode on the details state and ShowDetails on the QR state.

#### Automated Checks
- No test coverage added, changed, or removed: this is a presentation-only change to button variant, title, and icon, with no behavior or state logic touched.
- Local: simulator Debug build succeeded, SwiftFormat lint reports no changes required, and `validate-translations.js` passes with 0 errors.
- CI: standard build and test checks run by the PR bot.
