### PR TITLE
refactor: batch paykit contact cleanup

### DIFF
--- a/Bitkit/Services/PrivatePaykitService+Contacts.swift
+++ b/Bitkit/Services/PrivatePaykitService+Contacts.swift
@@ -87,53 +87,66 @@ extension PrivatePaykitService {
     }
 
     func removePublishedEndpoints(for publicKeys: [String]) async throws {
-        var firstError: Error?
-        var didChangeState = false
-        for publicKey in normalizedSavedContactKeys(publicKeys) {
-            var didFail = false
-            let cleanupReceiverPaths: [String]
-            do {
-                cleanupReceiverPaths = try await receiverPathsForCleanup(publicKey: publicKey)
-            } catch {
-                firstError = firstError ?? error
-                Self.markDeletedContactCleanupPending([publicKey])
-                continue
-            }
+        let publicKeys = normalizedSavedContactKeys(publicKeys)
+        guard !publicKeys.isEmpty else { return }
 
+        let linkedReceiverPaths: [String: Set<String>]
+        do {
+            linkedReceiverPaths = try await linkedReceiverPathsByPublicKey()
+        } catch {
+            Self.markDeletedContactCleanupPending(publicKeys)
+            throw error
+        }
+
+        var firstError: Error?
+        var failedPublicKeys = Set<String>()
+        var clearedRetryKeys = [PrivateMessageDrainRetryKey]()
+        var didChangeState = false
+        for publicKey in publicKeys {
+            let cleanupReceiverPaths = receiverPathsForCleanup(
+                publicKey: publicKey,
+                linkedReceiverPaths: linkedReceiverPaths[publicKey, default: []]
+            )
             for receiverPath in cleanupReceiverPaths {
                 do {
                     let report = try await PaykitSdkService.shared.clearPrivatePaymentList(to: publicKey, receiverPath: receiverPath)
                     if !report.failedToQueue.isEmpty || !report.failedToDeliver.isEmpty {
                         throw PrivatePaykitError.privateUnavailable
                     }
-                    let retryKey = PrivateMessageDrainRetryKey(publicKey: publicKey, receiverPath: receiverPath)
-                    await drainPendingPrivateMessages(reason: "cleanup", advancing: [retryKey])
-                    if await pendingPrivateMessageDrainKeys([retryKey]).contains(retryKey) {
-                        throw PrivatePaykitError.privateUnavailable
-                    }
+                    clearedRetryKeys.append(PrivateMessageDrainRetryKey(publicKey: publicKey, receiverPath: receiverPath))
                 } catch {
-                    didFail = true
+                    failedPublicKeys.insert(publicKey)
                     firstError = firstError ?? error
-                    Self.markDeletedContactCleanupPending([publicKey])
                 }
-            }
-
-            if !didFail {
-                if var contactState = state.contacts[publicKey] {
-                    let hadStateToClear = !contactState.cachedResolvedEndpoints.isEmpty ||
-                        !contactState.localInvoicesByReceiverPath.isEmpty ||
-                        !contactState.publishedPrivatePaymentReceiverPaths.isEmpty
-                    contactState.cachedResolvedEndpoints = []
-                    contactState.localInvoicesByReceiverPath = [:]
-                    contactState.publishedPrivatePaymentReceiverPaths = []
-                    let shouldRemoveContact = !contactState.hasCacheState
-                    state.contacts[publicKey] = shouldRemoveContact ? nil : contactState
-                    didChangeState = didChangeState || hadStateToClear || shouldRemoveContact
-                }
-
-                Self.clearDeletedContactCleanupPending([publicKey])
             }
         }
+
+        if !clearedRetryKeys.isEmpty {
+            await drainPendingPrivateMessages(reason: "cleanup", advancing: clearedRetryKeys)
+            let pendingRetryKeys = await pendingPrivateMessageDrainKeys(clearedRetryKeys)
+            if !pendingRetryKeys.isEmpty {
+                failedPublicKeys.formUnion(pendingRetryKeys.map(\.publicKey))
+                firstError = firstError ?? PrivatePaykitError.privateUnavailable
+            }
+        }
+
+        let successfulPublicKeys = Set(publicKeys).subtracting(failedPublicKeys)
+        for publicKey in successfulPublicKeys {
+            if var contactState = state.contacts[publicKey] {
+                let hadStateToClear = !contactState.cachedResolvedEndpoints.isEmpty ||
+                    !contactState.localInvoicesByReceiverPath.isEmpty ||
+                    !contactState.publishedPrivatePaymentReceiverPaths.isEmpty
+                contactState.cachedResolvedEndpoints = []
+                contactState.localInvoicesByReceiverPath = [:]
+                contactState.publishedPrivatePaymentReceiverPaths = []
+                let shouldRemoveContact = !contactState.hasCacheState
+                state.contacts[publicKey] = shouldRemoveContact ? nil : contactState
+                didChangeState = didChangeState || hadStateToClear || shouldRemoveContact
+            }
+        }
+
+        Self.markDeletedContactCleanupPending(Array(failedPublicKeys))
+        Self.clearDeletedContactCleanupPending(Array(successfulPublicKeys))
 
         if didChangeState {
             persistState(markWalletBackup: true)
@@ -265,6 +278,16 @@ extension PrivatePaykitService {
         var firstError: Error?
         var updates = [PrivatePaymentListReservationUpdateInput]()
         var linkRetryKeys = [PrivateMessageDrainRetryKey]()
+        let linkedReceiverPaths: [String: Set<String>]
+        let linkedReceiverPathsError: Error?
+        do {
+            linkedReceiverPaths = try await linkedReceiverPathsByPublicKey()
+            linkedReceiverPathsError = nil
+        } catch {
+            linkedReceiverPaths = [:]
+            linkedReceiverPathsError = error
+        }
+
         for publicKey in publicKeys {
             let receiverPaths: [String]
             do {
@@ -296,17 +319,18 @@ extension PrivatePaykitService {
                 )
             }
             let cleanupReceiverPaths: [String]
-            do {
-                cleanupReceiverPaths = try await receiverPathsForPrivateEndpointCleanup(
-                    publicKey: publicKey,
-                    excluding: publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths
-                )
-            } catch {
+            if let linkedReceiverPathsError {
                 cleanupReceiverPaths = []
-                firstError = firstError ?? error
+                firstError = firstError ?? linkedReceiverPathsError
                 Logger.warn(
-                    "Failed to inspect private Paykit links for \(PubkyPublicKeyFormat.redacted(publicKey)) during \(reason): \(error)",
+                    "Failed to inspect private Paykit links for \(PubkyPublicKeyFormat.redacted(publicKey)) during \(reason): \(linkedReceiverPathsError)",
                     context: "PrivatePaykit"
+                )
+            } else {
+                cleanupReceiverPaths = receiverPathsForPrivateEndpointCleanup(
+                    publicKey: publicKey,
+                    excluding: publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths,
+                    linkedReceiverPaths: linkedReceiverPaths[publicKey, default: []]
                 )
             }
 
@@ -652,35 +676,33 @@ extension PrivatePaykitService {
 
     private func receiverPathsForPrivateEndpointCleanup(
         publicKey: String,
-        excluding publicationReceiverPaths: [String]
-    ) async throws -> [String] {
+        excluding publicationReceiverPaths: [String],
+        linkedReceiverPaths: Set<String>
+    ) -> [String] {
         let publishedPaths = publishedPrivatePaymentReceiverPaths(publicKey: publicKey)
-        let linkedPaths = try await linkedReceiverPaths(publicKey: publicKey)
         let excluded = Set(publicationReceiverPaths)
-        return Array(Set(publishedPaths).union(linkedPaths).subtracting(excluded))
+        return Array(Set(publishedPaths).union(linkedReceiverPaths).subtracting(excluded))
             .filter { PaykitReceiverPath.supported.contains($0) }
             .sorted()
     }
 
-    private func receiverPathsForCleanup(publicKey: String) async throws -> [String] {
-        let linkedPaths = try await linkedReceiverPaths(publicKey: publicKey)
+    private func receiverPathsForCleanup(publicKey: String, linkedReceiverPaths: Set<String>) -> [String] {
         let publishedPaths = publishedPrivatePaymentReceiverPaths(publicKey: publicKey)
-        return Array(Set(linkedPaths).union(publishedPaths))
+        return Array(linkedReceiverPaths.union(publishedPaths))
             .filter { PaykitReceiverPath.supported.contains($0) }
             .sorted()
     }
 
-    private func linkedReceiverPaths(publicKey: String) async throws -> [String] {
-        guard let publicKey = PubkyPublicKeyFormat.normalized(publicKey) else { return [] }
+    private func linkedReceiverPathsByPublicKey() async throws -> [String: Set<String>] {
         let peers = try await PaykitSdkService.shared.linkedPeers()
-
-        let linkedPaths = peers.compactMap { peer -> String? in
-            guard PubkyPublicKeyFormat.normalized(peer.counterparty) == publicKey,
+        var linkedPaths = [String: Set<String>]()
+        for peer in peers {
+            guard let publicKey = PubkyPublicKeyFormat.normalized(peer.counterparty),
                   PaykitReceiverPath.supported.contains(peer.counterpartyReceiverPath)
-            else { return nil }
-            return peer.counterpartyReceiverPath
+            else { continue }
+            linkedPaths[publicKey, default: []].insert(peer.counterpartyReceiverPath)
         }
-        return Array(Set(linkedPaths)).sorted()
+        return linkedPaths
     }
 
     private func publishedPrivatePaymentReceiverPaths(publicKey: String) -> [String] {

--- a/Bitkit/Services/PrivatePaykitService+Contacts.swift
+++ b/Bitkit/Services/PrivatePaykitService+Contacts.swift
@@ -90,12 +90,15 @@ extension PrivatePaykitService {
         let publicKeys = normalizedSavedContactKeys(publicKeys)
         guard !publicKeys.isEmpty else { return }
 
-        let linkedReceiverPaths: [String: Set<String>]
+        let linkedReceiverPathsSnapshot: [String: Set<String>]?
         do {
-            linkedReceiverPaths = try await linkedReceiverPathsByPublicKey()
+            linkedReceiverPathsSnapshot = try await linkedReceiverPathsByPublicKey()
         } catch {
-            Self.markDeletedContactCleanupPending(publicKeys)
-            throw error
+            linkedReceiverPathsSnapshot = nil
+            Logger.warn(
+                "Failed to inspect private Paykit links for cleanup; retrying per contact: \(error)",
+                context: "PrivatePaykit"
+            )
         }
 
         var firstError: Error?
@@ -103,9 +106,25 @@ extension PrivatePaykitService {
         var clearedRetryKeys = [PrivateMessageDrainRetryKey]()
         var didChangeState = false
         for publicKey in publicKeys {
+            let contactLinkedReceiverPaths: Set<String>
+            if let linkedReceiverPathsSnapshot {
+                contactLinkedReceiverPaths = linkedReceiverPathsSnapshot[publicKey, default: []]
+            } else {
+                do {
+                    contactLinkedReceiverPaths = try await linkedReceiverPaths(publicKey: publicKey)
+                } catch {
+                    contactLinkedReceiverPaths = []
+                    failedPublicKeys.insert(publicKey)
+                    firstError = firstError ?? error
+                    Logger.warn(
+                        "Failed to inspect private Paykit links for \(PubkyPublicKeyFormat.redacted(publicKey)) during cleanup: \(error)",
+                        context: "PrivatePaykit"
+                    )
+                }
+            }
             let cleanupReceiverPaths = receiverPathsForCleanup(
                 publicKey: publicKey,
-                linkedReceiverPaths: linkedReceiverPaths[publicKey, default: []]
+                linkedReceiverPaths: contactLinkedReceiverPaths
             )
             for receiverPath in cleanupReceiverPaths {
                 do {
@@ -278,14 +297,15 @@ extension PrivatePaykitService {
         var firstError: Error?
         var updates = [PrivatePaymentListReservationUpdateInput]()
         var linkRetryKeys = [PrivateMessageDrainRetryKey]()
-        let linkedReceiverPaths: [String: Set<String>]
-        let linkedReceiverPathsError: Error?
+        let linkedReceiverPathsSnapshot: [String: Set<String>]?
         do {
-            linkedReceiverPaths = try await linkedReceiverPathsByPublicKey()
-            linkedReceiverPathsError = nil
+            linkedReceiverPathsSnapshot = try await linkedReceiverPathsByPublicKey()
         } catch {
-            linkedReceiverPaths = [:]
-            linkedReceiverPathsError = error
+            linkedReceiverPathsSnapshot = nil
+            Logger.warn(
+                "Failed to inspect private Paykit links during \(reason); retrying per contact: \(error)",
+                context: "PrivatePaykit"
+            )
         }
 
         for publicKey in publicKeys {
@@ -318,21 +338,26 @@ extension PrivatePaykitService {
                     context: "PrivatePaykit"
                 )
             }
-            let cleanupReceiverPaths: [String]
-            if let linkedReceiverPathsError {
-                cleanupReceiverPaths = []
-                firstError = firstError ?? linkedReceiverPathsError
-                Logger.warn(
-                    "Failed to inspect private Paykit links for \(PubkyPublicKeyFormat.redacted(publicKey)) during \(reason): \(linkedReceiverPathsError)",
-                    context: "PrivatePaykit"
-                )
+            let contactLinkedReceiverPaths: Set<String>
+            if let linkedReceiverPathsSnapshot {
+                contactLinkedReceiverPaths = linkedReceiverPathsSnapshot[publicKey, default: []]
             } else {
-                cleanupReceiverPaths = receiverPathsForPrivateEndpointCleanup(
-                    publicKey: publicKey,
-                    excluding: publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths,
-                    linkedReceiverPaths: linkedReceiverPaths[publicKey, default: []]
-                )
+                do {
+                    contactLinkedReceiverPaths = try await linkedReceiverPaths(publicKey: publicKey)
+                } catch {
+                    contactLinkedReceiverPaths = []
+                    firstError = firstError ?? error
+                    Logger.warn(
+                        "Failed to inspect private Paykit links for \(PubkyPublicKeyFormat.redacted(publicKey)) during \(reason): \(error)",
+                        context: "PrivatePaykit"
+                    )
+                }
             }
+            let cleanupReceiverPaths = receiverPathsForPrivateEndpointCleanup(
+                publicKey: publicKey,
+                excluding: publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths,
+                linkedReceiverPaths: contactLinkedReceiverPaths
+            )
 
             for receiverPath in Set(linkableReceiverPaths).union(cleanupReceiverPaths) {
                 linkRetryKeys.append(PrivateMessageDrainRetryKey(publicKey: publicKey, receiverPath: receiverPath))
@@ -703,6 +728,11 @@ extension PrivatePaykitService {
             linkedPaths[publicKey, default: []].insert(peer.counterpartyReceiverPath)
         }
         return linkedPaths
+    }
+
+    private func linkedReceiverPaths(publicKey: String) async throws -> Set<String> {
+        guard let publicKey = PubkyPublicKeyFormat.normalized(publicKey) else { return [] }
+        return try await linkedReceiverPathsByPublicKey()[publicKey, default: []]
     }
 
     private func publishedPrivatePaymentReceiverPaths(publicKey: String) -> [String] {

--- a/Bitkit/Services/PrivatePaykitService+Contacts.swift
+++ b/Bitkit/Services/PrivatePaykitService+Contacts.swift
@@ -90,41 +90,26 @@ extension PrivatePaykitService {
         let publicKeys = normalizedSavedContactKeys(publicKeys)
         guard !publicKeys.isEmpty else { return }
 
-        let linkedReceiverPathsSnapshot: [String: Set<String>]?
-        do {
-            linkedReceiverPathsSnapshot = try await linkedReceiverPathsByPublicKey()
-        } catch {
-            linkedReceiverPathsSnapshot = nil
-            Logger.warn(
-                "Failed to inspect private Paykit links for cleanup; retrying per contact: \(error)",
-                context: "PrivatePaykit"
-            )
+        try await withPublicationLock {
+            try await removePublishedEndpointsLocked(for: publicKeys)
         }
+    }
 
-        var firstError: Error?
-        var failedPublicKeys = Set<String>()
+    private func removePublishedEndpointsLocked(for publicKeys: [String]) async throws {
+        let publicKeySet = Set(publicKeys)
+        let cleanupStateSnapshots = Dictionary(uniqueKeysWithValues: publicKeys.map { publicKey in
+            (publicKey, publishedEndpointCleanupState(publicKey: publicKey))
+        })
+
+        let linkedReceiverPathsSnapshot = await linkedReceiverPathsSnapshot(reason: "cleanup")
+
+        var firstError = linkedReceiverPathsSnapshot.error
+        var failedPublicKeys = linkedReceiverPathsSnapshot.error == nil ? Set<String>() : publicKeySet
         var clearedRetryKeys = [PrivateMessageDrainRetryKey]()
-        var didChangeState = false
         for publicKey in publicKeys {
-            let contactLinkedReceiverPaths: Set<String>
-            if let linkedReceiverPathsSnapshot {
-                contactLinkedReceiverPaths = linkedReceiverPathsSnapshot[publicKey, default: []]
-            } else {
-                do {
-                    contactLinkedReceiverPaths = try await linkedReceiverPaths(publicKey: publicKey)
-                } catch {
-                    contactLinkedReceiverPaths = []
-                    failedPublicKeys.insert(publicKey)
-                    firstError = firstError ?? error
-                    Logger.warn(
-                        "Failed to inspect private Paykit links for \(PubkyPublicKeyFormat.redacted(publicKey)) during cleanup: \(error)",
-                        context: "PrivatePaykit"
-                    )
-                }
-            }
             let cleanupReceiverPaths = receiverPathsForCleanup(
                 publicKey: publicKey,
-                linkedReceiverPaths: contactLinkedReceiverPaths
+                linkedReceiverPaths: linkedReceiverPathsSnapshot.paths[publicKey, default: []]
             )
             for receiverPath in cleanupReceiverPaths {
                 do {
@@ -149,25 +134,23 @@ extension PrivatePaykitService {
             }
         }
 
-        let successfulPublicKeys = Set(publicKeys).subtracting(failedPublicKeys)
-        for publicKey in successfulPublicKeys {
-            if var contactState = state.contacts[publicKey] {
-                let hadStateToClear = !contactState.cachedResolvedEndpoints.isEmpty ||
-                    !contactState.localInvoicesByReceiverPath.isEmpty ||
-                    !contactState.publishedPrivatePaymentReceiverPaths.isEmpty
-                contactState.cachedResolvedEndpoints = []
-                contactState.localInvoicesByReceiverPath = [:]
-                contactState.publishedPrivatePaymentReceiverPaths = []
-                let shouldRemoveContact = !contactState.hasCacheState
-                state.contacts[publicKey] = shouldRemoveContact ? nil : contactState
-                didChangeState = didChangeState || hadStateToClear || shouldRemoveContact
+        for publicKey in publicKeySet.subtracting(failedPublicKeys) {
+            guard publishedEndpointCleanupState(publicKey: publicKey) == cleanupStateSnapshots[publicKey] else {
+                failedPublicKeys.insert(publicKey)
+                firstError = firstError ?? PrivatePaykitError.privateUnavailable
+                Logger.warn(
+                    "Private Paykit state changed during cleanup for \(PubkyPublicKeyFormat.redacted(publicKey)); deferring local cleanup",
+                    context: "PrivatePaykit"
+                )
+                continue
             }
         }
 
-        Self.markDeletedContactCleanupPending(Array(failedPublicKeys))
-        Self.clearDeletedContactCleanupPending(Array(successfulPublicKeys))
-
-        if didChangeState {
+        let successfulPublicKeys = publicKeySet.subtracting(failedPublicKeys)
+        if applyPublishedEndpointCleanupResults(
+            successfulPublicKeys: successfulPublicKeys,
+            failedPublicKeys: failedPublicKeys
+        ) {
             persistState(markWalletBackup: true)
         }
 
@@ -179,6 +162,7 @@ extension PrivatePaykitService {
     func removeSavedContact(publicKey: String) async {
         guard let normalizedKey = PubkyPublicKeyFormat.normalized(publicKey) else { return }
         knownSavedContactKeys.remove(normalizedKey)
+        Self.markDeletedContactCleanupPending([normalizedKey])
         do {
             try await removePublishedEndpoints(for: [normalizedKey])
             await clearContactState(publicKey: normalizedKey)
@@ -195,6 +179,7 @@ extension PrivatePaykitService {
         for publicKey in normalizedKeys {
             knownSavedContactKeys.remove(publicKey)
         }
+        Self.markDeletedContactCleanupPending(normalizedKeys)
         do {
             try await removePublishedEndpoints(for: normalizedKeys)
             for publicKey in normalizedKeys {
@@ -294,19 +279,10 @@ extension PrivatePaykitService {
             return requireImmediatePublication ? PubkyServiceError.sessionNotActive : nil
         }
 
-        var firstError: Error?
+        let linkedReceiverPathsSnapshot = await linkedReceiverPathsSnapshot(reason: reason)
+        var firstError = linkedReceiverPathsSnapshot.error
         var updates = [PrivatePaymentListReservationUpdateInput]()
         var linkRetryKeys = [PrivateMessageDrainRetryKey]()
-        let linkedReceiverPathsSnapshot: [String: Set<String>]?
-        do {
-            linkedReceiverPathsSnapshot = try await linkedReceiverPathsByPublicKey()
-        } catch {
-            linkedReceiverPathsSnapshot = nil
-            Logger.warn(
-                "Failed to inspect private Paykit links during \(reason); retrying per contact: \(error)",
-                context: "PrivatePaykit"
-            )
-        }
 
         for publicKey in publicKeys {
             let receiverPaths: [String]
@@ -338,25 +314,10 @@ extension PrivatePaykitService {
                     context: "PrivatePaykit"
                 )
             }
-            let contactLinkedReceiverPaths: Set<String>
-            if let linkedReceiverPathsSnapshot {
-                contactLinkedReceiverPaths = linkedReceiverPathsSnapshot[publicKey, default: []]
-            } else {
-                do {
-                    contactLinkedReceiverPaths = try await linkedReceiverPaths(publicKey: publicKey)
-                } catch {
-                    contactLinkedReceiverPaths = []
-                    firstError = firstError ?? error
-                    Logger.warn(
-                        "Failed to inspect private Paykit links for \(PubkyPublicKeyFormat.redacted(publicKey)) during \(reason): \(error)",
-                        context: "PrivatePaykit"
-                    )
-                }
-            }
             let cleanupReceiverPaths = receiverPathsForPrivateEndpointCleanup(
                 publicKey: publicKey,
                 excluding: publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths,
-                linkedReceiverPaths: contactLinkedReceiverPaths
+                linkedReceiverPaths: linkedReceiverPathsSnapshot.paths[publicKey, default: []]
             )
 
             for receiverPath in Set(linkableReceiverPaths).union(cleanupReceiverPaths) {
@@ -730,9 +691,53 @@ extension PrivatePaykitService {
         return linkedPaths
     }
 
-    private func linkedReceiverPaths(publicKey: String) async throws -> Set<String> {
-        guard let publicKey = PubkyPublicKeyFormat.normalized(publicKey) else { return [] }
-        return try await linkedReceiverPathsByPublicKey()[publicKey, default: []]
+    private func linkedReceiverPathsSnapshot(reason: String) async -> (paths: [String: Set<String>], error: Error?) {
+        do {
+            return try await (linkedReceiverPathsByPublicKey(), nil)
+        } catch {
+            Logger.warn("Failed to inspect private Paykit links during \(reason); retrying once: \(error)", context: "PrivatePaykit")
+        }
+
+        do {
+            return try await (linkedReceiverPathsByPublicKey(), nil)
+        } catch {
+            Logger.warn("Failed to inspect private Paykit links during \(reason) after retry: \(error)", context: "PrivatePaykit")
+            return ([:], error)
+        }
+    }
+
+    private func publishedEndpointCleanupState(publicKey: String) -> PublishedEndpointCleanupState {
+        let contactState = state.contacts[publicKey]
+        return PublishedEndpointCleanupState(
+            cachedResolvedEndpoints: contactState?.cachedResolvedEndpoints ?? [],
+            localInvoicesByReceiverPath: contactState?.localInvoicesByReceiverPath ?? [:],
+            publishedPrivatePaymentReceiverPaths: contactState?.publishedPrivatePaymentReceiverPaths ?? []
+        )
+    }
+
+    @discardableResult
+    func applyPublishedEndpointCleanupResults(
+        successfulPublicKeys: Set<String>,
+        failedPublicKeys: Set<String>
+    ) -> Bool {
+        var didChangeState = false
+        for publicKey in successfulPublicKeys {
+            if var contactState = state.contacts[publicKey] {
+                let hadStateToClear = !contactState.cachedResolvedEndpoints.isEmpty ||
+                    !contactState.localInvoicesByReceiverPath.isEmpty ||
+                    !contactState.publishedPrivatePaymentReceiverPaths.isEmpty
+                contactState.cachedResolvedEndpoints = []
+                contactState.localInvoicesByReceiverPath = [:]
+                contactState.publishedPrivatePaymentReceiverPaths = []
+                let shouldRemoveContact = !contactState.hasCacheState
+                state.contacts[publicKey] = shouldRemoveContact ? nil : contactState
+                didChangeState = didChangeState || hadStateToClear || shouldRemoveContact
+            }
+        }
+
+        Self.markDeletedContactCleanupPending(Array(failedPublicKeys))
+        Self.clearDeletedContactCleanupPending(Array(successfulPublicKeys))
+        return didChangeState
     }
 
     private func publishedPrivatePaymentReceiverPaths(publicKey: String) -> [String] {
@@ -757,5 +762,11 @@ extension PrivatePaykitService {
         contactState.localInvoicesByReceiverPath.removeValue(forKey: receiverPath)
         state.contacts[publicKey] = contactState.hasCacheState ? contactState : nil
         return true
+    }
+
+    private struct PublishedEndpointCleanupState: Equatable {
+        let cachedResolvedEndpoints: [StoredPaymentEntry]
+        let localInvoicesByReceiverPath: [String: StoredInvoice]
+        let publishedPrivatePaymentReceiverPaths: [String]
     }
 }

--- a/Bitkit/Services/PrivatePaykitService+Models.swift
+++ b/Bitkit/Services/PrivatePaykitService+Models.swift
@@ -30,7 +30,7 @@ extension PrivatePaykitService {
         }
     }
 
-    struct StoredPaymentEntry: Codable {
+    struct StoredPaymentEntry: Codable, Equatable {
         var methodId: String
         var endpointData: String
 
@@ -45,7 +45,7 @@ extension PrivatePaykitService {
         }
     }
 
-    struct StoredInvoice: Codable {
+    struct StoredInvoice: Codable, Equatable {
         var bolt11: String
         var paymentHash: String
         var expiresAt: Double

--- a/BitkitTests/PrivatePaykitServiceTests.swift
+++ b/BitkitTests/PrivatePaykitServiceTests.swift
@@ -291,9 +291,56 @@ final class PrivatePaykitServiceTests: XCTestCase {
         )
         await service.clearTestPendingMessageDrainRetries()
     }
+
+    func testPublishedEndpointCleanupPreservesFailedContactStateAndRetryMarker() async {
+        let successfulPublicKey = "pubky3rsduhcxpw74snwyct86m38c63j3pq8x4ycqikxg64roik8yw5xg"
+        let failedPublicKey = "pubky1rsduhcxpw74snwyct86m38c63j3pq8x4ycqikxg64roik8yw5xg"
+        let previousPendingKeys = PrivatePaykitService.pendingDeletedContactCleanupKeys()
+        PrivatePaykitService.clearDeletedContactCleanupPending()
+        defer {
+            PrivatePaykitService.clearDeletedContactCleanupPending()
+            PrivatePaykitService.markDeletedContactCleanupPending(Array(previousPendingKeys))
+        }
+
+        let service = PrivatePaykitService()
+        var contactState = PrivatePaykitService.ContactState()
+        contactState.cachedResolvedEndpoints = [
+            PrivatePaykitService.StoredPaymentEntry(
+                methodId: PublicPaykitService.MethodId.bitcoinLightningBolt11.rawValue,
+                endpointData: #"{"value":"lnbc1private"}"#
+            ),
+        ]
+        contactState.localInvoicesByReceiverPath = [
+            PaykitReceiverPath.wallet: PrivatePaykitService.StoredInvoice(
+                bolt11: "lnbc1private",
+                paymentHash: "payment-hash",
+                expiresAt: 123
+            ),
+        ]
+        contactState.publishedPrivatePaymentReceiverPaths = [PaykitReceiverPath.wallet]
+        await service.setTestContactState(contactState, publicKey: successfulPublicKey)
+        await service.setTestContactState(contactState, publicKey: failedPublicKey)
+        PrivatePaykitService.markDeletedContactCleanupPending([successfulPublicKey, failedPublicKey])
+
+        let didChangeState = await service.applyPublishedEndpointCleanupResults(
+            successfulPublicKeys: [successfulPublicKey],
+            failedPublicKeys: [failedPublicKey]
+        )
+
+        XCTAssertTrue(didChangeState)
+        let successfulContactState = await service.testContactState(publicKey: successfulPublicKey)
+        let failedContactState = await service.testContactState(publicKey: failedPublicKey)
+        XCTAssertNil(successfulContactState)
+        XCTAssertNotNil(failedContactState)
+        XCTAssertEqual(PrivatePaykitService.pendingDeletedContactCleanupKeys(), [failedPublicKey])
+    }
 }
 
 private extension PrivatePaykitService {
+    func setTestContactState(_ contactState: ContactState, publicKey: String) {
+        state.contacts[publicKey] = contactState
+    }
+
     func setTestLocalInvoice(_ invoice: StoredInvoice, publicKey: String) {
         state.contacts[publicKey] = ContactState()
         state.contacts[publicKey]?.localInvoicesByReceiverPath[PaykitReceiverPath.wallet] = invoice


### PR DESCRIPTION
### Description

This PR builds on #637 to address the Paykit cleanup performance follow-ups from #620:

- Reads the SDK linked-peer list once per multi-contact publication or cleanup pass, with one shared retry instead of a per-contact fallback.
- Clears receiver-scoped payment lists as before, then drains outbound private messages and checks pending status once for the whole successful batch.
- Preserves per-contact failure isolation: contacts with failed or still-pending cleanup retain their cached state and retry marker, while successful contacts are cleared.
- Serializes cleanup with endpoint publication and skips the local state wipe if relevant contact state changes during an awaited SDK operation.

On the error path, a failed link snapshot still clears locally recorded published receiver paths while retaining the contact state and retry marker. A batch-level drain-inspection failure conservatively keeps the whole affected batch pending for retry. No user-facing behavior changes are intended.

### Linked Issues/Tasks

- Base PR: #637
- Review follow-up: #620
- Companion Android PR: https://github.com/synonymdev/bitkit-android/pull/1099

### Screenshot / Video

N/A — service-only refactor.

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

- `PrivatePaykitServiceTests.swift`: all 13 focused tests passed in the iOS simulator, including mixed cleanup success/failure coverage.
- SwiftFormat passed for the changed Swift files.
- `git diff --check` passed.
