### PR TITLE
fix: allow terminal profile deletion

### DIFF
--- a/Bitkit/Managers/PubkyProfileManager.swift
+++ b/Bitkit/Managers/PubkyProfileManager.swift
@@ -346,7 +346,7 @@ class PubkyProfileManager: ObservableObject {
     }
 
     func deleteProfile() async throws {
-        try await Self.removePrivatePaykitEndpoints(context: "PubkyProfileManager.deleteProfile")
+        await Self.removePrivatePaykitEndpointsBestEffort(context: "PubkyProfileManager.deleteProfile")
         do {
             try await Task.detached {
                 try await PubkyService.deletePaykitProfile()

--- a/Bitkit/Resources/Localization/en.lproj/Localizable.strings
+++ b/Bitkit/Resources/Localization/en.lproj/Localizable.strings
@@ -1143,7 +1143,7 @@
 "profile__edit_delete_section" = "DELETE";
 "profile__edit_public_note" = "Please note profile information is stored in public files. Changes you make in Bitkit will not update your pubky.app profile.";
 "profile__delete_title" = "Delete Profile?";
-"profile__delete_description" = "Are you sure you want to delete all of your profile information for your pubky?";
+"profile__delete_description" = "Deleting your profile removes it from Pubky. Contacts may still retain profile and payment information previously shared with them.";
 "profile__delete_confirm" = "Yes, Delete";
 "profile__delete_error_title" = "Unable to Delete Profile";
 "profile__delete_error_description" = "We couldn't delete your profile data. Retry, or disconnect this pubky from Bitkit.";

--- a/changelog.d/next/640.fixed.md
+++ b/changelog.d/next/640.fixed.md
@@ -1,0 +1,1 @@
+Fixed profile deletion being blocked when private Paykit contact cleanup could not complete.


### PR DESCRIPTION
### Description

This PR allows terminal Pubky profile deletion to continue when private Paykit endpoint cleanup cannot finish, such as when a contact is offline or a private link is still being established.

- Reuses the existing best-effort private endpoint cleanup path before deleting the profile.
- Keeps the remote Pubky deletion authoritative, so a homeserver or connectivity failure still reaches the existing retry/disconnect UI.
- Preserves local Paykit cleanup after the Pubky profile is deleted.
- Warns that contacts may retain profile and payment information shared with them previously.

Paykit lifecycle/concurrency hardening and E2E repository changes remain outside this PR.

### Linked Issues/Tasks

- UI follow-up: #636
- Android UI PR: https://github.com/synonymdev/bitkit-android/pull/1097
- Companion Android fix: https://github.com/synonymdev/bitkit-android/pull/1108

### Screenshot / Video

N/A — behavior and confirmation-copy update only.

### QA Notes

#### Manual Tests

- [ ] **1.** Profile → Edit Profile → Delete Profile with an offline or still-linking contact → confirm: Pubky deletion proceeds instead of being blocked by private cleanup.
- [ ] **2.** Profile → Edit Profile → Delete Profile while the Pubky homeserver is unavailable → confirm: Unable to Delete Profile still offers retry or disconnect.
- [ ] **3.** Profile → Edit Profile → Delete Profile: confirmation explains that contacts may retain previously shared profile and payment information.

#### Automated Checks

- Arm64 iOS simulator Debug build passed.
- Translation validation passed with 0 errors.
- SwiftFormat lint passed for the changed Swift file.
- `git diff --check` passed.
- `PubkyProfileManagerTests.swift`: 34 of 37 tests passed; three unchanged tests crash in the existing test host at `Env.swift:211` because its documents directory is unavailable.
