### PR TITLE
fix(send): preserve pending send failure details

### DIFF
--- a/Bitkit/ViewModels/AppViewModel.swift
+++ b/Bitkit/ViewModels/AppViewModel.swift
@@ -8,6 +8,13 @@ import SwiftUI
 struct SendSheetPendingResolution: Equatable {
     let paymentHash: String
     let success: Bool
+    let failureReason: PaymentFailureReason?
+
+    init(paymentHash: String, success: Bool, failureReason: PaymentFailureReason? = nil) {
+        self.paymentHash = paymentHash
+        self.success = success
+        self.failureReason = failureReason
+    }
 }
 
 struct ContactPaymentContext: Equatable {
@@ -1010,11 +1017,11 @@ extension AppViewModel {
                     accessibilityIdentifier: "PaymentSuccessToast"
                 )
             }
-        case let .paymentFailed(paymentId, paymentHash, _):
+        case let .paymentFailed(paymentId, paymentHash, reason):
             let hash = paymentId ?? paymentHash
             if let hash, pendingPaymentHashes.contains(hash) {
                 pendingPaymentHashes.remove(hash)
-                sendSheetPendingResolution = SendSheetPendingResolution(paymentHash: hash, success: false)
+                sendSheetPendingResolution = SendSheetPendingResolution(paymentHash: hash, success: false, failureReason: reason)
                 toast(
                     type: .error,
                     title: t("wallet__toast_payment_failed_title"),

--- a/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
+++ b/Bitkit/Views/Wallets/Send/LnurlPayConfirm.swift
@@ -225,7 +225,7 @@ struct LnurlPayConfirm: View {
                 sats: nil,
                 onTimeout: {
                     app.addPendingPaymentHash(paymentHash, contactPublicKey: contactPublicKey)
-                    navigationPath.append(.pending(paymentHash: paymentHash, retryRoute: .lnurlPayConfirm))
+                    navigationPath.append(.pending(paymentHash: paymentHash, retryRoute: .lnurlPayConfirm, paymentRequest: bolt11))
                 }
             )
             app.addPendingContactPaymentContext(paymentHash, contactPublicKey: contactPublicKey)

--- a/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
+++ b/Bitkit/Views/Wallets/Send/SendConfirmationView.swift
@@ -520,7 +520,7 @@ struct SendConfirmationView: View {
                         sats: paymentSats,
                         onTimeout: {
                             app.addPendingPaymentHash(paymentHash, contactPublicKey: contactPublicKey)
-                            navigationPath.append(.pending(paymentHash: paymentHash, retryRoute: .confirm))
+                            navigationPath.append(.pending(paymentHash: paymentHash, retryRoute: .confirm, paymentRequest: invoice.bolt11))
                         }
                     )
                     await syncContactForActivity(paymentId: paymentHash, contactPublicKey: contactPublicKey)

--- a/Bitkit/Views/Wallets/Send/SendPendingScreen.swift
+++ b/Bitkit/Views/Wallets/Send/SendPendingScreen.swift
@@ -26,6 +26,8 @@ struct HourglassLoadingView: View {
 struct SendPendingScreen: View {
     let paymentHash: String
     let retryRoute: SendRetryRoute
+    let paymentRequest: String?
+    let routingCacheResetAttempted: Bool
     @Binding var navigationPath: [SendRoute]
 
     @EnvironmentObject private var activityList: ActivityListViewModel
@@ -89,9 +91,10 @@ struct SendPendingScreen: View {
             } else {
                 app.consumeContactPaymentContext(forPendingPaymentHash: paymentHash)
                 navigationPath.append(.failure(SendFailureContext(
-                    message: t("wallet__payment_failed_description"),
+                    error: AppError(paymentFailureReason: resolution.failureReason),
                     retryRoute: retryRoute,
-                    resetRoutingCachesOnRetry: false
+                    routingCacheResetAttempted: routingCacheResetAttempted,
+                    paymentRequest: paymentRequest
                 )))
             }
         }

--- a/Bitkit/Views/Wallets/Send/SendQuickpay.swift
+++ b/Bitkit/Views/Wallets/Send/SendQuickpay.swift
@@ -74,7 +74,7 @@ struct SendQuickpay: View {
                 sats: nil,
                 onTimeout: {
                     app.addPendingPaymentHash(paymentHash)
-                    navigationPath.append(.pending(paymentHash: paymentHash, retryRoute: .quickpay))
+                    navigationPath.append(.pending(paymentHash: paymentHash, retryRoute: .quickpay, paymentRequest: bolt11))
                 }
             )
             Logger.info("Quickpay payment successful: \(paymentHash)")

--- a/Bitkit/Views/Wallets/Send/SendSheet.swift
+++ b/Bitkit/Views/Wallets/Send/SendSheet.swift
@@ -63,7 +63,7 @@ enum SendRoute: Hashable {
     case tag
     case quickpay
     case pin
-    case pending(paymentHash: String, retryRoute: SendRetryRoute)
+    case pending(paymentHash: String, retryRoute: SendRetryRoute, paymentRequest: String? = nil)
     case success(paymentId: String)
     case failure(SendFailureContext)
     case lnurlPayAmount
@@ -485,8 +485,14 @@ struct SendSheet: View {
             SendQuickpay(navigationPath: $navigationPath, routingCacheResetAttempted: routingCacheResetAttempted)
         case .pin:
             SendPinScreen(onCancel: { resolvePinCheck(false) }, onPinVerified: { resolvePinCheck(true) })
-        case let .pending(paymentHash, retryRoute):
-            SendPendingScreen(paymentHash: paymentHash, retryRoute: retryRoute, navigationPath: $navigationPath)
+        case let .pending(paymentHash, retryRoute, paymentRequest):
+            SendPendingScreen(
+                paymentHash: paymentHash,
+                retryRoute: retryRoute,
+                paymentRequest: paymentRequest,
+                routingCacheResetAttempted: routingCacheResetAttempted,
+                navigationPath: $navigationPath
+            )
         case let .success(paymentId):
             SendSuccess(paymentId: paymentId)
         case let .failure(context):

--- a/Bitkit/Views/Wallets/Send/SendSheet.swift
+++ b/Bitkit/Views/Wallets/Send/SendSheet.swift
@@ -22,22 +22,6 @@ struct SendFailureContext: Hashable {
     let paymentRequest: String?
     let routingCacheResetAttempted: Bool
 
-    init(
-        message: String?,
-        retryRoute: SendRetryRoute,
-        resetRoutingCachesOnRetry: Bool,
-        failureType: String = "Unknown",
-        paymentRequest: String? = nil,
-        routingCacheResetAttempted: Bool = false
-    ) {
-        self.message = message
-        self.retryRoute = retryRoute
-        self.resetRoutingCachesOnRetry = resetRoutingCachesOnRetry
-        self.failureType = failureType
-        self.paymentRequest = paymentRequest
-        self.routingCacheResetAttempted = routingCacheResetAttempted
-    }
-
     init(error: Error, retryRoute: SendRetryRoute, routingCacheResetAttempted: Bool = false, paymentRequest: String? = nil) {
         let shouldResetRoutingCaches = shouldResetRoutingCachesOnRetry(for: error)
 
@@ -63,7 +47,7 @@ enum SendRoute: Hashable {
     case tag
     case quickpay
     case pin
-    case pending(paymentHash: String, retryRoute: SendRetryRoute, paymentRequest: String? = nil)
+    case pending(paymentHash: String, retryRoute: SendRetryRoute, paymentRequest: String?)
     case success(paymentId: String)
     case failure(SendFailureContext)
     case lnurlPayAmount


### PR DESCRIPTION
## Summary

- Preserve the LDK `PaymentFailureReason` when a Lightning payment times out into Pending and later fails.
- Pass pending payment context through to the failure screen so it shows the correct localized failure message.
- Keep routing-cache reset retry eligibility intact for pending failures like `routeNotFound` and `retriesExhausted`.
- Carry the BOLT11 through the pending route so the support report prefill still has payment context.

Follow-up to https://github.com/synonymdev/bitkit-ios/pull/652, no changelog entry needed.

https://github.com/user-attachments/assets/271de387-cb60-43eb-8ec0-fed637d41d15
