### PR TITLE
chore: use ldk-node rc.63

### DIFF
--- a/Bitkit.xcodeproj/project.pbxproj
+++ b/Bitkit.xcodeproj/project.pbxproj
@@ -1206,7 +1206,7 @@
 			repositoryURL = "https://github.com/synonymdev/ldk-node";
 			requirement = {
 				kind = exactVersion;
-				version = "0.7.0-rc.57";
+				version = "0.7.0-rc.63";
 			};
 		};
 		96DEA0382DE8BBA1009932BF /* XCRemoteSwiftPackageReference "bitkit-core" */ = {

--- a/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/synonymdev/ldk-node",
       "state" : {
-        "revision" : "e676d20cd2ba6277f68619dc32261f541aa3bdfe",
-        "version" : "0.7.0-rc.57"
+        "revision" : "c9a41458a646324c6c8728b4de8329ad4d52ac8d",
+        "version" : "0.7.0-rc.63"
       }
     },
     {


### PR DESCRIPTION
### Description

This PR pins `ldk-node` from `0.7.0-rc.57` to `0.7.0-rc.63` so iOS master uses the production Lightning stack needed for 2.4.1.

- Picks up the Electrum runtime / peer-persistence crash fixes already on Android rc.62.
- Drops the `0.2.2-accept-stale-monitors` rust-lightning fork (BITKIT-SEC-004). Stale monitor mismatches fail closed with `DangerousValue`.
- Pin only. `#664` already removed `setAcceptStaleChannelMonitors`; `ElectrumSyncConfig` already has the extra fields, so no app code change.

Release: https://github.com/synonymdev/ldk-node/releases/tag/v0.7.0-rc.63

Intended for cherry-pick onto `release-2.4.1`.

### Linked Issues/Tasks

- BITKIT-SEC-004
- https://github.com/synonymdev/audit/issues/55
- Companion: https://github.com/synonymdev/bitkit-android/pull/1175

### Screenshot / Video

N/A — dependency pin only.

### QA Notes

#### Manual Tests

- [x] `regression:` Launch an existing wallet with channels and send to Android `#1175`

#### Automated Checks

- Resolved SPM to `ldk-node` `0.7.0-rc.63` (`c9a41458`).
- Simulator arm64 Debug build succeeded against the new pin. No UDL call-site fallout.
- CI: standard build and test checks run by the PR bot.
