### PR TITLE
fix: consume vss-client 0.5.23

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -1187,7 +1187,7 @@
 			repositoryURL = "https://github.com/synonymdev/vss-rust-client-ffi";
 			requirement = {
 				kind = exactVersion;
-				version = 0.5.21;
+				version = 0.5.23;
 			};
 		};
 		4AAB08C82E1FE77600BA63DF /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/synonymdev/vss-rust-client-ffi",
       "state" : {
-        "revision" : "97c07caf96dce993728b299380aebbaa85f59ac1",
-        "version" : "0.5.21"
+        "revision" : "d7cbc6237a83e50a55b3c93b8837b6f18134065c",
+        "version" : "0.5.23"
       }
     }
   ],

--- a/changelog.d/next/673.security.md
+++ b/changelog.d/next/673.security.md
@@ -1,0 +1,1 @@
+Wallet backups now use VSS 0.5.23, which rejects unauthenticated encryption.


### PR DESCRIPTION
This PR bumps vss-rust-client-ffi from 0.5.21 to 0.5.23.

### Description

0.5.23 includes [synonymdev/vss-rust-client-ffi#20](https://github.com/synonymdev/vss-rust-client-ffi/pull/20). Unauthenticated client setup now returns AuthError instead of encrypting with a public all-zero key.

Companion Android PR: https://github.com/synonymdev/bitkit-android/pull/1164

### Linked Issues/Tasks

- https://github.com/synonymdev/audit/issues/55
- https://github.com/synonymdev/vss-rust-client-ffi/pull/20

### Screenshot / Video

N/A

### QA Notes
#### Manual Tests
- [ ] **1.** `regression:` Fresh wallet → backup/Lightning start with current Env LNURL-auth URL: setup still succeeds.

#### Automated Checks
- Local Debug simulator build passed against 0.5.23.