### PR TITLE
ci: bump actions off node 20

### DIFF
--- a/.github/workflows/ai-device-tests.yml
+++ b/.github/workflows/ai-device-tests.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload diagnostics
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ai-device-tests-trezor-${{ github.run_number }}
           path: ai-device-artifacts/trezor

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,7 +27,7 @@ jobs:
       code: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -126,7 +126,7 @@ jobs:
           cp -r DerivedData/Build/Products/Debug-iphonesimulator/Bitkit.app e2e-app/bitkit.app
 
       - name: Upload iOS app (local)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: e2e-app/
@@ -215,7 +215,7 @@ jobs:
           cp -r DerivedData/Build/Products/Debug-iphonesimulator/Bitkit.app e2e-app/bitkit.app
 
       - name: Upload iOS app (regtest)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bitkit-e2e-ios-regtest_${{ github.run_number }}
           path: e2e-app/
@@ -259,7 +259,7 @@ jobs:
           ref: ${{ needs.e2e-branch.outputs.branch }}
 
       - name: Download iOS app
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -359,7 +359,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/
@@ -399,7 +399,7 @@ jobs:
           ref: ${{ needs.e2e-branch.outputs.branch }}
 
       - name: Download iOS app (regtest)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: bitkit-e2e-ios-regtest_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -501,7 +501,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts-regtest_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/e2e_migration.yml
+++ b/.github/workflows/e2e_migration.yml
@@ -104,7 +104,7 @@ jobs:
           cp -r DerivedData/Build/Products/Debug-iphonesimulator/Bitkit.app e2e-app/bitkit.app
 
       - name: Upload iOS app (regtest)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: e2e-app/
@@ -171,13 +171,13 @@ jobs:
           ref: ${{ needs.e2e-branch.outputs.branch }}
 
       - name: Download iOS app
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: bitkit-e2e-ios_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
 
       - name: Download migration env
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: migration-env_${{ matrix.rn_version }}_${{ matrix.scenario.name }}
           path: bitkit-e2e-tests/artifacts
@@ -316,7 +316,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.scenario.name }})
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts_${{ matrix.scenario.name }}_${{ matrix.rn_version }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,7 +95,7 @@ jobs:
           exit 1
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: integration-test-results

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -79,7 +79,7 @@ jobs:
           echo "✅ Unit tests completed at $(date)"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: test-results


### PR DESCRIPTION
### Description

This PR bumps GitHub Actions used by CI workflows off Node.js 20 to versions that run on Node.js 24 by default, matching Android and clearing the deprecation warnings that show up on E2E artifact download/upload.

1. Bumps `actions/upload-artifact` and `actions/download-artifact` from v6 to v7 across E2E, migration, unit, integration, and AI device workflows.
2. Bumps `dorny/paths-filter` from v3 to v4 in the E2E workflow.

### Linked Issues/Tasks

N/A

### Screenshot / Video

N/A

### QA Notes
#### Manual Tests
N/A
#### Automated Checks
- CI workflow pins only; no app code changes.
- Standard CI checks run by the PR bot (after merge, subsequent PRs use the updated action versions).

Made with [Cursor](https://cursor.com)